### PR TITLE
Add Zenodo and citation metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,47 @@
+{
+  "title": "Sandbox",
+  "description": "Experimental Eclipse JDT cleanup plugins, quick fixes, and related tooling for Eclipse-based Java development. The project explores automated Java source transformations, JUnit migration, encoding modernization, functional loop conversion, static analysis helpers, and Eclipse plugin infrastructure.",
+  "creators": [
+    {
+      "name": "Hammer, Carsten",
+      "orcid": "0009-0005-1047-6381"
+    }
+  ],
+  "license": "EPL-2.0",
+  "upload_type": "software",
+  "access_right": "open",
+  "keywords": [
+    "Eclipse",
+    "Eclipse JDT",
+    "Java",
+    "Java 21",
+    "Refactoring",
+    "Cleanup",
+    "Quick Fix",
+    "Static Analysis",
+    "Code Analysis",
+    "JUnit",
+    "JUnit 5",
+    "Encoding",
+    "Charset",
+    "Streams",
+    "AST",
+    "Eclipse Plugin",
+    "Developer Tools"
+  ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/carstenartur/sandbox",
+      "relation": "isSupplementTo",
+      "scheme": "url",
+      "resource_type": "software"
+    },
+    {
+      "identifier": "https://carstenartur.github.io/sandbox/",
+      "relation": "isDocumentedBy",
+      "scheme": "url",
+      "resource_type": "publication-technicalnote"
+    }
+  ],
+  "communities": []
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,29 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it using the metadata from this file."
+type: software
+title: "Sandbox"
+abstract: "Experimental Eclipse JDT cleanup plugins, quick fixes, and related tooling for Eclipse-based Java development."
+authors:
+  - family-names: "Hammer"
+    given-names: "Carsten"
+    orcid: "https://orcid.org/0009-0005-1047-6381"
+repository-code: "https://github.com/carstenartur/sandbox"
+url: "https://carstenartur.github.io/sandbox/"
+license: "EPL-2.0"
+keywords:
+  - eclipse
+  - eclipse-jdt
+  - java
+  - refactoring
+  - cleanup
+  - quickfix
+  - static-analysis
+  - code-analysis
+  - junit
+  - junit5
+  - encoding
+  - charset
+  - streams
+  - ast
+  - eclipse-plugin
+  - developer-tools


### PR DESCRIPTION
Adds repository-level metadata for scientific citation and Zenodo archiving.

Changes:
- Add `CITATION.cff` with author, ORCID, repository, license, and keywords
- Add `.zenodo.json` with Zenodo software metadata, keywords, license, related identifiers, and ORCID

ORCID used: `0009-0005-1047-6381`

Note: The README was not changed in this PR to avoid replacing the long existing README content through the contents API. A DOI badge and citation section can be added after the first Zenodo release DOI exists.