### PR TITLE
Disable custom Copilot setup for support diagnosis

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,47 +1,24 @@
-# Copilot Setup Steps
-# This workflow configures the environment for the GitHub Copilot coding agent.
-# It ensures the agent has Java 21, Maven 3.9.9, cached dependencies, and Xvfb
-# so that Tycho/Eclipse builds can succeed within the agent's time limits.
+# Copilot Setup Steps (no-op)
 #
-# The Maven cache key matches the one in maven.yml, so after a successful CI build
-# on main, the agent gets a full cache hit with all Tycho/P2 dependencies pre-resolved.
+# Temporarily disabled for diagnosis of GitHub Support ticket 4157159.
+#
+# The previous custom setup installed Java/Maven dependencies, restored Maven
+# caches, installed GUI libraries, and started Xvfb. GitHub Support asked to
+# remove or rename this file to rule out the custom environment as the cause of
+# Copilot cloud agent sessions hanging for hours.
+#
+# This active workflow is intentionally kept as a minimal no-op so that the
+# previous commands cannot affect a fresh agent session. The original content is
+# preserved in `.github/workflows/copilot-setup-steps.yml.disabled`.
 
-name: "Copilot Setup Steps"
+name: "Copilot Setup Steps Disabled"
 on: workflow_dispatch
 
 jobs:
   copilot-setup-steps:
     runs-on: ubuntu-latest
-    env:
-      DISPLAY: :0
-      MAVEN_OPTS: -Djava.awt.headless=true
     steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0 # required for jgit timestamp provider to work
-
-      - name: Set up JDK 21
-        uses: actions/setup-java@v5
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-
-      - name: Cache Maven dependencies
-        uses: actions/cache@v5
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml', 'sandbox_target/*.target') }}
-          restore-keys: ${{ runner.os }}-maven-
-
-      - name: Set up Maven
-        uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
-        with:
-          maven-version: 3.9.14
-
-      - name: Install Xvfb and GUI dependencies
+      - name: Custom Copilot setup disabled
         run: |
-          sudo apt-get update
-          sudo apt-get install -y xvfb xauth \
-           libgtk-3-0 libxext6 libxrender1 libxtst6 libxi6 libxrandr2 libxfixes3 \
-           libasound2t64 libnss3 libgbm1
-          sudo /usr/bin/Xvfb $DISPLAY -screen 0 1280x1024x24 &
+          echo "Custom Copilot setup is disabled for GitHub Support ticket 4157159."
+          echo "Original setup preserved in .github/workflows/copilot-setup-steps.yml.disabled."

--- a/.github/workflows/copilot-setup-steps.yml.disabled
+++ b/.github/workflows/copilot-setup-steps.yml.disabled
@@ -1,0 +1,55 @@
+# Copilot Setup Steps (disabled)
+#
+# This file was moved from `.github/workflows/copilot-setup-steps.yml` to
+# `.github/workflows/copilot-setup-steps.yml.disabled` for diagnosis of
+# GitHub Copilot cloud agent failures reported in GitHub Support ticket 4157159.
+#
+# GitHub Support asked to remove or rename the active setup file so that a fresh
+# Copilot agent session can run without the custom environment setup. Keeping the
+# original content here preserves the configuration for later comparison.
+#
+# Original purpose:
+# - Configure Java 21
+# - Configure Maven
+# - Cache Maven dependencies
+# - Install and start Xvfb with GUI libraries for Eclipse/Tycho tests
+
+name: "Copilot Setup Steps"
+on: workflow_dispatch
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    env:
+      DISPLAY: :0
+      MAVEN_OPTS: -Djava.awt.headless=true
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # required for jgit timestamp provider to work
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@v5
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml', 'sandbox_target/*.target') }}
+          restore-keys: ${{ runner.os }}-maven-
+
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
+        with:
+          maven-version: 3.9.14
+
+      - name: Install Xvfb and GUI dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb xauth \
+           libgtk-3-0 libxext6 libxrender1 libxtst6 libxi6 libxrandr2 libxfixes3 \
+           libasound2t64 libnss3 libgbm1
+          sudo /usr/bin/Xvfb $DISPLAY -screen 0 1280x1024x24 &


### PR DESCRIPTION
This PR follows GitHub Support's request from ticket 4157159 to rule out the custom Copilot cloud agent environment setup.

What changed:
- Preserved the previous `.github/workflows/copilot-setup-steps.yml` content in `.github/workflows/copilot-setup-steps.yml.disabled`.
- Replaced the active `.github/workflows/copilot-setup-steps.yml` with a minimal no-op workflow.

Why:
GitHub Support asked to remove or rename the custom setup file and then start a fresh Copilot agent session. The previous setup installed Java/Maven tooling, restored Maven caches, installed GUI libraries, and started Xvfb. Any of these steps could affect Copilot cloud agent initialization or make sessions appear stuck.

Note:
The direct delete/rename operation was not available via the connector, so this PR disables all custom setup commands while preserving the old file for comparison. If GitHub Support requires the filename itself to disappear completely, the active `.github/workflows/copilot-setup-steps.yml` file can be deleted manually after this PR is reviewed.