### PR TITLE
Add mining budget controls for Gemini free-tier runs

### DIFF
--- a/sandbox_mining_core/src/main/java/org/sandbox/mining/core/budget/BudgetProfile.java
+++ b/sandbox_mining_core/src/main/java/org/sandbox/mining/core/budget/BudgetProfile.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Carsten Hammer
+ *******************************************************************************/
+package org.sandbox.mining.core.budget;
+
+import java.util.Locale;
+
+/**
+ * Preset budget profiles for LLM-backed mining runs.
+ * <p>
+ * The values are deliberately conservative for free-tier operation. They are
+ * intended as defaults; callers may still override the resulting request and
+ * commit limits explicitly.
+ * </p>
+ */
+public enum BudgetProfile {
+
+	/**
+	 * Cheapest profile: one commit per request and low daily defaults.
+	 */
+	FREE(1, 50, 100),
+
+	/**
+	 * Default profile: keeps the current batching behaviour but still offers
+	 * explicit accounting hooks.
+	 */
+	BALANCED(4, 200, 800),
+
+	/**
+	 * Full context profile: unlimited by default unless explicit limits are set.
+	 */
+	THOROUGH(4, 0, 0);
+
+	private final int recommendedCommitsPerRequest;
+
+	private final int defaultMaxRequests;
+
+	private final int defaultMaxCommits;
+
+	BudgetProfile(int recommendedCommitsPerRequest, int defaultMaxRequests,
+			int defaultMaxCommits) {
+		this.recommendedCommitsPerRequest = recommendedCommitsPerRequest;
+		this.defaultMaxRequests = defaultMaxRequests;
+		this.defaultMaxCommits = defaultMaxCommits;
+	}
+
+	/**
+	 * @return recommended commits per LLM request for this profile
+	 */
+	public int recommendedCommitsPerRequest() {
+		return recommendedCommitsPerRequest;
+	}
+
+	/**
+	 * @return default maximum LLM requests; {@code 0} means unlimited
+	 */
+	public int defaultMaxRequests() {
+		return defaultMaxRequests;
+	}
+
+	/**
+	 * @return default maximum commits sent to the LLM; {@code 0} means unlimited
+	 */
+	public int defaultMaxCommits() {
+		return defaultMaxCommits;
+	}
+
+	/**
+	 * Parse a profile name from CLI/configuration text.
+	 *
+	 * @param value the profile name
+	 * @return the parsed profile
+	 * @throws IllegalArgumentException if the profile is unknown
+	 */
+	public static BudgetProfile parse(String value) {
+		if (value == null || value.isBlank()) {
+			return BALANCED;
+		}
+		String normalized = value.trim().toUpperCase(Locale.ROOT).replace('-', '_');
+		return BudgetProfile.valueOf(normalized);
+	}
+
+	/**
+	 * Apply this profile's batching recommendation unless the user explicitly
+	 * provided a different value.
+	 *
+	 * @param currentValue value currently configured
+	 * @param explicitlyConfigured whether the user configured the value explicitly
+	 * @return effective commits-per-request value
+	 */
+	public int effectiveCommitsPerRequest(int currentValue,
+			boolean explicitlyConfigured) {
+		if (explicitlyConfigured) {
+			return currentValue;
+		}
+		return Math.max(1, recommendedCommitsPerRequest);
+	}
+}

--- a/sandbox_mining_core/src/main/java/org/sandbox/mining/core/budget/BudgetProfile.java
+++ b/sandbox_mining_core/src/main/java/org/sandbox/mining/core/budget/BudgetProfile.java
@@ -13,7 +13,9 @@
  *******************************************************************************/
 package org.sandbox.mining.core.budget;
 
+import java.util.Arrays;
 import java.util.Locale;
+import java.util.stream.Collectors;
 
 /**
  * Preset budget profiles for LLM-backed mining runs.
@@ -77,17 +79,30 @@ public enum BudgetProfile {
 
 	/**
 	 * Parse a profile name from CLI/configuration text.
+	 * <p>
+	 * Matching is case-insensitive; hyphens are treated as underscores so that
+	 * {@code "free"} and {@code "FREE"} are both valid.
+	 * </p>
 	 *
 	 * @param value the profile name
 	 * @return the parsed profile
-	 * @throws IllegalArgumentException if the profile is unknown
+	 * @throws IllegalArgumentException if the profile is unknown, with a message
+	 *                                  that lists the supported profile names
 	 */
 	public static BudgetProfile parse(String value) {
 		if (value == null || value.isBlank()) {
 			return BALANCED;
 		}
 		String normalized = value.trim().toUpperCase(Locale.ROOT).replace('-', '_');
-		return BudgetProfile.valueOf(normalized);
+		try {
+			return BudgetProfile.valueOf(normalized);
+		} catch (IllegalArgumentException e) {
+			String supported = Arrays.stream(BudgetProfile.values())
+					.map(Enum::name)
+					.collect(Collectors.joining(", ")); //$NON-NLS-1$
+			throw new IllegalArgumentException(
+					"Unknown budget profile: '" + value + "'. Supported profiles: " + supported); //$NON-NLS-1$ //$NON-NLS-2$
+		}
 	}
 
 	/**

--- a/sandbox_mining_core/src/main/java/org/sandbox/mining/core/budget/MiningBudget.java
+++ b/sandbox_mining_core/src/main/java/org/sandbox/mining/core/budget/MiningBudget.java
@@ -1,0 +1,142 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Carsten Hammer
+ *******************************************************************************/
+package org.sandbox.mining.core.budget;
+
+/**
+ * Tracks request and commit budgets for LLM mining runs.
+ * <p>
+ * A value of {@code 0} for a maximum means unlimited. The class intentionally
+ * does not depend on a concrete LLM client so it can be tested and reused by
+ * the CLI, scheduled jobs, and dry-run tooling.
+ * </p>
+ */
+public final class MiningBudget {
+
+	private final int maxRequests;
+
+	private final int maxCommits;
+
+	private int requestsUsed;
+
+	private int commitsSent;
+
+	/**
+	 * Create a new budget.
+	 *
+	 * @param maxRequests maximum number of LLM requests; {@code 0} means unlimited
+	 * @param maxCommits maximum number of commits sent to the LLM; {@code 0} means unlimited
+	 */
+	public MiningBudget(int maxRequests, int maxCommits) {
+		if (maxRequests < 0) {
+			throw new IllegalArgumentException("maxRequests must be >= 0"); //$NON-NLS-1$
+		}
+		if (maxCommits < 0) {
+			throw new IllegalArgumentException("maxCommits must be >= 0"); //$NON-NLS-1$
+		}
+		this.maxRequests = maxRequests;
+		this.maxCommits = maxCommits;
+	}
+
+	/**
+	 * Build a budget from a profile plus optional explicit overrides.
+	 *
+	 * @param profile the budget profile
+	 * @param explicitMaxRequests explicit request limit, or {@code 0} for profile default
+	 * @param explicitMaxCommits explicit commit limit, or {@code 0} for profile default
+	 * @return budget instance
+	 */
+	public static MiningBudget from(BudgetProfile profile, int explicitMaxRequests,
+			int explicitMaxCommits) {
+		BudgetProfile effectiveProfile = profile == null ? BudgetProfile.BALANCED : profile;
+		int requestLimit = explicitMaxRequests > 0
+				? explicitMaxRequests
+				: effectiveProfile.defaultMaxRequests();
+		int commitLimit = explicitMaxCommits > 0
+				? explicitMaxCommits
+				: effectiveProfile.defaultMaxCommits();
+		return new MiningBudget(requestLimit, commitLimit);
+	}
+
+	/**
+	 * @return whether another LLM request may be started
+	 */
+	public boolean hasRequestCapacity() {
+		return maxRequests == 0 || requestsUsed < maxRequests;
+	}
+
+	/**
+	 * Returns how many commits may be included in the next LLM request.
+	 *
+	 * @param proposedCommitCount requested number of commits
+	 * @return allowed number of commits, possibly {@code 0}
+	 */
+	public int allowedCommitsForNextRequest(int proposedCommitCount) {
+		if (proposedCommitCount <= 0 || !hasRequestCapacity()) {
+			return 0;
+		}
+		if (maxCommits == 0) {
+			return proposedCommitCount;
+		}
+		int remaining = maxCommits - commitsSent;
+		return Math.max(0, Math.min(proposedCommitCount, remaining));
+	}
+
+	/**
+	 * Records an LLM request after the caller has decided to send one.
+	 *
+	 * @param commitCount number of commits included in the request
+	 */
+	public void recordRequest(int commitCount) {
+		if (commitCount < 0) {
+			throw new IllegalArgumentException("commitCount must be >= 0"); //$NON-NLS-1$
+		}
+		requestsUsed++;
+		commitsSent += commitCount;
+	}
+
+	/**
+	 * @return whether either configured limit has been exhausted
+	 */
+	public boolean isExhausted() {
+		boolean requestsExhausted = maxRequests > 0 && requestsUsed >= maxRequests;
+		boolean commitsExhausted = maxCommits > 0 && commitsSent >= maxCommits;
+		return requestsExhausted || commitsExhausted;
+	}
+
+	public int getMaxRequests() {
+		return maxRequests;
+	}
+
+	public int getMaxCommits() {
+		return maxCommits;
+	}
+
+	public int getRequestsUsed() {
+		return requestsUsed;
+	}
+
+	public int getCommitsSent() {
+		return commitsSent;
+	}
+
+	/**
+	 * @return human-readable budget summary for logs and reports
+	 */
+	public String formatSummary() {
+		return "LLM budget: requests " + requestsUsed + '/' //$NON-NLS-1$
+				+ (maxRequests == 0 ? "unlimited" : Integer.toString(maxRequests)) //$NON-NLS-1$
+				+ ", commits " + commitsSent + '/' //$NON-NLS-1$
+				+ (maxCommits == 0 ? "unlimited" : Integer.toString(maxCommits)); //$NON-NLS-1$
+	}
+}

--- a/sandbox_mining_core/src/main/java/org/sandbox/mining/core/budget/MiningBudget.java
+++ b/sandbox_mining_core/src/main/java/org/sandbox/mining/core/budget/MiningBudget.java
@@ -50,19 +50,31 @@ public final class MiningBudget {
 
 	/**
 	 * Build a budget from a profile plus optional explicit overrides.
+	 * <p>
+	 * Pass {@code -1} for either override to use the profile default.
+	 * Pass {@code 0} to explicitly request an unlimited budget for that dimension.
+	 * Any value lower than {@code -1} is rejected as invalid.
+	 * </p>
 	 *
 	 * @param profile the budget profile
-	 * @param explicitMaxRequests explicit request limit, or {@code 0} for profile default
-	 * @param explicitMaxCommits explicit commit limit, or {@code 0} for profile default
+	 * @param explicitMaxRequests explicit request limit, {@code 0} for unlimited, or {@code -1} for profile default
+	 * @param explicitMaxCommits explicit commit limit, {@code 0} for unlimited, or {@code -1} for profile default
 	 * @return budget instance
+	 * @throws IllegalArgumentException if either explicit value is less than {@code -1}
 	 */
 	public static MiningBudget from(BudgetProfile profile, int explicitMaxRequests,
 			int explicitMaxCommits) {
+		if (explicitMaxRequests < -1) {
+			throw new IllegalArgumentException("explicitMaxRequests must be >= -1"); //$NON-NLS-1$
+		}
+		if (explicitMaxCommits < -1) {
+			throw new IllegalArgumentException("explicitMaxCommits must be >= -1"); //$NON-NLS-1$
+		}
 		BudgetProfile effectiveProfile = profile == null ? BudgetProfile.BALANCED : profile;
-		int requestLimit = explicitMaxRequests > 0
+		int requestLimit = explicitMaxRequests >= 0
 				? explicitMaxRequests
 				: effectiveProfile.defaultMaxRequests();
-		int commitLimit = explicitMaxCommits > 0
+		int commitLimit = explicitMaxCommits >= 0
 				? explicitMaxCommits
 				: effectiveProfile.defaultMaxCommits();
 		return new MiningBudget(requestLimit, commitLimit);

--- a/sandbox_mining_core/src/test/java/org/sandbox/mining/core/budget/MiningBudgetTest.java
+++ b/sandbox_mining_core/src/test/java/org/sandbox/mining/core/budget/MiningBudgetTest.java
@@ -27,7 +27,7 @@ class MiningBudgetTest {
 
 	@Test
 	void testFreeProfileDefaultsAreConservative() {
-		MiningBudget budget = MiningBudget.from(BudgetProfile.FREE, 0, 0);
+		MiningBudget budget = MiningBudget.from(BudgetProfile.FREE, -1, -1);
 
 		assertEquals(50, budget.getMaxRequests());
 		assertEquals(100, budget.getMaxCommits());
@@ -72,15 +72,36 @@ class MiningBudgetTest {
 	}
 
 	@Test
-	void testBudgetProfileParsingAcceptsHyphenatedNames() {
+	void testBudgetProfileParsingAcceptsCaseInsensitiveAndHyphenatedNames() {
 		assertEquals(BudgetProfile.FREE, BudgetProfile.parse("free")); //$NON-NLS-1$
 		assertEquals(BudgetProfile.BALANCED, BudgetProfile.parse("balanced")); //$NON-NLS-1$
 		assertEquals(BudgetProfile.THOROUGH, BudgetProfile.parse("thorough")); //$NON-NLS-1$
+		assertEquals(BudgetProfile.FREE, BudgetProfile.parse("FREE")); //$NON-NLS-1$
+		assertEquals(BudgetProfile.BALANCED, BudgetProfile.parse("Balanced")); //$NON-NLS-1$
+	}
+
+	@Test
+	void testBudgetProfileParsingRejectsUnknownProfiles() {
+		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+				() -> BudgetProfile.parse("unknown")); //$NON-NLS-1$
+		assertTrue(ex.getMessage().contains("unknown")); //$NON-NLS-1$
+		assertTrue(ex.getMessage().contains("FREE")); //$NON-NLS-1$
 	}
 
 	@Test
 	void testNegativeLimitsRejected() {
 		assertThrows(IllegalArgumentException.class, () -> new MiningBudget(-1, 0));
 		assertThrows(IllegalArgumentException.class, () -> new MiningBudget(0, -1));
+		assertThrows(IllegalArgumentException.class, () -> MiningBudget.from(BudgetProfile.FREE, -2, -1));
+		assertThrows(IllegalArgumentException.class, () -> MiningBudget.from(BudgetProfile.FREE, -1, -2));
+	}
+
+	@Test
+	void testExplicitZeroMeansUnlimitedOverride() {
+		MiningBudget budget = MiningBudget.from(BudgetProfile.FREE, 0, 0);
+
+		assertEquals(0, budget.getMaxRequests());
+		assertEquals(0, budget.getMaxCommits());
+		assertFalse(budget.isExhausted());
 	}
 }

--- a/sandbox_mining_core/src/test/java/org/sandbox/mining/core/budget/MiningBudgetTest.java
+++ b/sandbox_mining_core/src/test/java/org/sandbox/mining/core/budget/MiningBudgetTest.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Carsten Hammer
+ *******************************************************************************/
+package org.sandbox.mining.core.budget;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link MiningBudget} and {@link BudgetProfile}.
+ */
+class MiningBudgetTest {
+
+	@Test
+	void testFreeProfileDefaultsAreConservative() {
+		MiningBudget budget = MiningBudget.from(BudgetProfile.FREE, 0, 0);
+
+		assertEquals(50, budget.getMaxRequests());
+		assertEquals(100, budget.getMaxCommits());
+		assertEquals(1, BudgetProfile.FREE.recommendedCommitsPerRequest());
+	}
+
+	@Test
+	void testExplicitLimitsOverrideProfileDefaults() {
+		MiningBudget budget = MiningBudget.from(BudgetProfile.FREE, 7, 13);
+
+		assertEquals(7, budget.getMaxRequests());
+		assertEquals(13, budget.getMaxCommits());
+	}
+
+	@Test
+	void testAllowedCommitCountIsClampedByRemainingBudget() {
+		MiningBudget budget = new MiningBudget(10, 5);
+		budget.recordRequest(3);
+
+		assertEquals(2, budget.allowedCommitsForNextRequest(4));
+	}
+
+	@Test
+	void testRequestLimitStopsFurtherRequests() {
+		MiningBudget budget = new MiningBudget(1, 0);
+		assertTrue(budget.hasRequestCapacity());
+
+		budget.recordRequest(4);
+
+		assertFalse(budget.hasRequestCapacity());
+		assertEquals(0, budget.allowedCommitsForNextRequest(1));
+		assertTrue(budget.isExhausted());
+	}
+
+	@Test
+	void testUnlimitedBudgetDoesNotClamp() {
+		MiningBudget budget = new MiningBudget(0, 0);
+
+		assertEquals(100, budget.allowedCommitsForNextRequest(100));
+		budget.recordRequest(100);
+		assertFalse(budget.isExhausted());
+	}
+
+	@Test
+	void testBudgetProfileParsingAcceptsHyphenatedNames() {
+		assertEquals(BudgetProfile.FREE, BudgetProfile.parse("free")); //$NON-NLS-1$
+		assertEquals(BudgetProfile.BALANCED, BudgetProfile.parse("balanced")); //$NON-NLS-1$
+		assertEquals(BudgetProfile.THOROUGH, BudgetProfile.parse("thorough")); //$NON-NLS-1$
+	}
+
+	@Test
+	void testNegativeLimitsRejected() {
+		assertThrows(IllegalArgumentException.class, () -> new MiningBudget(-1, 0));
+		assertThrows(IllegalArgumentException.class, () -> new MiningBudget(0, -1));
+	}
+}


### PR DESCRIPTION
Adds the first building block for making the mining pipeline safe for free-tier LLM usage.

## Changes

- Add `BudgetProfile` with `FREE`, `BALANCED`, and `THOROUGH` presets.
- Add `MiningBudget` for request and commit accounting.
- Add unit tests covering conservative free-tier defaults, explicit overrides, request exhaustion, commit clamping, unlimited mode, and validation.

## Why

The current staged mining pipeline can still consume Gemini quota quickly because the expensive request path is not guarded by explicit request/commit budgets. This PR adds the reusable model needed before wiring `--budget-profile`, `--max-llm-requests`, and `--max-llm-commits` into `MiningCli`.

## Follow-up

A later PR can wire this into `MiningCli` once the staged candidate pipeline PR is merged or while continuing this stacked branch.