### PR TITLE
Add compact screening stage for staged mining

### DIFF
--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/llm/CommitScreening.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/llm/CommitScreening.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Carsten Hammer
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.llm;
+
+import org.sandbox.jdt.triggerpattern.llm.CommitEvaluation.TrafficLight;
+
+/**
+ * Lightweight first-stage LLM result used to decide whether a commit is worth
+ * a full candidate-generation request.
+ * <p>
+ * This deliberately omits expensive fields such as DSL rules, before/after
+ * examples, and negative examples. Those should only be requested for commits
+ * that pass this cheap screening stage.
+ * </p>
+ *
+ * @param commitHash   the commit hash
+ * @param relevant     whether the commit is relevant for mining
+ * @param trafficLight coarse suitability assessment
+ * @param category     coarse category, if known
+ * @param confidence   confidence in the assessment, between {@code 0.0} and {@code 1.0}
+ * @param reason       short explanation for the decision
+ */
+public record CommitScreening(
+		String commitHash,
+		boolean relevant,
+		TrafficLight trafficLight,
+		String category,
+		double confidence,
+		String reason) {
+
+	/** Default confidence threshold for a full candidate request. */
+	public static final double DEFAULT_CANDIDATE_THRESHOLD = 0.75d;
+
+	/**
+	 * @return whether this result should continue to full candidate generation
+	 */
+	public boolean shouldRequestCandidateDetails() {
+		return relevant && trafficLight == TrafficLight.GREEN
+				&& confidence >= DEFAULT_CANDIDATE_THRESHOLD;
+	}
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/llm/ScreeningPromptBuilder.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/llm/ScreeningPromptBuilder.java
@@ -60,7 +60,8 @@ public class ScreeningPromptBuilder {
 		sb.append("You are screening commits for reusable Java cleanup/refactoring patterns.\n"); //$NON-NLS-1$
 		sb.append("Do not produce DSL rules. Do not produce before/after examples.\n"); //$NON-NLS-1$
 		sb.append("Only decide whether each commit is worth a later, more expensive candidate-generation request.\n\n"); //$NON-NLS-1$
-		sb.append("Return a JSON array with exactly ").append(commits.size()).append(" objects.\n"); //$NON-NLS-1$ //$NON-NLS-2$
+		sb.append("Return a JSON array with exactly ").append(commits.size()); //$NON-NLS-1$
+		sb.append(" objects, one per commit, in the same order as presented.\n"); //$NON-NLS-1$
 		sb.append("Schema per object:\n"); //$NON-NLS-1$
 		sb.append("{\n"); //$NON-NLS-1$
 		sb.append("  \"commitHash\": \"hash\",\n"); //$NON-NLS-1$
@@ -69,7 +70,8 @@ public class ScreeningPromptBuilder {
 		sb.append("  \"category\": \"short category or null\",\n"); //$NON-NLS-1$
 		sb.append("  \"confidence\": 0.0,\n"); //$NON-NLS-1$
 		sb.append("  \"reason\": \"one short sentence\"\n"); //$NON-NLS-1$
-		sb.append("}\n\n"); //$NON-NLS-1$
+		sb.append("}\n"); //$NON-NLS-1$
+		sb.append("confidence MUST be a decimal between 0.0 and 1.0 (not 0–100).\n\n"); //$NON-NLS-1$
 		for (int i = 0; i < commits.size(); i++) {
 			CommitData commit = commits.get(i);
 			sb.append("## Commit ").append(i).append(" (").append(commit.commitHash()).append(")\n"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/llm/ScreeningPromptBuilder.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/llm/ScreeningPromptBuilder.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Carsten Hammer
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.llm;
+
+import java.util.List;
+
+import org.sandbox.jdt.triggerpattern.llm.PromptBuilder.CommitData;
+
+/**
+ * Builds compact first-stage prompts for cheap commit screening.
+ * <p>
+ * The screening prompt intentionally avoids full DSL context and does not ask
+ * for DSL rules or code examples. It is intended for Gemini free-tier friendly
+ * mining runs where only promising commits should continue to the expensive
+ * candidate-generation stage.
+ * </p>
+ */
+public class ScreeningPromptBuilder {
+
+	private static final int DEFAULT_MAX_DIFF_CHARS = 4_000;
+
+	private final int maxDiffChars;
+
+	/** Create a builder with the default diff truncation limit. */
+	public ScreeningPromptBuilder() {
+		this(DEFAULT_MAX_DIFF_CHARS);
+	}
+
+	/**
+	 * Create a builder with an explicit diff truncation limit.
+	 *
+	 * @param maxDiffChars maximum characters of each diff included in the prompt
+	 */
+	public ScreeningPromptBuilder(int maxDiffChars) {
+		if (maxDiffChars < 500) {
+			throw new IllegalArgumentException("maxDiffChars must be at least 500"); //$NON-NLS-1$
+		}
+		this.maxDiffChars = maxDiffChars;
+	}
+
+	/**
+	 * Builds a compact batch prompt for first-stage screening.
+	 *
+	 * @param commits commits to screen
+	 * @return prompt text
+	 */
+	public String buildScreeningPrompt(List<CommitData> commits) {
+		StringBuilder sb = new StringBuilder();
+		sb.append("You are screening commits for reusable Java cleanup/refactoring patterns.\n"); //$NON-NLS-1$
+		sb.append("Do not produce DSL rules. Do not produce before/after examples.\n"); //$NON-NLS-1$
+		sb.append("Only decide whether each commit is worth a later, more expensive candidate-generation request.\n\n"); //$NON-NLS-1$
+		sb.append("Return a JSON array with exactly ").append(commits.size()).append(" objects.\n"); //$NON-NLS-1$ //$NON-NLS-2$
+		sb.append("Schema per object:\n"); //$NON-NLS-1$
+		sb.append("{\n"); //$NON-NLS-1$
+		sb.append("  \"commitHash\": \"hash\",\n"); //$NON-NLS-1$
+		sb.append("  \"relevant\": true,\n"); //$NON-NLS-1$
+		sb.append("  \"trafficLight\": \"GREEN|YELLOW|RED|NOT_APPLICABLE\",\n"); //$NON-NLS-1$
+		sb.append("  \"category\": \"short category or null\",\n"); //$NON-NLS-1$
+		sb.append("  \"confidence\": 0.0,\n"); //$NON-NLS-1$
+		sb.append("  \"reason\": \"one short sentence\"\n"); //$NON-NLS-1$
+		sb.append("}\n\n"); //$NON-NLS-1$
+		for (int i = 0; i < commits.size(); i++) {
+			CommitData commit = commits.get(i);
+			sb.append("## Commit ").append(i).append(" (").append(commit.commitHash()).append(")\n"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			sb.append("Message:\n").append(commit.commitMessage()).append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+			sb.append("Diff:\n```\n"); //$NON-NLS-1$
+			sb.append(truncate(commit.diff())).append("\n```\n\n"); //$NON-NLS-1$
+		}
+		return sb.toString();
+	}
+
+	private String truncate(String diff) {
+		if (diff == null) {
+			return ""; //$NON-NLS-1$
+		}
+		if (diff.length() <= maxDiffChars) {
+			return diff;
+		}
+		return diff.substring(0, maxDiffChars) + "\n... [diff truncated for screening]"; //$NON-NLS-1$
+	}
+}

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/llm/ScreeningPromptBuilderTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/llm/ScreeningPromptBuilderTest.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Carsten Hammer
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.llm;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.sandbox.jdt.triggerpattern.llm.CommitEvaluation.TrafficLight;
+import org.sandbox.jdt.triggerpattern.llm.PromptBuilder.CommitData;
+
+/**
+ * Tests for {@link ScreeningPromptBuilder} and {@link CommitScreening}.
+ */
+class ScreeningPromptBuilderTest {
+
+	@Test
+	void testScreeningPromptDoesNotAskForExpensiveCandidateFields() {
+		CommitData commit = new CommitData("abc123", "Replace legacy API", "diff"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
+		String prompt = new ScreeningPromptBuilder().buildScreeningPrompt(List.of(commit));
+
+		assertTrue(prompt.contains("trafficLight")); //$NON-NLS-1$
+		assertTrue(prompt.contains("confidence")); //$NON-NLS-1$
+		assertFalse(prompt.contains("dslRule")); //$NON-NLS-1$
+		assertFalse(prompt.contains("beforeExample")); //$NON-NLS-1$
+		assertFalse(prompt.contains("afterExample")); //$NON-NLS-1$
+		assertFalse(prompt.contains("negativeExample")); //$NON-NLS-1$
+	}
+
+	@Test
+	void testDiffIsTruncatedForScreening() {
+		String longDiff = "x".repeat(2_000); //$NON-NLS-1$
+		CommitData commit = new CommitData("abc123", "Long diff", longDiff); //$NON-NLS-1$ //$NON-NLS-2$
+
+		String prompt = new ScreeningPromptBuilder(1_000).buildScreeningPrompt(List.of(commit));
+
+		assertTrue(prompt.contains("[diff truncated for screening]")); //$NON-NLS-1$
+	}
+
+	@Test
+	void testCommitScreeningCandidateThreshold() {
+		CommitScreening good = new CommitScreening("abc123", true, //$NON-NLS-1$
+				TrafficLight.GREEN, "api-modernization", 0.9d, "Reusable API replacement"); //$NON-NLS-1$ //$NON-NLS-2$
+		CommitScreening weak = new CommitScreening("def456", true, //$NON-NLS-1$
+				TrafficLight.GREEN, "api-modernization", 0.4d, "Unclear pattern"); //$NON-NLS-1$ //$NON-NLS-2$
+		CommitScreening yellow = new CommitScreening("ghi789", true, //$NON-NLS-1$
+				TrafficLight.YELLOW, "api-modernization", 0.95d, "Needs DSL change"); //$NON-NLS-1$ //$NON-NLS-2$
+
+		assertTrue(good.shouldRequestCandidateDetails());
+		assertFalse(weak.shouldRequestCandidateDetails());
+		assertFalse(yellow.shouldRequestCandidateDetails());
+	}
+}

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/llm/ScreeningPromptBuilderTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/llm/ScreeningPromptBuilderTest.java
@@ -42,6 +42,17 @@ class ScreeningPromptBuilderTest {
 	}
 
 	@Test
+	void testScreeningPromptConstrainsOrderingAndConfidenceScale() {
+		CommitData c1 = new CommitData("aaa111", "First commit", "diff1"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		CommitData c2 = new CommitData("bbb222", "Second commit", "diff2"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
+		String prompt = new ScreeningPromptBuilder().buildScreeningPrompt(List.of(c1, c2));
+
+		assertTrue(prompt.contains("in the same order as presented")); //$NON-NLS-1$
+		assertTrue(prompt.contains("0.0 and 1.0")); //$NON-NLS-1$
+	}
+
+	@Test
 	void testDiffIsTruncatedForScreening() {
 		String longDiff = "x".repeat(2_000); //$NON-NLS-1$
 		CommitData commit = new CommitData("abc123", "Long diff", longDiff); //$NON-NLS-1$ //$NON-NLS-2$


### PR DESCRIPTION
Adds the compact first-stage model and prompt builder for a two-step Gemini mining flow.

## Changes

- Add `CommitScreening`, a lightweight first-stage result that decides whether a commit is worth full candidate generation.
- Add `ScreeningPromptBuilder`, which creates compact prompts that explicitly avoid DSL rules and before/after examples.
- Truncate large diffs during screening to reduce token usage.
- Add tests verifying that expensive fields are not requested and that candidate-detail thresholds work.

## Why

The staged mining pipeline currently asks Gemini for full candidate details too early. This PR introduces the compact screening foundation so a later integration can first ask for cheap relevance/traffic-light/confidence decisions and only request `dslRule` plus examples for high-confidence GREEN commits.

## Follow-up

Wire screening into `MiningCli` as stage 1, then call the existing full `PromptBuilder` only for `CommitScreening.shouldRequestCandidateDetails()` results.