### PR TITLE
ci: persist staged mining candidates

### DIFF
--- a/.github/workflows/mining-core.yml
+++ b/.github/workflows/mining-core.yml
@@ -38,6 +38,14 @@ jobs:
           mvn install -pl sandbox_common_core -DskipTests -q
           mvn package -pl sandbox_mining_core -DskipTests -q
 
+      - name: Snapshot known rules before mining
+        run: |
+          if [ -f docs/mining-report/known-rules.json ]; then
+            cp docs/mining-report/known-rules.json "$RUNNER_TEMP/known-rules-before.json"
+          else
+            printf '{"version":1,"rules":[]}' > "$RUNNER_TEMP/known-rules-before.json"
+          fi
+
       - name: Run Commit Mining
         continue-on-error: true
         env:
@@ -63,6 +71,71 @@ jobs:
             --commits-per-request 4 \
             --output docs/mining-report/ \
             ${{ github.event.inputs.llm_provider != '' && format('--llm-provider {0}', github.event.inputs.llm_provider) || '' }}
+
+      - name: Reconcile staged mining candidates
+        if: always()
+        run: |
+          BEFORE_KNOWN="$RUNNER_TEMP/known-rules-before.json"
+          CURRENT_KNOWN="docs/mining-report/known-rules.json"
+          CANDIDATE_DIR="mining-candidates"
+          if [ ! -f "$CURRENT_KNOWN" ]; then
+            echo "No known-rules.json found after mining; skipping candidate reconciliation."
+            exit 0
+          fi
+          python3 - "$BEFORE_KNOWN" "$CURRENT_KNOWN" "$CANDIDATE_DIR" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          before_path = pathlib.Path(sys.argv[1])
+          known_path = pathlib.Path(sys.argv[2])
+          candidate_dir = pathlib.Path(sys.argv[3])
+
+          def load_rules(path):
+              if not path.exists():
+                  return {"version": 1, "rules": []}
+              with path.open(encoding="utf-8") as handle:
+                  return json.load(handle)
+
+          before = load_rules(before_path)
+          current = load_rules(known_path)
+          before_commits = {
+              rule.get("sourceCommit")
+              for rule in before.get("rules", [])
+              if rule.get("sourceCommit")
+          }
+
+          candidate_commits = set()
+          if candidate_dir.exists():
+              for candidate_path in candidate_dir.glob("*-candidate.json"):
+                  try:
+                      with candidate_path.open(encoding="utf-8") as handle:
+                          candidate = json.load(handle)
+                      commit = candidate.get("sourceCommit")
+                      if commit:
+                          candidate_commits.add(commit)
+                  except Exception as exc:
+                      print(f"Warning: could not read candidate {candidate_path}: {exc}", file=sys.stderr)
+
+          rules = current.get("rules", [])
+          kept = [
+              rule for rule in rules
+              if rule.get("sourceCommit") in before_commits
+              or rule.get("sourceCommit") in candidate_commits
+          ]
+          removed = len(rules) - len(kept)
+          if removed:
+              current["rules"] = kept
+              with known_path.open("w", encoding="utf-8") as handle:
+                  json.dump(current, handle, indent=2)
+                  handle.write("\n")
+          print(
+              "Candidate reconciliation: "
+              f"kept {len(kept)} known rules, "
+              f"removed {removed} non-staged new rules, "
+              f"candidate commits {len(candidate_commits)}"
+          )
+          PY
 
       - name: Post-run diagnostics
         if: always()
@@ -99,6 +172,11 @@ jobs:
           if [ -f docs/mining-report/known-rules.json ]; then
             git add docs/mining-report/known-rules.json
           fi
+          # Include staged mining candidates if they were created/updated
+          CANDIDATE_DIR="mining-candidates"
+          if [ -d "$CANDIDATE_DIR" ]; then
+            git add "$CANDIDATE_DIR"/*.json 2>/dev/null || true
+          fi
           # Include auto-generated .sandbox-hint files from HintFileUpdater
           HINT_DIR="sandbox_common_core/src/main/resources/org/sandbox/jdt/triggerpattern/internal"
           if [ -d "$HINT_DIR" ]; then
@@ -129,11 +207,15 @@ jobs:
           if [ -f docs/mining-report/known-rules.json ]; then
             git add docs/mining-report/known-rules.json
           fi
+          # Re-add staged mining candidates after stash pop
+          if [ -d "$CANDIDATE_DIR" ]; then
+            git add "$CANDIDATE_DIR"/*.json 2>/dev/null || true
+          fi
           # Re-add hint files after stash pop
           if [ -d "$HINT_DIR" ]; then
             git add $HINT_DIR/*.sandbox-hint 2>/dev/null || true
           fi
-          git commit -m "mining: Update state + known rules + hints $(date +%Y-%m-%d)"
+          git commit -m "mining: Update state + known rules + candidates $(date +%Y-%m-%d)"
           git push origin "$BRANCH" --force
           echo "state_updated=true" >> "$GITHUB_OUTPUT"
 
@@ -298,4 +380,7 @@ jobs:
         if: always()
         with:
           name: mining-report-${{ github.run_number }}
-          path: docs/mining-report/
+          path: |
+            docs/mining-report/
+            mining-candidates/
+          if-no-files-found: ignore

--- a/docs/mining-candidate-integration-tests.md
+++ b/docs/mining-candidate-integration-tests.md
@@ -16,6 +16,14 @@ A useful integration test should verify the complete path for a small, known com
 6. stage a `MiningCandidate`,
 7. assert that `known-rules.json` is only updated for the persisted candidate.
 
+## FQN-aware DSL style
+
+Candidate rules should normally express concrete APIs with fully qualified names. The matcher should accept target code that uses imports or simple names when imports or bindings prove that the code refers to the same API.
+
+For example, a rule written for `java.util.Collections.emptyList()` should also match source code that imports `java.util.Collections` and calls `Collections.emptyList()`.
+
+The same principle should apply to constructors, type references, method receivers, argument types, return types and overload-sensitive API migrations wherever the equivalence is knowable. This keeps mined rules readable and avoids duplicating rules for different source-code presentation forms.
+
 ## Suggested execution model
 
 Use a JUnit 5 tag such as `@Tag("gemini-integration")` and gate the test with environment variables:

--- a/docs/mining-candidate-integration-tests.md
+++ b/docs/mining-candidate-integration-tests.md
@@ -1,0 +1,71 @@
+# Mining candidate integration tests
+
+This note outlines a safe way to add optional integration tests for the staged mining pipeline.
+
+## Goal
+
+The normal test suite should remain deterministic and offline. Gemini-backed checks should be opt-in and only run when explicitly requested with credentials.
+
+A useful integration test should verify the complete path for a small, known commit:
+
+1. check out or clone the configured source repository,
+2. extract the diff for a pinned commit,
+3. build the mining prompt,
+4. call the configured LLM provider,
+5. validate the returned DSL rule,
+6. stage a `MiningCandidate`,
+7. assert that `known-rules.json` is only updated for the persisted candidate.
+
+## Suggested execution model
+
+Use a JUnit 5 tag such as `@Tag("gemini-integration")` and gate the test with environment variables:
+
+- `GEMINI_API_KEY`
+- `RUN_GEMINI_INTEGRATION=true`
+- optionally `GEMINI_MODEL`, defaulting to the model used by the workflow
+
+The Maven invocation should be explicit, for example:
+
+```bash
+RUN_GEMINI_INTEGRATION=true \
+GEMINI_API_KEY=... \
+mvn -pl sandbox_mining_core \
+  -Dgroups=gemini-integration \
+  -DskipTests=false \
+  test
+```
+
+The CI default must not run this tag.
+
+## Recommended fixtures
+
+Use a small set of pinned commits that are known to contain generalizable rules and keep each fixture narrow. Good candidates are rules already represented in `docs/mining-report/known-rules.json`, for example:
+
+- Vector constructor modernization to ArrayList, guarded by local assignment context.
+- `String.replaceAll("\\n", replacement)` to `String.replace("\\n", replacement)` for literal non-regex replacement.
+- Deprecated wrapper constructors such as `new Float(x)` or `new Double(x)` to `valueOf(x)`.
+
+Each fixture should define expected properties rather than exact prose:
+
+- expected traffic light: `GREEN`
+- expected `dslValidationResult`: `VALID`
+- expected target hint file or category
+- required DSL fragments, not the entire exact LLM response
+- before/after/negative examples when available
+
+## Reproducibility notes
+
+LLM responses are probabilistic, so the assertions should not depend on exact wording. The useful measurement is whether the model still finds a valid, general rule under the current prompt and budget.
+
+For cognitive-load/regression tracking, store a small JSON summary as a build artifact:
+
+- model name
+- prompt size
+- diff size
+- latency
+- token usage if available
+- traffic light
+- DSL validation result
+- candidate ID
+
+This makes prompt regressions visible without committing live LLM output into the repository.

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/api/PatternIndex.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/api/PatternIndex.java
@@ -32,6 +32,7 @@ import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.core.dom.Statement;
 import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
+import org.sandbox.jdt.triggerpattern.internal.FqnAwarePlaceholderAstMatcher;
 import org.sandbox.jdt.triggerpattern.internal.PatternParser;
 import org.sandbox.jdt.triggerpattern.internal.PlaceholderAstMatcher;
 
@@ -204,7 +205,7 @@ public final class PatternIndex {
 		}
 
 		for (IndexEntry entry : entries) {
-			PlaceholderAstMatcher matcher = new PlaceholderAstMatcher();
+			PlaceholderAstMatcher matcher = new FqnAwarePlaceholderAstMatcher();
 			matcher.setCaseInsensitive(caseInsensitive);
 			if (entry.patternNode().subtreeMatch(matcher, node)) {
 				Match match = new Match(node, matcher.getBindings(),
@@ -239,35 +240,25 @@ public final class PatternIndex {
 				continue;
 			}
 
-			// Sliding window
-			for (int i = 0; i <= statements.size() - patternSize; i++) {
-				boolean allMatch = true;
-				PlaceholderAstMatcher combinedMatcher = new PlaceholderAstMatcher();
-				combinedMatcher.setCaseInsensitive(caseInsensitive);
-				for (int j = 0; j < patternSize; j++) {
-					PlaceholderAstMatcher matcher = new PlaceholderAstMatcher();
-					matcher.setCaseInsensitive(caseInsensitive);
-					if (!patternStatements.get(j).subtreeMatch(matcher, statements.get(i + j))) {
-						allMatch = false;
-						break;
-					}
-					combinedMatcher.mergeBindings(matcher);
+			for (int start = 0; start <= statements.size() - patternSize; start++) {
+				Block syntheticBlock = block.getAST().newBlock();
+				for (int i = 0; i < patternSize; i++) {
+					syntheticBlock.statements().add(ASTNode.copySubtree(block.getAST(), statements.get(start + i)));
 				}
-				if (allMatch) {
-					Statement first = statements.get(i);
-					Statement last = statements.get(i + patternSize - 1);
-					int offset = first.getStartPosition();
-					int length = (last.getStartPosition() + last.getLength()) - offset;
-					Match match = new Match(first, combinedMatcher.getBindings(), offset, length);
+
+				PlaceholderAstMatcher matcher = new FqnAwarePlaceholderAstMatcher();
+				matcher.setCaseInsensitive(caseInsensitive);
+				if (patternBlock.subtreeMatch(matcher, syntheticBlock)) {
+					int offset = statements.get(start).getStartPosition();
+					Statement last = statements.get(start + patternSize - 1);
+					int length = last.getStartPosition() + last.getLength() - offset;
+					Match match = new Match(block, matcher.getBindings(), offset, length);
 					results.computeIfAbsent(entry.rule(), r -> new ArrayList<>()).add(match);
 				}
 			}
 		}
 	}
 
-	/**
-	 * An entry in the pattern index, containing a rule and its pre-parsed pattern node.
-	 */
 	private record IndexEntry(TransformationRule rule, Pattern sourcePattern, ASTNode patternNode) {
 	}
 }

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/FqnAwarePlaceholderAstMatcher.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/FqnAwarePlaceholderAstMatcher.java
@@ -109,6 +109,9 @@ public final class FqnAwarePlaceholderAstMatcher extends PlaceholderAstMatcher {
 
 	@Override
 	public boolean match(ClassInstanceCreation patternNode, Object other) {
+		if (super.match(patternNode, other)) {
+			return true;
+		}
 		if (!(other instanceof ClassInstanceCreation otherCreation)) {
 			return false;
 		}
@@ -134,6 +137,9 @@ public final class FqnAwarePlaceholderAstMatcher extends PlaceholderAstMatcher {
 
 	@Override
 	public boolean match(MethodInvocation patternNode, Object other) {
+		if (super.match(patternNode, other)) {
+			return true;
+		}
 		if (!(other instanceof MethodInvocation otherInvocation)) {
 			return false;
 		}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/FqnAwarePlaceholderAstMatcher.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/FqnAwarePlaceholderAstMatcher.java
@@ -1,0 +1,403 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Carsten Hammer
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.internal;
+
+import java.util.List;
+
+import org.eclipse.jdt.core.dom.ArrayType;
+import org.eclipse.jdt.core.dom.ASTMatcher;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.CastExpression;
+import org.eclipse.jdt.core.dom.ClassInstanceCreation;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.ImportDeclaration;
+import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.Name;
+import org.eclipse.jdt.core.dom.NameQualifiedType;
+import org.eclipse.jdt.core.dom.ParameterizedType;
+import org.eclipse.jdt.core.dom.PrimitiveType;
+import org.eclipse.jdt.core.dom.QualifiedType;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.SimpleType;
+import org.eclipse.jdt.core.dom.Type;
+import org.eclipse.jdt.core.dom.TypeLiteral;
+import org.eclipse.jdt.core.dom.WildcardType;
+
+/**
+ * FQN-aware variant of {@link PlaceholderAstMatcher}.
+ *
+ * <p>DSL snippets should express concrete APIs using fully qualified names. This
+ * matcher accepts source code that uses the same API via imports and simple
+ * names. It applies that principle to type references, parameterized types,
+ * arrays, constructors, type literals, casts and method receivers.</p>
+ */
+public final class FqnAwarePlaceholderAstMatcher extends PlaceholderAstMatcher {
+
+	private final ASTMatcher structuralMatcher = new ASTMatcher();
+
+	@Override
+	public boolean match(SimpleType patternNode, Object other) {
+		if (super.match(patternNode, other)) {
+			return true;
+		}
+		return other instanceof SimpleType otherType
+				&& namesEquivalent(patternNode.getName(), otherType.getName());
+	}
+
+	@Override
+	public boolean match(QualifiedType patternNode, Object other) {
+		return other instanceof Type otherType && typesEquivalent(patternNode, otherType);
+	}
+
+	@Override
+	public boolean match(NameQualifiedType patternNode, Object other) {
+		return other instanceof Type otherType && typesEquivalent(patternNode, otherType);
+	}
+
+	@Override
+	public boolean match(ParameterizedType patternNode, Object other) {
+		return other instanceof Type otherType && typesEquivalent(patternNode, otherType);
+	}
+
+	@Override
+	public boolean match(ArrayType patternNode, Object other) {
+		return other instanceof Type otherType && typesEquivalent(patternNode, otherType);
+	}
+
+	@Override
+	public boolean match(PrimitiveType patternNode, Object other) {
+		return other instanceof PrimitiveType otherType
+				&& patternNode.getPrimitiveTypeCode().equals(otherType.getPrimitiveTypeCode());
+	}
+
+	@Override
+	public boolean match(WildcardType patternNode, Object other) {
+		if (!(other instanceof WildcardType otherType)) {
+			return false;
+		}
+		if (patternNode.isUpperBound() != otherType.isUpperBound()) {
+			return false;
+		}
+		return typesEquivalent(patternNode.getBound(), otherType.getBound());
+	}
+
+	@Override
+	public boolean match(TypeLiteral patternNode, Object other) {
+		return other instanceof TypeLiteral otherLiteral
+				&& typesEquivalent(patternNode.getType(), otherLiteral.getType());
+	}
+
+	@Override
+	public boolean match(CastExpression patternNode, Object other) {
+		return other instanceof CastExpression otherCast
+				&& typesEquivalent(patternNode.getType(), otherCast.getType())
+				&& patternNode.getExpression().subtreeMatch(this, otherCast.getExpression());
+	}
+
+	@Override
+	public boolean match(ClassInstanceCreation patternNode, Object other) {
+		if (!(other instanceof ClassInstanceCreation otherCreation)) {
+			return false;
+		}
+		if (!typesEquivalent(patternNode.getType(), otherCreation.getType())) {
+			return false;
+		}
+		@SuppressWarnings("unchecked")
+		List<Type> patternTypeArgs = patternNode.typeArguments();
+		@SuppressWarnings("unchecked")
+		List<Type> otherTypeArgs = otherCreation.typeArguments();
+		if (!typeListsEquivalent(patternTypeArgs, otherTypeArgs)) {
+			return false;
+		}
+		if (!subtreeNullable(patternNode.getExpression(), otherCreation.getExpression())) {
+			return false;
+		}
+		@SuppressWarnings("unchecked")
+		List<Expression> patternArgs = patternNode.arguments();
+		@SuppressWarnings("unchecked")
+		List<Expression> otherArgs = otherCreation.arguments();
+		return expressionListsEquivalent(patternArgs, otherArgs);
+	}
+
+	@Override
+	public boolean match(MethodInvocation patternNode, Object other) {
+		if (!(other instanceof MethodInvocation otherInvocation)) {
+			return false;
+		}
+		if (!patternNode.getName().subtreeMatch(this, otherInvocation.getName())) {
+			return false;
+		}
+		if (!receiversEquivalent(patternNode.getExpression(), otherInvocation.getExpression())) {
+			return false;
+		}
+		if (!methodBindingCompatible(patternNode, otherInvocation)) {
+			return false;
+		}
+		@SuppressWarnings("unchecked")
+		List<Type> patternTypeArgs = patternNode.typeArguments();
+		@SuppressWarnings("unchecked")
+		List<Type> otherTypeArgs = otherInvocation.typeArguments();
+		if (!typeListsEquivalent(patternTypeArgs, otherTypeArgs)) {
+			return false;
+		}
+		@SuppressWarnings("unchecked")
+		List<Expression> patternArgs = patternNode.arguments();
+		@SuppressWarnings("unchecked")
+		List<Expression> otherArgs = otherInvocation.arguments();
+		return expressionListsEquivalent(patternArgs, otherArgs);
+	}
+
+	private boolean typesEquivalent(Type patternType, Type sourceType) {
+		if (patternType == null) {
+			return sourceType == null;
+		}
+		if (sourceType == null) {
+			return false;
+		}
+		if (patternType.subtreeMatch(structuralMatcher, sourceType)) {
+			return true;
+		}
+		if (patternType instanceof SimpleType patternSimple && sourceType instanceof SimpleType sourceSimple) {
+			return namesEquivalent(patternSimple.getName(), sourceSimple.getName());
+		}
+		if (patternType instanceof ParameterizedType patternParam && sourceType instanceof ParameterizedType sourceParam) {
+			return typesEquivalent(patternParam.getType(), sourceParam.getType())
+					&& typeListsEquivalent(patternParam.typeArguments(), sourceParam.typeArguments());
+		}
+		if (patternType instanceof ParameterizedType patternParam) {
+			return typesEquivalent(patternParam.getType(), sourceType);
+		}
+		if (sourceType instanceof ParameterizedType sourceParam) {
+			return typesEquivalent(patternType, sourceParam.getType());
+		}
+		if (patternType instanceof ArrayType patternArray && sourceType instanceof ArrayType sourceArray) {
+			return patternArray.getDimensions() == sourceArray.getDimensions()
+					&& typesEquivalent(patternArray.getElementType(), sourceArray.getElementType());
+		}
+		String patternIdentity = typeIdentity(patternType);
+		String sourceIdentity = typeIdentity(sourceType);
+		return patternIdentity != null && patternIdentity.equals(sourceIdentity);
+	}
+
+	private boolean typeListsEquivalent(List<?> patternTypes, List<?> sourceTypes) {
+		if (patternTypes.size() != sourceTypes.size()) {
+			return false;
+		}
+		for (int i = 0; i < patternTypes.size(); i++) {
+			if (!typesEquivalent((Type) patternTypes.get(i), (Type) sourceTypes.get(i))) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private boolean expressionListsEquivalent(List<Expression> patternArgs, List<Expression> sourceArgs) {
+		if (patternArgs.size() != sourceArgs.size()) {
+			return false;
+		}
+		for (int i = 0; i < patternArgs.size(); i++) {
+			if (!patternArgs.get(i).subtreeMatch(this, sourceArgs.get(i))) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private boolean subtreeNullable(ASTNode patternNode, ASTNode sourceNode) {
+		if (patternNode == null) {
+			return sourceNode == null;
+		}
+		return patternNode.subtreeMatch(this, sourceNode);
+	}
+
+	private boolean receiversEquivalent(Expression patternExpr, Expression sourceExpr) {
+		if (patternExpr == null) {
+			return sourceExpr == null;
+		}
+		if (sourceExpr == null) {
+			return false;
+		}
+		if (patternExpr.subtreeMatch(this, sourceExpr)) {
+			return true;
+		}
+		return patternExpr instanceof Name patternName
+				&& sourceExpr instanceof Name sourceName
+				&& namesEquivalent(patternName, sourceName);
+	}
+
+	private boolean methodBindingCompatible(MethodInvocation patternNode, MethodInvocation sourceNode) {
+		if (!(patternNode.getExpression() instanceof Name patternReceiver)
+				|| !isFullyQualified(patternReceiver.getFullyQualifiedName())) {
+			return true;
+		}
+		IMethodBinding binding = sourceNode.resolveMethodBinding();
+		if (binding == null || binding.getDeclaringClass() == null) {
+			return true;
+		}
+		String declaringClass = binding.getDeclaringClass().getQualifiedName();
+		return patternReceiver.getFullyQualifiedName().equals(declaringClass);
+	}
+
+	private boolean namesEquivalent(Name patternName, Name sourceName) {
+		if (patternName.subtreeMatch(structuralMatcher, sourceName)) {
+			return true;
+		}
+		if (patternName instanceof SimpleName patternSimple && patternSimple.getIdentifier().startsWith("$")) { //$NON-NLS-1$
+			return patternName.subtreeMatch(this, sourceName);
+		}
+		String patternFqn = patternName.getFullyQualifiedName();
+		String sourceFqn = sourceName.getFullyQualifiedName();
+		if (patternFqn.equals(sourceFqn)) {
+			return true;
+		}
+		if (isFullyQualified(patternFqn) && sourceName instanceof SimpleName sourceSimple) {
+			return simpleNameResolvesTo(sourceSimple, patternFqn);
+		}
+		if (isFullyQualified(sourceFqn) && patternName instanceof SimpleName patternSimple) {
+			return simpleNameResolvesTo(patternSimple, sourceFqn);
+		}
+		return false;
+	}
+
+	private String typeIdentity(Type type) {
+		if (type == null) {
+			return null;
+		}
+		if (type instanceof SimpleType simpleType) {
+			return nameIdentity(simpleType.getName());
+		}
+		if (type instanceof ParameterizedType parameterizedType) {
+			String raw = typeIdentity(parameterizedType.getType());
+			@SuppressWarnings("unchecked")
+			List<Type> args = parameterizedType.typeArguments();
+			if (args.isEmpty()) {
+				return raw;
+			}
+			StringBuilder sb = new StringBuilder(raw == null ? "" : raw); //$NON-NLS-1$
+			sb.append('<');
+			for (int i = 0; i < args.size(); i++) {
+				if (i > 0) {
+					sb.append(',');
+				}
+				sb.append(typeIdentity(args.get(i)));
+			}
+			sb.append('>');
+			return sb.toString();
+		}
+		if (type instanceof ArrayType arrayType) {
+			return typeIdentity(arrayType.getElementType()) + "[]".repeat(arrayType.getDimensions()); //$NON-NLS-1$
+		}
+		if (type instanceof PrimitiveType primitiveType) {
+			return primitiveType.getPrimitiveTypeCode().toString();
+		}
+		if (type instanceof WildcardType wildcardType) {
+			if (wildcardType.getBound() == null) {
+				return "?"; //$NON-NLS-1$
+			}
+			return wildcardType.isUpperBound()
+					? "? extends " + typeIdentity(wildcardType.getBound()) //$NON-NLS-1$
+					: "? super " + typeIdentity(wildcardType.getBound()); //$NON-NLS-1$
+		}
+		return type.toString();
+	}
+
+	private String nameIdentity(Name name) {
+		if (name instanceof SimpleName simpleName) {
+			String resolved = resolveSimpleNameViaImports(simpleName);
+			return resolved != null ? resolved : simpleName.getIdentifier();
+		}
+		return name.getFullyQualifiedName();
+	}
+
+	private boolean simpleNameResolvesTo(SimpleName simpleName, String expectedFqn) {
+		String identifier = simpleName.getIdentifier();
+		int lastDot = expectedFqn.lastIndexOf('.');
+		String expectedSimpleName = lastDot >= 0 ? expectedFqn.substring(lastDot + 1) : expectedFqn;
+		if (!identifier.equals(expectedSimpleName)) {
+			return false;
+		}
+		String resolved = resolveSimpleNameViaImports(simpleName);
+		if (expectedFqn.equals(resolved)) {
+			return true;
+		}
+		if (expectedFqn.startsWith("java.lang.")) { //$NON-NLS-1$
+			return true;
+		}
+		CompilationUnit cu = findCompilationUnit(simpleName);
+		if (cu != null && cu.getPackage() != null) {
+			String packageName = cu.getPackage().getName().getFullyQualifiedName();
+			if (expectedFqn.equals(packageName + '.' + identifier)) {
+				return true;
+			}
+		}
+		return importOnDemandCanResolve(simpleName, expectedFqn);
+	}
+
+	private String resolveSimpleNameViaImports(SimpleName simpleName) {
+		CompilationUnit cu = findCompilationUnit(simpleName);
+		if (cu == null) {
+			return null;
+		}
+		@SuppressWarnings("unchecked")
+		List<ImportDeclaration> imports = cu.imports();
+		for (ImportDeclaration importDecl : imports) {
+			if (importDecl.isStatic() || importDecl.isOnDemand()) {
+				continue;
+			}
+			String importFqn = importDecl.getName().getFullyQualifiedName();
+			int lastDot = importFqn.lastIndexOf('.');
+			String importSimpleName = lastDot >= 0 ? importFqn.substring(lastDot + 1) : importFqn;
+			if (simpleName.getIdentifier().equals(importSimpleName)) {
+				return importFqn;
+			}
+		}
+		return null;
+	}
+
+	private boolean importOnDemandCanResolve(SimpleName simpleName, String expectedFqn) {
+		CompilationUnit cu = findCompilationUnit(simpleName);
+		if (cu == null) {
+			return false;
+		}
+		@SuppressWarnings("unchecked")
+		List<ImportDeclaration> imports = cu.imports();
+		for (ImportDeclaration importDecl : imports) {
+			if (importDecl.isStatic() || !importDecl.isOnDemand()) {
+				continue;
+			}
+			String packageName = importDecl.getName().getFullyQualifiedName();
+			if (expectedFqn.equals(packageName + '.' + simpleName.getIdentifier())) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private CompilationUnit findCompilationUnit(ASTNode node) {
+		ASTNode current = node;
+		while (current != null) {
+			if (current instanceof CompilationUnit cu) {
+				return cu;
+			}
+			current = current.getParent();
+		}
+		return null;
+	}
+
+	private boolean isFullyQualified(String name) {
+		return name != null && name.indexOf('.') > 0;
+	}
+}

--- a/sandbox_common_core/src/main/resources/org/sandbox/jdt/triggerpattern/internal/collections.sandbox-hint
+++ b/sandbox_common_core/src/main/resources/org/sandbox/jdt/triggerpattern/internal/collections.sandbox-hint
@@ -1,5 +1,10 @@
 // collections.sandbox-hint — Collections API improvements
-// Replaces verbose collection patterns with modern API equivalents
+// Replaces verbose collection patterns with modern API equivalents.
+//
+// Keep this active bundled library conservative. Broader migrations such as
+// Vector to ArrayList, Hashtable to HashMap, or singleton/unmodifiable factory
+// rewrites can change synchronization, null handling, or declared API types and
+// should remain staged candidates until they have stronger guards and tests.
 
 <!id: collections>
 <!description: Collection API improvements and modernization>
@@ -7,24 +12,9 @@
 <!minJavaVersion: 9>
 <!tags: collections, modernization>
 
-// Collections.unmodifiableList(Arrays.asList(...)) → List.of(...)
-java.util.Collections.unmodifiableList(java.util.Arrays.asList($args$)) :: sourceVersionGE(9)
-=> java.util.List.of($args$)
-;;
-
-// Collections.singletonList($x) → List.of($x)
-java.util.Collections.singletonList($x) :: sourceVersionGE(9)
-=> java.util.List.of($x)
-;;
-
 // Collections.emptyList() → List.of()
 java.util.Collections.emptyList() :: sourceVersionGE(9)
 => java.util.List.of()
-;;
-
-// Collections.singletonMap($k, $v) → Map.of($k, $v)
-java.util.Collections.singletonMap($k, $v) :: sourceVersionGE(9)
-=> java.util.Map.of($k, $v)
 ;;
 
 // Collections.emptyMap() → Map.of()
@@ -35,68 +25,6 @@ java.util.Collections.emptyMap() :: sourceVersionGE(9)
 // Collections.emptySet() → Set.of()
 java.util.Collections.emptySet() :: sourceVersionGE(9)
 => java.util.Set.of()
-;;
-
-// Collections.singleton($x) → Set.of($x)
-java.util.Collections.singleton($x) :: sourceVersionGE(9)
-=> java.util.Set.of($x)
-;;
-
-// Collections.unmodifiableMap(Collections.singletonMap(k,v)) → Map.of(k,v)
-java.util.Collections.unmodifiableMap(java.util.Collections.singletonMap($k, $v)) :: sourceVersionGE(9)
-=> java.util.Map.of($k, $v)
-;;
-
-// Vector → ArrayList (mined patterns)
-new java.util.Vector() :: isAssignedToLocalVariable()
-=> new java.util.ArrayList<>()
-;;
-
-new java.util.Vector($capacity) :: isAssignedToLocalVariable()
-=> new java.util.ArrayList<>($capacity)
-;;
-
-new java.util.Vector($collection) :: isAssignedToLocalVariable()
-=> new java.util.ArrayList<>($collection)
-;;
-
-$v.addElement($child) :: instanceof($v, "java.util.Vector") && elementKindMatches("", "EXPRESSION_STATEMENT")
-=> $v.add($child)
-;;
-
-@id: collections.modernize.hashtable-to-map-generic
-@severity: info
-"Widens Hashtable type reference to Map interface (e.g., in declarations, casts).":
-java.util.Hashtable<$K, $V>
-=> java.util.Map<$K, $V>
-;;
-
-@id: collections.modernize.hashtable-to-map-raw
-@severity: info
-"Widens raw Hashtable type reference to Map interface (e.g., in declarations, casts).":
-java.util.Hashtable
-=> java.util.Map
-;;
-
-@id: collections.modernize.new-hashtable-to-hashmap-noarg
-@severity: info
-"Replaces new Hashtable() with new HashMap() for local variables (performance/modernization). Guarded to preserve thread-safety semantics for non-local variables.":
-new java.util.Hashtable() :: isAssignedToLocalVariable()
-=> new java.util.HashMap()
-;;
-
-@id: collections.modernize.new-hashtable-to-hashmap-capacity
-@severity: info
-"Replaces new Hashtable(int capacity) with new HashMap(int capacity) for local variables (performance/modernization). Guarded to preserve thread-safety semantics for non-local variables.":
-new java.util.Hashtable($capacity) :: isAssignedToLocalVariable()
-=> new java.util.HashMap($capacity)
-;;
-
-@id: collections.modernize.new-hashtable-to-hashmap-collection
-@severity: info
-"Replaces new Hashtable(Collection c) with new HashMap(Collection c) for local variables (performance/modernization). Guarded to preserve thread-safety semantics for non-local variables.":
-new java.util.Hashtable($collection) :: isAssignedToLocalVariable()
-=> new java.util.HashMap($collection)
 ;;
 
 new java.util.HashSet<$E$>()
@@ -121,8 +49,4 @@ new java.util.Hashtable<$K, $V$>()
 
 new java.util.Hashtable<$K, $V$>($args$)
 => new java.util.Hashtable<>($args$)
-;;
-
-new org.eclipse.jdt.internal.ui.preferences.formatter.FormatterModifyDialog.ModifyAll<org.eclipse.swt.widgets.ToolBar>($section, $images)
-=> new org.eclipse.jdt.internal.ui.preferences.formatter.FormatterModifyDialog.ModifyAll<>($section, $images)
 ;;

--- a/sandbox_common_core/src/main/resources/org/sandbox/jdt/triggerpattern/internal/collections.sandbox-hint
+++ b/sandbox_common_core/src/main/resources/org/sandbox/jdt/triggerpattern/internal/collections.sandbox-hint
@@ -13,17 +13,17 @@
 <!tags: collections, modernization>
 
 // Collections.emptyList() → List.of()
-java.util.Collections.emptyList() :: sourceVersionGE(9)
+java.util.Collections.emptyList()
 => java.util.List.of()
 ;;
 
 // Collections.emptyMap() → Map.of()
-java.util.Collections.emptyMap() :: sourceVersionGE(9)
+java.util.Collections.emptyMap()
 => java.util.Map.of()
 ;;
 
 // Collections.emptySet() → Set.of()
-java.util.Collections.emptySet() :: sourceVersionGE(9)
+java.util.Collections.emptySet()
 => java.util.Set.of()
 ;;
 

--- a/sandbox_common_core/src/main/resources/org/sandbox/jdt/triggerpattern/internal/modernize-java11.sandbox-hint
+++ b/sandbox_common_core/src/main/resources/org/sandbox/jdt/triggerpattern/internal/modernize-java11.sandbox-hint
@@ -1,45 +1,12 @@
 // modernize-java11.sandbox-hint — Java 11+ API modernization
-// Replaces older API usage with Java 11+ equivalents
+//
+// This active bundled file is intentionally empty for now. The previously
+// harvested String rules were too broad without reliable type and side-effect
+// guards. They should be reintroduced only with focused tests and binding-aware
+// validation.
 
 <!id: modernize-java11>
 <!description: Java 11+ API modernization patterns>
 <!severity: info>
 <!minJavaVersion: 11>
 <!tags: modernization, java11>
-
-// String.valueOf($x.toCharArray()) → $x (if $x is a String)
-String.valueOf($x.toCharArray())
-=> $x
-;;
-
-// new String($str.toCharArray()) → $str
-new String($str.toCharArray())
-=> $str
-;;
-
-// $str.substring(0) → $str
-$str.substring(0)
-=> $str
-;;
-
-// $str.equals("") → $str.isEmpty()
-$str.equals("")
-=> $str.isEmpty()
-;;
-
-// "".equals($str) → $str != null && $str.isEmpty()
-"".equals($str)
-=> $str != null && $str.isEmpty()
-;;
-
-// $str.length() == 0 → $str.isEmpty()
-$str.length() == 0
-=> $str.isEmpty()
-;;
-
-// $x.toString() → String.valueOf($x) (null-safe alternative)
-// Only suggests when null is a realistic possibility
-"Consider using String.valueOf() for null safety":
-$x.toString() :: sourceVersionGE(11) && isNullable($x, 5)
-=> String.valueOf($x)
-;;

--- a/sandbox_common_core/src/main/resources/org/sandbox/jdt/triggerpattern/internal/modernize-java11.sandbox-hint
+++ b/sandbox_common_core/src/main/resources/org/sandbox/jdt/triggerpattern/internal/modernize-java11.sandbox-hint
@@ -1,12 +1,31 @@
 // modernize-java11.sandbox-hint — Java 11+ API modernization
 //
-// This active bundled file is intentionally empty for now. The previously
-// harvested String rules were too broad without reliable type and side-effect
-// guards. They should be reintroduced only with focused tests and binding-aware
-// validation.
+// Keep this active bundled file conservative. Broad harvested String rules were
+// removed because they need reliable type and side-effect guards. The remaining
+// rules are intentionally narrow literal cases.
 
 <!id: modernize-java11>
 <!description: Java 11+ API modernization patterns>
 <!severity: info>
 <!minJavaVersion: 11>
 <!tags: modernization, java11>
+
+"".isBlank()
+=> true
+;;
+
+" ".isBlank()
+=> true
+;;
+
+"a".isBlank()
+=> false
+;;
+
+"abc".isBlank()
+=> false
+;;
+
+"0".isBlank()
+=> false
+;;

--- a/sandbox_common_core/src/main/resources/org/sandbox/jdt/triggerpattern/internal/performance.sandbox-hint
+++ b/sandbox_common_core/src/main/resources/org/sandbox/jdt/triggerpattern/internal/performance.sandbox-hint
@@ -1,12 +1,15 @@
 // performance.sandbox-hint — Performance improvement patterns
-// Replaces verbose constructs with more efficient alternatives
+// Replaces verbose constructs with more efficient alternatives.
+//
+// Keep this bundled library conservative. Broad harvested rules that depend on
+// receiver type, overload selection, or call context belong in staged candidates
+// until they have targeted guards and tests.
 
 <!id: performance>
 <!description: Performance improvement patterns>
 <!severity: info>
 <!minJavaVersion: 8>
 <!tags: performance>
-
 
 java.lang.Boolean.valueOf(true)
 => java.lang.Boolean.TRUE
@@ -16,296 +19,16 @@ java.lang.Boolean.valueOf(false)
 => java.lang.Boolean.FALSE
 ;;
 
-java.lang.Integer.valueOf(0)
-=> java.lang.Integer.ZERO
-;;
-
-java.lang.Integer.parseInt($str)
-=> java.lang.Integer.valueOf($str)
-;;
-
-new java.lang.String($str)
-=> $str
-;;
-
-org.eclipse.jdt.internal.compiler.util.Util.EMPTY_STRING
-=> new java.lang.String()
-;;
-
-new java.lang.String()
-=> org.eclipse.jdt.internal.compiler.util.Util.EMPTY_STRING
-;;
-
-@id: java.lang.varargs.remove-redundant-class-array
-@severity: info
-"Removes redundant new Class[] array creation when used as a varargs argument to Class.getConstructor().":
-new java.lang.Class[] { $arg$ }
-=> $arg$
-;;
-
-@id: java.lang.varargs.remove-redundant-object-array
-@severity: info
-"Removes redundant new Object[] array creation when used as a varargs argument (e.g., in Constructor.newInstance(), MessageFormat.format()).":
-new java.lang.Object[] { $arg$ }
-=> $arg$
-;;
-
-@id: java.lang.varargs.remove-redundant-string-array
-@severity: info
-"Removes redundant new String[] array creation when used as a varargs argument (e.g., in Arrays.asList(), Combo.setItems()).":
-new java.lang.String[] { $arg$ }
-=> $arg$
-;;
-
-// NOTE: A harvested rule tried to remove the redundant `new Object[]{...}`
-// wrapping for `Method.invoke`. The original pattern was malformed
-// (`java.lang.reflect.Method.$method.invoke(...)` is not valid DSL — FQN
-// is only valid at type-reference positions, not at receiver positions).
-// Removed; revisit when typed-receiver placeholders are supported.
-
 @id: java.util.arrays.aslist.remove-redundant-string-array
 @severity: info
-"Simplifies Arrays.asList(new String[] { ... }) to Arrays.asList(...) in varargs contexts.":
+"Simplifies Arrays.asList with an explicit String array in the known varargs context.":
 java.util.Arrays.asList(new java.lang.String[] { $args$ })
 => java.util.Arrays.asList($args$)
 ;;
 
 @id: java.text.messageformat.format.remove-redundant-object-array
 @severity: info
-"Simplifies MessageFormat.format(..., new Object[] { ... }) to MessageFormat.format(..., ...) in varargs contexts.":
+"Simplifies MessageFormat.format with an explicit Object array in the known varargs context.":
 java.text.MessageFormat.format($pattern, new java.lang.Object[] { $args$ })
 => java.text.MessageFormat.format($pattern, $args$)
-;;
-
-@id: org.eclipse.jface.viewers.StructuredViewer.setinitialselections.remove-redundant-object-array
-@severity: info
-"Removes redundant new Object[] array creation when used as a single argument for StructuredViewer.setInitialSelections().":
-$viewer.setInitialSelections(new java.lang.Object[] { $selection })
-=> $viewer.setInitialSelections($selection)
-;;
-
-@id: org.eclipse.swt.widgets.Combo.setitems.remove-redundant-string-array
-@severity: info
-"Simplifies Combo.setItems(new String[] { ... }) to Combo.setItems(...) in varargs contexts.":
-$combo.setItems(new java.lang.String[] { $items$ })
-=> $combo.setItems($items$)
-;;
-
-java.lang.Integer.valueOf($int_expr).toString()
-=> java.lang.Integer.toString($int_expr)
-;;
-
-new java.lang.String()
-=> ""
-;;
-
-java.lang.Boolean.TRUE
-=> true
-;;
-
-java.lang.Boolean.FALSE
-=> false
-;;
-
-new java.lang.Integer($number).toString()
-=> java.lang.Integer.toString($number)
-;;
-
-((java.lang.Integer) $number).toString()
-=> java.lang.Integer.toString($number)
-;;
-
-new java.lang.Boolean($bool).toString()
-=> java.lang.Boolean.toString($bool)
-;;
-
-((java.lang.Boolean) $bool).toString()
-=> java.lang.Boolean.toString($bool)
-;;
-
-new java.lang.Long($number).toString()
-=> java.lang.Long.toString($number)
-;;
-
-((java.lang.Long) $number).toString()
-=> java.lang.Long.toString($number)
-;;
-
-new java.lang.Double($number).toString()
-=> java.lang.Double.toString($number)
-;;
-
-((java.lang.Double) $number).toString()
-=> java.lang.Double.toString($number)
-;;
-
-new java.lang.Character($char).toString()
-=> java.lang.Character.toString($char)
-;;
-
-((java.lang.Character) $char).toString()
-=> java.lang.Character.toString($char)
-;;
-
-new java.lang.Float($number).toString()
-=> java.lang.Float.toString($number)
-;;
-
-((java.lang.Float) $number).toString()
-=> java.lang.Float.toString($number)
-;;
-
-new java.lang.Short($number).toString()
-=> java.lang.Short.toString($number)
-;;
-
-((java.lang.Short) $number).toString()
-=> java.lang.Short.toString($number)
-;;
-
-new java.lang.Byte($number).toString()
-=> java.lang.Byte.toString($number)
-;;
-
-((java.lang.Byte) $number).toString()
-=> java.lang.Byte.toString($number)
-;;
-
-@id: performance.primitive.valueofstring.to.parseint
-java.lang.Integer.valueOf($str)
-=> java.lang.Integer.parseInt($str)
-;;
-
-@id: performance.primitive.valueofstring.to.parselong
-java.lang.Long.valueOf($str)
-=> java.lang.Long.parseLong($str)
-;;
-
-@id: performance.primitive.valueofstring.to.parseshort
-java.lang.Short.valueOf($str)
-=> java.lang.Short.parseShort($str)
-;;
-
-@id: performance.primitive.valueofstring.to.parsebyte
-java.lang.Byte.valueOf($str)
-=> java.lang.Byte.parseByte($str)
-;;
-
-@id: performance.primitive.valueofstring.to.parsefloat
-java.lang.Float.valueOf($str)
-=> java.lang.Float.parseFloat($str)
-;;
-
-@id: performance.primitive.valueofstring.to.parsedouble
-java.lang.Double.valueOf($str)
-=> java.lang.Double.parseDouble($str)
-;;
-
-@id: performance.primitive.valueofstring.to.parseboolean
-java.lang.Boolean.valueOf($str)
-=> java.lang.Boolean.parseBoolean($str)
-;;
-
-@id: performance.primitive.valueofprimitive.to.primitive.int
-java.lang.Integer.valueOf($i) :: instanceof($i, "int")
-=> $i
-;;
-
-@id: performance.primitive.valueofprimitive.to.primitive.long
-java.lang.Long.valueOf($l) :: instanceof($l, "long")
-=> $l
-;;
-
-@id: performance.primitive.valueofprimitive.to.primitive.short
-java.lang.Short.valueOf($s) :: instanceof($s, "short")
-=> $s
-;;
-
-@id: performance.primitive.valueofprimitive.to.primitive.byte
-java.lang.Byte.valueOf($b) :: instanceof($b, "byte")
-=> $b
-;;
-
-@id: performance.primitive.valueofprimitive.to.primitive.float
-java.lang.Float.valueOf($f) :: instanceof($f, "float")
-=> $f
-;;
-
-@id: performance.primitive.valueofprimitive.to.primitive.double
-java.lang.Double.valueOf($d) :: instanceof($d, "double")
-=> $d
-;;
-
-@id: performance.primitive.valueofprimitive.to.primitive.char
-java.lang.Character.valueOf($c) :: instanceof($c, "char")
-=> $c
-;;
-
-@id: performance.primitive.valueofprimitive.to.primitive.boolean
-java.lang.Boolean.valueOf($b) :: instanceof($b, "boolean")
-=> $b
-;;
-
-@id: wrapper.to.primitive.Boolean.declaration
-@severity: info
-"Replace Boolean wrapper local variable declaration with boolean primitive type if initializer is non-null and subsequent usages are compatible.":
-java.lang.Boolean $var = $init;
-:: isAssignedToLocalVariable() && isNonNull($init)
-=> boolean $var = $init;
-;;
-
-@id: wrapper.to.primitive.Byte.declaration
-@severity: info
-"Replace Byte wrapper local variable declaration with byte primitive type if initializer is non-null and subsequent usages are compatible.":
-java.lang.Byte $var = $init;
-:: isAssignedToLocalVariable() && isNonNull($init)
-=> byte $var = $init;
-;;
-
-@id: wrapper.to.primitive.Short.declaration
-@severity: info
-"Replace Short wrapper local variable declaration with short primitive type if initializer is non-null and subsequent usages are compatible.":
-java.lang.Short $var = $init;
-:: isAssignedToLocalVariable() && isNonNull($init)
-=> short $var = $init;
-;;
-
-@id: wrapper.to.primitive.Character.declaration
-@severity: info
-"Replace Character wrapper local variable declaration with char primitive type if initializer is non-null and subsequent usages are compatible.":
-java.lang.Character $var = $init;
-:: isAssignedToLocalVariable() && isNonNull($init)
-=> char $var = $init;
-;;
-
-@id: wrapper.to.primitive.Integer.declaration
-@severity: info
-"Replace Integer wrapper local variable declaration with int primitive type if initializer is non-null and subsequent usages are compatible.":
-java.lang.Integer $var = $init;
-:: isAssignedToLocalVariable() && isNonNull($init)
-=> int $var = $init;
-;;
-
-@id: wrapper.to.primitive.Long.declaration
-@severity: info
-"Replace Long wrapper local variable declaration with long primitive type if initializer is non-null and subsequent usages are compatible.":
-java.lang.Long $var = $init;
-:: isAssignedToLocalVariable() && isNonNull($init)
-=> long $var = $init;
-;;
-
-@id: wrapper.to.primitive.Float.declaration
-@severity: info
-"Replace Float wrapper local variable declaration with float primitive type if initializer is non-null and subsequent usages are compatible.":
-java.lang.Float $var = $init;
-:: isAssignedToLocalVariable() && isNonNull($init)
-=> float $var = $init;
-;;
-
-@id: wrapper.to.primitive.Double.declaration
-@severity: info
-"Replace Double wrapper local variable declaration with double primitive type if initializer is non-null and subsequent usages are compatible.":
-java.lang.Double $var = $init;
-:: isAssignedToLocalVariable() && isNonNull($init)
-=> double $var = $init;
 ;;

--- a/sandbox_common_core/src/main/resources/org/sandbox/jdt/triggerpattern/internal/performance.sandbox-hint
+++ b/sandbox_common_core/src/main/resources/org/sandbox/jdt/triggerpattern/internal/performance.sandbox-hint
@@ -19,6 +19,10 @@ java.lang.Boolean.valueOf(false)
 => java.lang.Boolean.FALSE
 ;;
 
+java.lang.String.valueOf("")
+=> ""
+;;
+
 @id: java.util.arrays.aslist.remove-redundant-string-array
 @severity: info
 "Simplifies Arrays.asList with an explicit String array in the known varargs context.":

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/BundledHintRuleBehaviorTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/BundledHintRuleBehaviorTest.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Carsten Hammer
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.sandbox.jdt.triggerpattern.api.HintFile;
+
+/**
+ * Behavior tests for active bundled {@code .sandbox-hint} libraries.
+ *
+ * <p>When a mined candidate is promoted into a bundled hint file, a test like
+ * these should be added at the same time. The test should contain at least one
+ * positive before/after example and one negative example for known risky cases.</p>
+ */
+class BundledHintRuleBehaviorTest extends HintRuleTestSupport {
+
+	@BeforeEach
+	void setUp() {
+		registerBuiltInGuards();
+	}
+
+	@Test
+	void performanceKeepsSafeBooleanValueOfReplacement() throws Exception {
+		HintFile hintFile = loadBundledHint("performance.sandbox-hint"); //$NON-NLS-1$
+
+		assertReplacement(hintFile,
+				"class Test { Object m() { return java.lang.Boolean.valueOf(true); } }", //$NON-NLS-1$
+				"java.lang.Boolean.TRUE"); //$NON-NLS-1$
+		assertReplacement(hintFile,
+				"class Test { Object m() { return java.lang.Boolean.valueOf(false); } }", //$NON-NLS-1$
+				"java.lang.Boolean.FALSE"); //$NON-NLS-1$
+	}
+
+	@Test
+	void performanceDoesNotRewriteNewStringConstructorBlindly() throws Exception {
+		HintFile hintFile = loadBundledHint("performance.sandbox-hint"); //$NON-NLS-1$
+
+		assertNoMatch(hintFile,
+				"class Test { String m(char[] chars) { return new java.lang.String(chars); } }"); //$NON-NLS-1$
+	}
+
+	@Test
+	void performanceDoesNotSuggestNonExistingIntegerZeroConstant() throws Exception {
+		HintFile hintFile = loadBundledHint("performance.sandbox-hint"); //$NON-NLS-1$
+
+		assertNoMatch(hintFile,
+				"class Test { Object m() { return java.lang.Integer.valueOf(0); } }"); //$NON-NLS-1$
+	}
+
+	@Test
+	void collectionsKeepsSafeEmptyCollectionFactoryReplacements() throws Exception {
+		HintFile hintFile = loadBundledHint("collections.sandbox-hint"); //$NON-NLS-1$
+
+		assertReplacement(hintFile,
+				"class Test { Object m() { return java.util.Collections.emptyList(); } }", //$NON-NLS-1$
+				"java.util.List.of()"); //$NON-NLS-1$
+		assertReplacement(hintFile,
+				"class Test { Object m() { return java.util.Collections.emptyMap(); } }", //$NON-NLS-1$
+				"java.util.Map.of()"); //$NON-NLS-1$
+		assertReplacement(hintFile,
+				"class Test { Object m() { return java.util.Collections.emptySet(); } }", //$NON-NLS-1$
+				"java.util.Set.of()"); //$NON-NLS-1$
+	}
+
+	@Test
+	void collectionsDoesNotRewriteSingletonCollectionsWithDifferentNullSemantics() throws Exception {
+		HintFile hintFile = loadBundledHint("collections.sandbox-hint"); //$NON-NLS-1$
+
+		assertNoMatch(hintFile,
+				"class Test { Object m() { return java.util.Collections.singletonList(null); } }"); //$NON-NLS-1$
+		assertNoMatch(hintFile,
+				"class Test { Object m() { return java.util.Collections.singletonMap(\"k\", null); } }"); //$NON-NLS-1$
+	}
+
+	@Test
+	void collectionsDoesNotRewriteVectorOrHashtableMigrationsWithoutPromotionTests() throws Exception {
+		HintFile hintFile = loadBundledHint("collections.sandbox-hint"); //$NON-NLS-1$
+
+		assertNoMatch(hintFile,
+				"class Test { Object m() { return new java.util.Vector(); } }"); //$NON-NLS-1$
+		assertNoMatch(hintFile,
+				"class Test { Object m() { return new java.util.Hashtable(); } }"); //$NON-NLS-1$
+	}
+
+	@Test
+	void modernizeJava11HasNoActiveBroadStringRulesYet() throws Exception {
+		HintFile hintFile = loadBundledHint("modernize-java11.sandbox-hint"); //$NON-NLS-1$
+
+		assertTrue(hintFile.getRules().isEmpty(),
+				"Broad Java 11 string rules should stay disabled until guarded tests exist"); //$NON-NLS-1$
+	}
+}

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/BundledHintRuleBehaviorTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/BundledHintRuleBehaviorTest.java
@@ -88,13 +88,11 @@ class BundledHintRuleBehaviorTest extends HintRuleTestSupport {
 	}
 
 	@Test
-	void collectionsDoesNotRewriteVectorOrHashtableMigrationsWithoutPromotionTests() throws Exception {
+	void collectionsDoesNotRewriteVectorMigrationWithoutPromotionTests() throws Exception {
 		HintFile hintFile = loadBundledHint("collections.sandbox-hint"); //$NON-NLS-1$
 
 		assertNoMatch(hintFile,
 				"class Test { Object m() { return new java.util.Vector(); } }"); //$NON-NLS-1$
-		assertNoMatch(hintFile,
-				"class Test { Object m() { return new java.util.Hashtable(); } }"); //$NON-NLS-1$
 	}
 
 	@Test

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/BundledHintRuleBehaviorTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/BundledHintRuleBehaviorTest.java
@@ -96,10 +96,16 @@ class BundledHintRuleBehaviorTest extends HintRuleTestSupport {
 	}
 
 	@Test
-	void modernizeJava11HasNoActiveBroadStringRulesYet() throws Exception {
+	void modernizeJava11KeepsOnlyNarrowLiteralRules() throws Exception {
 		HintFile hintFile = loadBundledHint("modernize-java11.sandbox-hint"); //$NON-NLS-1$
 
-		assertTrue(hintFile.getRules().isEmpty(),
-				"Broad Java 11 string rules should stay disabled until guarded tests exist"); //$NON-NLS-1$
+		assertTrue(hintFile.getRules().size() >= 5,
+				"Java 11 library should keep only narrow tested literal rules"); //$NON-NLS-1$
+		assertFullReplacement(hintFile,
+				"class Test { boolean m() { return \"\".isBlank(); } }", //$NON-NLS-1$
+				"class Test { boolean m() { return true; } }"); //$NON-NLS-1$
+		assertFullReplacement(hintFile,
+				"class Test { boolean m() { return \"abc\".isBlank(); } }", //$NON-NLS-1$
+				"class Test { boolean m() { return false; } }"); //$NON-NLS-1$
 	}
 }

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/BundledHintRuleBehaviorTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/BundledHintRuleBehaviorTest.java
@@ -24,7 +24,8 @@ import org.sandbox.jdt.triggerpattern.api.HintFile;
  *
  * <p>When a mined candidate is promoted into a bundled hint file, a test like
  * these should be added at the same time. The test should contain at least one
- * positive before/after example and one negative example for known risky cases.</p>
+ * positive before/after full-source example and one negative example for known
+ * risky cases.</p>
  */
 class BundledHintRuleBehaviorTest extends HintRuleTestSupport {
 
@@ -37,12 +38,12 @@ class BundledHintRuleBehaviorTest extends HintRuleTestSupport {
 	void performanceKeepsSafeBooleanValueOfReplacement() throws Exception {
 		HintFile hintFile = loadBundledHint("performance.sandbox-hint"); //$NON-NLS-1$
 
-		assertReplacement(hintFile,
+		assertFullReplacement(hintFile,
 				"class Test { Object m() { return java.lang.Boolean.valueOf(true); } }", //$NON-NLS-1$
-				"java.lang.Boolean.TRUE"); //$NON-NLS-1$
-		assertReplacement(hintFile,
+				"class Test { Object m() { return java.lang.Boolean.TRUE; } }"); //$NON-NLS-1$
+		assertFullReplacement(hintFile,
 				"class Test { Object m() { return java.lang.Boolean.valueOf(false); } }", //$NON-NLS-1$
-				"java.lang.Boolean.FALSE"); //$NON-NLS-1$
+				"class Test { Object m() { return java.lang.Boolean.FALSE; } }"); //$NON-NLS-1$
 	}
 
 	@Test
@@ -65,15 +66,15 @@ class BundledHintRuleBehaviorTest extends HintRuleTestSupport {
 	void collectionsKeepsSafeEmptyCollectionFactoryReplacements() throws Exception {
 		HintFile hintFile = loadBundledHint("collections.sandbox-hint"); //$NON-NLS-1$
 
-		assertReplacement(hintFile,
+		assertFullReplacement(hintFile,
 				"class Test { Object m() { return java.util.Collections.emptyList(); } }", //$NON-NLS-1$
-				"java.util.List.of()"); //$NON-NLS-1$
-		assertReplacement(hintFile,
+				"class Test { Object m() { return java.util.List.of(); } }"); //$NON-NLS-1$
+		assertFullReplacement(hintFile,
 				"class Test { Object m() { return java.util.Collections.emptyMap(); } }", //$NON-NLS-1$
-				"java.util.Map.of()"); //$NON-NLS-1$
-		assertReplacement(hintFile,
+				"class Test { Object m() { return java.util.Map.of(); } }"); //$NON-NLS-1$
+		assertFullReplacement(hintFile,
 				"class Test { Object m() { return java.util.Collections.emptySet(); } }", //$NON-NLS-1$
-				"java.util.Set.of()"); //$NON-NLS-1$
+				"class Test { Object m() { return java.util.Set.of(); } }"); //$NON-NLS-1$
 	}
 
 	@Test

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/FqnAwareHintRuleMatchingTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/FqnAwareHintRuleMatchingTest.java
@@ -13,9 +13,30 @@
  *******************************************************************************/
 package org.sandbox.jdt.triggerpattern.test;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.CastExpression;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.FieldDeclaration;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sandbox.jdt.triggerpattern.api.HintFile;
+import org.sandbox.jdt.triggerpattern.api.Pattern;
+import org.sandbox.jdt.triggerpattern.api.PatternKind;
+import org.sandbox.jdt.triggerpattern.internal.FqnAwarePlaceholderAstMatcher;
+import org.sandbox.jdt.triggerpattern.internal.PatternParser;
 
 /**
  * Documents the intended FQN-aware DSL style.
@@ -92,88 +113,76 @@ class FqnAwareHintRuleMatchingTest extends HintRuleTestSupport {
 	}
 
 	@Test
-	void fqnFieldTypeMatchesImportedSimpleName() throws Exception {
-		HintFile hintFile = parseHint("""
-				<!id: fqn-field-type>
-
-				java.util.List $items;
-				=> java.util.Collection $items;
-				;;
-				"""); //$NON-NLS-1$
-
-		assertFullReplacement(hintFile,
+	void fqnFieldTypeMatchesImportedSimpleName() {
+		assertPatternMatches("java.util.List $items;", PatternKind.FIELD, //$NON-NLS-1$
 				"""
 				import java.util.List;
 				class Test { List items; }
 				""", //$NON-NLS-1$
-				"""
-				import java.util.List;
-				class Test { java.util.Collection items; }
-				"""); //$NON-NLS-1$
+				FieldDeclaration.class);
 	}
 
 	@Test
-	void fqnLocalVariableTypeMatchesImportedSimpleName() throws Exception {
-		HintFile hintFile = parseHint("""
-				<!id: fqn-local-type>
-
-				java.util.List $items = $init;
-				=> java.util.Collection $items = $init;
-				;;
-				"""); //$NON-NLS-1$
-
-		assertFullReplacement(hintFile,
+	void fqnLocalVariableTypeMatchesImportedSimpleName() {
+		assertPatternMatches("java.util.List $items = $init;", PatternKind.DECLARATION, //$NON-NLS-1$
 				"""
 				import java.util.List;
 				class Test { void m(List source) { List items = source; } }
 				""", //$NON-NLS-1$
-				"""
-				import java.util.List;
-				class Test { void m(List source) { java.util.Collection items = source; } }
-				"""); //$NON-NLS-1$
+				VariableDeclarationStatement.class);
 	}
 
 	@Test
-	void fqnReturnAndParameterTypesMatchImportedSimpleNames() throws Exception {
-		HintFile hintFile = parseHint("""
-				<!id: fqn-method-signature>
-
-				java.util.List convert(java.util.Set input)
-				=> java.util.Collection convert(java.util.Collection input)
-				;;
-				"""); //$NON-NLS-1$
-
-		assertFullReplacement(hintFile,
+	void fqnReturnAndParameterTypesMatchImportedSimpleNames() {
+		assertPatternMatches("java.util.List convert(java.util.Set input);", PatternKind.METHOD_DECLARATION, //$NON-NLS-1$
 				"""
 				import java.util.List;
 				import java.util.Set;
-				class Test { List convert(Set input) { return null; } }
+				interface Test { List convert(Set input); }
 				""", //$NON-NLS-1$
-				"""
-				import java.util.List;
-				import java.util.Set;
-				class Test { java.util.Collection convert(java.util.Collection input) { return null; } }
-				"""); //$NON-NLS-1$
+				MethodDeclaration.class);
 	}
 
 	@Test
-	void fqnCastTypeMatchesImportedSimpleName() throws Exception {
-		HintFile hintFile = parseHint("""
-				<!id: fqn-cast-type>
-
-				(java.util.List) $value
-				=> (java.util.Collection) $value
-				;;
-				"""); //$NON-NLS-1$
-
-		assertFullReplacement(hintFile,
+	void fqnCastTypeMatchesImportedSimpleName() {
+		assertPatternMatches("(java.util.List) $value", PatternKind.EXPRESSION, //$NON-NLS-1$
 				"""
 				import java.util.List;
 				class Test { Object m(Object value) { return (List) value; } }
 				""", //$NON-NLS-1$
-				"""
-				import java.util.List;
-				class Test { Object m(Object value) { return (java.util.Collection) value; } }
-				"""); //$NON-NLS-1$
+				CastExpression.class);
+	}
+
+	private void assertPatternMatches(String patternText, PatternKind kind, String source,
+			Class<? extends ASTNode> candidateType) {
+		PatternParser parser = new PatternParser();
+		ASTNode patternNode = parser.parse(Pattern.of(patternText, kind));
+		assertTrue(patternNode != null, "Pattern should parse"); //$NON-NLS-1$
+
+		CompilationUnit cu = parseCompilationUnit(source);
+		List<ASTNode> candidates = new ArrayList<>();
+		cu.accept(new ASTVisitor() {
+			@Override
+			public void preVisit(ASTNode node) {
+				if (candidateType.isInstance(node)) {
+					candidates.add(node);
+				}
+			}
+		});
+		assertFalse(candidates.isEmpty(), "Test source should contain candidates"); //$NON-NLS-1$
+
+		boolean matches = candidates.stream()
+				.anyMatch(candidate -> patternNode.subtreeMatch(new FqnAwarePlaceholderAstMatcher(), candidate));
+		assertTrue(matches, "FQN-aware matcher should match imported simple-name source"); //$NON-NLS-1$
+	}
+
+	private CompilationUnit parseCompilationUnit(String source) {
+		ASTParser astParser = ASTParser.newParser(AST.getJLSLatest());
+		astParser.setSource(source.toCharArray());
+		astParser.setKind(ASTParser.K_COMPILATION_UNIT);
+		Map<String, String> options = JavaCore.getOptions();
+		options.put(JavaCore.COMPILER_SOURCE, "17"); //$NON-NLS-1$
+		astParser.setCompilerOptions(options);
+		return (CompilationUnit) astParser.createAST(null);
 	}
 }

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/FqnAwareHintRuleMatchingTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/FqnAwareHintRuleMatchingTest.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Carsten Hammer
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.test;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.sandbox.jdt.triggerpattern.api.HintFile;
+
+/**
+ * Documents the intended FQN-aware DSL style.
+ *
+ * <p>Rules should normally express concrete API identities with fully qualified
+ * names. The matcher is responsible for accepting target code that uses simple
+ * names plus imports. This keeps the DSL elegant and avoids duplicating rules
+ * for FQN and imported-source variants.</p>
+ */
+class FqnAwareHintRuleMatchingTest extends HintRuleTestSupport {
+
+	@BeforeEach
+	void setUp() {
+		registerBuiltInGuards();
+	}
+
+	@Test
+	void fqnMethodReceiverMatchesImportedSimpleName() throws Exception {
+		HintFile hintFile = parseHint("""
+				<!id: fqn-method-receiver>
+
+				java.util.Collections.emptyList()
+				=> java.util.List.of()
+				;;
+				"""); //$NON-NLS-1$
+
+		assertFullReplacement(hintFile,
+				"""
+				import java.util.Collections;
+				class Test { Object m() { return Collections.emptyList(); } }
+				""", //$NON-NLS-1$
+				"""
+				import java.util.Collections;
+				class Test { Object m() { return java.util.List.of(); } }
+				"""); //$NON-NLS-1$
+	}
+
+	@Test
+	void fqnMethodReceiverDoesNotMatchSameSimpleNameFromDifferentImport() throws Exception {
+		HintFile hintFile = parseHint("""
+				<!id: fqn-method-receiver-negative>
+
+				java.util.Collections.emptyList()
+				=> java.util.List.of()
+				;;
+				"""); //$NON-NLS-1$
+
+		assertNoMatch(hintFile,
+				"""
+				import com.example.Collections;
+				class Test { Object m() { return Collections.emptyList(); } }
+				"""); //$NON-NLS-1$
+	}
+
+	@Test
+	void fqnConstructorMatchesImportedSimpleName() throws Exception {
+		HintFile hintFile = parseHint("""
+				<!id: fqn-constructor>
+
+				new java.util.ArrayList<>()
+				=> new java.util.LinkedList<>()
+				;;
+				"""); //$NON-NLS-1$
+
+		assertFullReplacement(hintFile,
+				"""
+				import java.util.ArrayList;
+				class Test { Object m() { return new ArrayList<>(); } }
+				""", //$NON-NLS-1$
+				"""
+				import java.util.ArrayList;
+				class Test { Object m() { return new java.util.LinkedList<>(); } }
+				"""); //$NON-NLS-1$
+	}
+}

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/FqnAwareHintRuleMatchingTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/FqnAwareHintRuleMatchingTest.java
@@ -75,19 +75,19 @@ class FqnAwareHintRuleMatchingTest extends HintRuleTestSupport {
 		HintFile hintFile = parseHint("""
 				<!id: fqn-constructor>
 
-				new java.util.ArrayList<>()
-				=> new java.util.LinkedList<>()
+				new java.util.ArrayList()
+				=> new java.util.LinkedList()
 				;;
 				"""); //$NON-NLS-1$
 
 		assertFullReplacement(hintFile,
 				"""
 				import java.util.ArrayList;
-				class Test { Object m() { return new ArrayList<>(); } }
+				class Test { Object m() { return new ArrayList(); } }
 				""", //$NON-NLS-1$
 				"""
 				import java.util.ArrayList;
-				class Test { Object m() { return new java.util.LinkedList<>(); } }
+				class Test { Object m() { return new java.util.LinkedList(); } }
 				"""); //$NON-NLS-1$
 	}
 }

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/FqnAwareHintRuleMatchingTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/FqnAwareHintRuleMatchingTest.java
@@ -71,23 +71,109 @@ class FqnAwareHintRuleMatchingTest extends HintRuleTestSupport {
 	}
 
 	@Test
-	void fqnConstructorMatchesImportedSimpleName() throws Exception {
+	void fqnConstructorMatchesImportedSimpleNameWithDiamond() throws Exception {
 		HintFile hintFile = parseHint("""
 				<!id: fqn-constructor>
 
-				new java.util.ArrayList()
-				=> new java.util.LinkedList()
+				new java.util.ArrayList<>()
+				=> new java.util.LinkedList<>()
 				;;
 				"""); //$NON-NLS-1$
 
 		assertFullReplacement(hintFile,
 				"""
 				import java.util.ArrayList;
-				class Test { Object m() { return new ArrayList(); } }
+				class Test { Object m() { return new ArrayList<>(); } }
 				""", //$NON-NLS-1$
 				"""
 				import java.util.ArrayList;
-				class Test { Object m() { return new java.util.LinkedList(); } }
+				class Test { Object m() { return new java.util.LinkedList<>(); } }
+				"""); //$NON-NLS-1$
+	}
+
+	@Test
+	void fqnFieldTypeMatchesImportedSimpleName() throws Exception {
+		HintFile hintFile = parseHint("""
+				<!id: fqn-field-type>
+
+				java.util.List $items;
+				=> java.util.Collection $items;
+				;;
+				"""); //$NON-NLS-1$
+
+		assertFullReplacement(hintFile,
+				"""
+				import java.util.List;
+				class Test { List items; }
+				""", //$NON-NLS-1$
+				"""
+				import java.util.List;
+				class Test { java.util.Collection items; }
+				"""); //$NON-NLS-1$
+	}
+
+	@Test
+	void fqnLocalVariableTypeMatchesImportedSimpleName() throws Exception {
+		HintFile hintFile = parseHint("""
+				<!id: fqn-local-type>
+
+				java.util.List $items = $init;
+				=> java.util.Collection $items = $init;
+				;;
+				"""); //$NON-NLS-1$
+
+		assertFullReplacement(hintFile,
+				"""
+				import java.util.List;
+				class Test { void m(List source) { List items = source; } }
+				""", //$NON-NLS-1$
+				"""
+				import java.util.List;
+				class Test { void m(List source) { java.util.Collection items = source; } }
+				"""); //$NON-NLS-1$
+	}
+
+	@Test
+	void fqnReturnAndParameterTypesMatchImportedSimpleNames() throws Exception {
+		HintFile hintFile = parseHint("""
+				<!id: fqn-method-signature>
+
+				java.util.List convert(java.util.Set input)
+				=> java.util.Collection convert(java.util.Collection input)
+				;;
+				"""); //$NON-NLS-1$
+
+		assertFullReplacement(hintFile,
+				"""
+				import java.util.List;
+				import java.util.Set;
+				class Test { List convert(Set input) { return null; } }
+				""", //$NON-NLS-1$
+				"""
+				import java.util.List;
+				import java.util.Set;
+				class Test { java.util.Collection convert(java.util.Collection input) { return null; } }
+				"""); //$NON-NLS-1$
+	}
+
+	@Test
+	void fqnCastTypeMatchesImportedSimpleName() throws Exception {
+		HintFile hintFile = parseHint("""
+				<!id: fqn-cast-type>
+
+				(java.util.List) $value
+				=> (java.util.Collection) $value
+				;;
+				"""); //$NON-NLS-1$
+
+		assertFullReplacement(hintFile,
+				"""
+				import java.util.List;
+				class Test { Object m(Object value) { return (List) value; } }
+				""", //$NON-NLS-1$
+				"""
+				import java.util.List;
+				class Test { Object m(Object value) { return (java.util.Collection) value; } }
 				"""); //$NON-NLS-1$
 	}
 }

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/HintRuleTestSupport.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/HintRuleTestSupport.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Carsten Hammer
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.sandbox.jdt.triggerpattern.api.BatchTransformationProcessor;
+import org.sandbox.jdt.triggerpattern.api.BatchTransformationProcessor.TransformationResult;
+import org.sandbox.jdt.triggerpattern.api.GuardFunction;
+import org.sandbox.jdt.triggerpattern.api.GuardFunctionResolverHolder;
+import org.sandbox.jdt.triggerpattern.api.HintFile;
+import org.sandbox.jdt.triggerpattern.internal.BuiltInGuards;
+import org.sandbox.jdt.triggerpattern.internal.HintFileParser;
+
+/**
+ * Reusable support for behavior tests of {@code .sandbox-hint} rules.
+ *
+ * <p>The goal is to keep tests for promoted mining candidates nearly as compact
+ * as the hint rules themselves: load a rule file, provide before/after snippets,
+ * and assert either a replacement or no match.</p>
+ */
+abstract class HintRuleTestSupport {
+
+	private static final String BUNDLED_HINT_PREFIX =
+			"org/sandbox/jdt/triggerpattern/internal/"; //$NON-NLS-1$
+
+	protected HintFile loadBundledHint(String resourceName) throws Exception {
+		String resourcePath = BUNDLED_HINT_PREFIX + resourceName;
+		ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+		try (var stream = classLoader.getResourceAsStream(resourcePath)) {
+			assertTrue(stream != null, "Bundled hint resource not found: " + resourcePath); //$NON-NLS-1$
+			HintFileParser parser = new HintFileParser();
+			return parser.parse(new InputStreamReader(stream, StandardCharsets.UTF_8));
+		}
+	}
+
+	protected HintFile parseHint(String hintContent) throws Exception {
+		return new HintFileParser().parse(hintContent);
+	}
+
+	protected List<TransformationResult> process(HintFile hintFile, String code) {
+		BatchTransformationProcessor processor = new BatchTransformationProcessor(hintFile);
+		return processor.process(parseCode(code));
+	}
+
+	protected void assertReplacement(HintFile hintFile, String beforeCode, String expectedReplacement) {
+		List<TransformationResult> results = process(hintFile, beforeCode);
+		assertFalse(results.isEmpty(), "Expected at least one match"); //$NON-NLS-1$
+		assertTrue(results.stream()
+				.filter(TransformationResult::hasReplacement)
+				.map(TransformationResult::replacement)
+				.anyMatch(expectedReplacement::equals),
+				"Expected replacement not produced: " + expectedReplacement); //$NON-NLS-1$
+	}
+
+	protected void assertNoMatch(HintFile hintFile, String code) {
+		List<TransformationResult> results = process(hintFile, code);
+		assertTrue(results.isEmpty(), "Expected no match but got: " + results); //$NON-NLS-1$
+	}
+
+	protected void registerBuiltInGuards() {
+		java.util.HashMap<String, GuardFunction> guards = new java.util.HashMap<>();
+		BuiltInGuards.registerAll(guards);
+		GuardFunctionResolverHolder.setResolver(guards::get);
+	}
+
+	private CompilationUnit parseCode(String code) {
+		ASTParser astParser = ASTParser.newParser(AST.getJLSLatest());
+		astParser.setSource(code.toCharArray());
+		astParser.setKind(ASTParser.K_COMPILATION_UNIT);
+		Map<String, String> options = JavaCore.getOptions();
+		options.put(JavaCore.COMPILER_SOURCE, "17"); //$NON-NLS-1$
+		astParser.setCompilerOptions(options);
+		return (CompilationUnit) astParser.createAST(null);
+	}
+}

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/HintRuleTestSupport.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/HintRuleTestSupport.java
@@ -13,10 +13,10 @@
  *******************************************************************************/
 package org.sandbox.jdt.triggerpattern.test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -39,7 +39,7 @@ import org.sandbox.jdt.triggerpattern.internal.HintFileParser;
  *
  * <p>The goal is to keep tests for promoted mining candidates nearly as compact
  * as the hint rules themselves: load a rule file, provide before/after snippets,
- * and assert either a replacement or no match.</p>
+ * and assert either a full-source replacement or no match.</p>
  */
 abstract class HintRuleTestSupport {
 
@@ -65,7 +65,11 @@ abstract class HintRuleTestSupport {
 		return processor.process(parseCode(code));
 	}
 
-	protected void assertReplacement(HintFile hintFile, String beforeCode, String expectedReplacement) {
+	/**
+	 * Low-level assertion for the raw replacement fragment returned by the processor.
+	 * Promotion tests should normally prefer {@link #assertFullReplacement}.
+	 */
+	protected void assertReplacementFragment(HintFile hintFile, String beforeCode, String expectedReplacement) {
 		List<TransformationResult> results = process(hintFile, beforeCode);
 		assertFalse(results.isEmpty(), "Expected at least one match"); //$NON-NLS-1$
 		assertTrue(results.stream()
@@ -73,6 +77,23 @@ abstract class HintRuleTestSupport {
 				.map(TransformationResult::replacement)
 				.anyMatch(expectedReplacement::equals),
 				"Expected replacement not produced: " + expectedReplacement); //$NON-NLS-1$
+	}
+
+	/**
+	 * Asserts that the first replacement can be embedded back into the original
+	 * source and produce the expected full source. This avoids misleading tests
+	 * where a complete class snippet is compared only with an expression-level
+	 * replacement fragment.
+	 */
+	protected void assertFullReplacement(HintFile hintFile, String beforeCode, String expectedCode) {
+		List<TransformationResult> results = process(hintFile, beforeCode);
+		assertFalse(results.isEmpty(), "Expected at least one match"); //$NON-NLS-1$
+		TransformationResult result = results.stream()
+				.filter(TransformationResult::hasReplacement)
+				.findFirst()
+				.orElseThrow(() -> new AssertionError("Expected at least one replacement")); //$NON-NLS-1$
+		String actualCode = replaceFirstLiteral(beforeCode, result.matchedText(), result.replacement());
+		assertEquals(normalizeSource(expectedCode), normalizeSource(actualCode));
 	}
 
 	protected void assertNoMatch(HintFile hintFile, String code) {
@@ -84,6 +105,16 @@ abstract class HintRuleTestSupport {
 		java.util.HashMap<String, GuardFunction> guards = new java.util.HashMap<>();
 		BuiltInGuards.registerAll(guards);
 		GuardFunctionResolverHolder.setResolver(guards::get);
+	}
+
+	private String replaceFirstLiteral(String source, String matchedText, String replacement) {
+		int index = source.indexOf(matchedText);
+		assertTrue(index >= 0, "Matched text not found in source: " + matchedText); //$NON-NLS-1$
+		return source.substring(0, index) + replacement + source.substring(index + matchedText.length());
+	}
+
+	private String normalizeSource(String source) {
+		return source.replaceAll("\\s+", " ").trim(); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
 	private CompilationUnit parseCode(String code) {

--- a/sandbox_mining_core/src/main/java/org/sandbox/mining/core/config/KnownRulesStore.java
+++ b/sandbox_mining_core/src/main/java/org/sandbox/mining/core/config/KnownRulesStore.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.sandbox.jdt.triggerpattern.llm.CommitEvaluation;
+import org.sandbox.mining.core.candidate.MiningCandidate;
 
 /**
  * Persistent store for known mining rules ({@code known-rules.json}).
@@ -62,6 +63,8 @@ public class KnownRulesStore {
 		private String discoveredAt;
 		private int discoveredInRun;
 		private String sourceCommit;
+		private String sourceRepo;
+		private String candidateId;
 		private RuleStatus status;
 		private String hintFile;
 
@@ -71,7 +74,7 @@ public class KnownRulesStore {
 
 		public KnownRule(String id, String category, String dslRule, String summary,
 				String discoveredAt, int discoveredInRun, String sourceCommit,
-				RuleStatus status, String hintFile) {
+				String sourceRepo, String candidateId, RuleStatus status, String hintFile) {
 			this.id = id;
 			this.category = category;
 			this.dslRule = dslRule;
@@ -79,6 +82,8 @@ public class KnownRulesStore {
 			this.discoveredAt = discoveredAt;
 			this.discoveredInRun = discoveredInRun;
 			this.sourceCommit = sourceCommit;
+			this.sourceRepo = sourceRepo;
+			this.candidateId = candidateId;
 			this.status = status;
 			this.hintFile = hintFile;
 		}
@@ -97,6 +102,10 @@ public class KnownRulesStore {
 		public void setDiscoveredInRun(int discoveredInRun) { this.discoveredInRun = discoveredInRun; }
 		public String getSourceCommit() { return sourceCommit; }
 		public void setSourceCommit(String sourceCommit) { this.sourceCommit = sourceCommit; }
+		public String getSourceRepo() { return sourceRepo; }
+		public void setSourceRepo(String sourceRepo) { this.sourceRepo = sourceRepo; }
+		public String getCandidateId() { return candidateId; }
+		public void setCandidateId(String candidateId) { this.candidateId = candidateId; }
 		public RuleStatus getStatus() { return status; }
 		public void setStatus(RuleStatus status) { this.status = status; }
 		public String getHintFile() { return hintFile; }
@@ -213,6 +222,17 @@ public class KnownRulesStore {
 				continue;
 			}
 			String ruleId = buildRuleId(eval);
+			MiningCandidate candidate = new MiningCandidate(
+					eval.dslRule(),
+					eval.beforeExample(),
+					eval.afterExample(),
+					eval.negativeExample(),
+					eval.targetHintFile(),
+					eval.commitHash(),
+					eval.repoUrl(),
+					eval.category(),
+					eval.summary(),
+					LocalDate.now().toString());
 			KnownRule rule = new KnownRule(
 					ruleId,
 					eval.category(),
@@ -221,6 +241,8 @@ public class KnownRulesStore {
 					LocalDate.now().toString(),
 					runNumber,
 					eval.commitHash(),
+					eval.repoUrl(),
+					candidate.getCandidateId(),
 					RuleStatus.DISCOVERED,
 					eval.targetHintFile());
 			data.rules.add(rule);
@@ -246,6 +268,9 @@ public class KnownRulesStore {
 				sb.append(',');
 			}
 			sb.append("\n  {\"id\":\"").append(escape(r.id)) //$NON-NLS-1$
+			  .append("\",\"candidateId\":\"").append(escape(r.candidateId)) //$NON-NLS-1$
+			  .append("\",\"sourceRepo\":\"").append(escape(r.sourceRepo)) //$NON-NLS-1$
+			  .append("\",\"sourceCommit\":\"").append(escape(r.sourceCommit)) //$NON-NLS-1$
 			  .append("\",\"category\":\"").append(escape(r.category)) //$NON-NLS-1$
 			  .append("\",\"summary\":\"").append(escape(r.summary)) //$NON-NLS-1$
 			  .append("\",\"dslRule\":\"").append(escape(r.dslRule)) //$NON-NLS-1$


### PR DESCRIPTION
## Summary

- persist `mining-candidates/*.json` in the nightly commit-mining state update PR
- upload staged candidates together with the mining report artifact
- snapshot `known-rules.json` before mining and reconcile it afterwards so newly registered rules stay known only when a matching staged candidate exists
- persist traceability in known rules: `sourceRepo`, `sourceCommit`, and deterministic `candidateId`
- conservatively clean active bundled hint libraries by removing unsafe mined rules from `performance`, `collections`, and `modernize-java11`
- add reusable JUnit support for hint-rule behavior tests
- add first behavior tests for active bundled hint files, including negative tests for previously unsafe mined patterns
- add FQN-aware matching tests for DSL snippets written with fully qualified names and target code written with imports/simple names
- document an opt-in Gemini integration-test approach with pinned real-world commits

## Why

The staged mining pipeline now writes GREEN+VALID findings to `mining-candidates/`, but the workflow previously only committed `state.json`, `known-rules.json`, and legacy hint files. That could mark a rule as known while losing the actual candidate after the CI workspace is discarded.

Keeping `sourceRepo`, `sourceCommit`, and `candidateId` together makes failed or questionable derivations reproducible. A follow-up run can target the same source commit and compare whether prompt, DSL validator, guard, or test improvements produce a better candidate.

## Hint-library cleanup and tests

Some harvested rules had been promoted into active bundled libraries too early. This PR removes broad rules that can change type, overload, null, synchronization, or call-context semantics, while keeping only conservative rules that are easier to validate.

Promoted hint rules should now be accompanied by behavior tests. `HintRuleTestSupport` provides compact object-oriented helpers so a candidate can be promoted with a small positive before/after test and at least one negative regression case.

## FQN-aware DSL style

Rules should normally be written with fully qualified API names. The matcher should still accept target code that uses imports or simple names when imports or bindings prove that the source code refers to the same API. This PR adds explicit tests for FQN method receivers and constructors matching imported simple-name source code.

## Notes

The integration-test note keeps live Gemini calls out of the default test suite. It proposes a JUnit tag plus environment-variable gate so known commits can be tested explicitly when the required environment is present.