### PR TITLE
Improve refactoring mining hint quality

### DIFF
--- a/.github/refactoring-mining/repos.yml
+++ b/.github/refactoring-mining/repos.yml
@@ -1,19 +1,22 @@
 mining:
-  # .sandbox-hint files to use
+  # .sandbox-hint files to use for automated mining reports.
+  #
+  # Broad style-only bundles such as collections are intentionally not part of
+  # the nightly report set. PR #1177 showed that they drown out higher-signal
+  # refactoring candidates with repeated diamond/factory-method modernization.
   hints:
-    - bundled:collections
-    - bundled:modernize-java11
-    - bundled:performance
-    - bundled:deprecated-api
+    - bundled:probable-bugs
+    - bundled:deprecations
+    - bundled:try-with-resources
+    - bundled:io-performance
     - bundled:collection-performance
     - bundled:stream-performance
+    - bundled:arrays
+    - bundled:string-equals
     - bundled:string-isblank
     - bundled:modernize-java9
-    - bundled:io-performance
-    - bundled:misc
-    - bundled:string-equals
-    - bundled:probable-bugs
-    - bundled:try-with-resources
+    - bundled:modernize-java11
+    - bundled:performance
 
   # Eclipse projects to scan
   repositories:
@@ -53,6 +56,10 @@ mining:
   settings:
     max-files-per-repo: 5000
     timeout-per-repo-minutes: 10
+    # Eclipse 2026-era projects and this sandbox build target Java 21. The CLI
+    # forwards this to guard evaluation so sourceVersionGE(...) rules behave
+    # deterministically during mining.
+    source-version: "21"
     # Gemini mining settings
     start-date: "2015-01-01"
     batch-size: 500

--- a/sandbox_common_core/src/main/resources/org/sandbox/jdt/triggerpattern/internal/arrays.sandbox-hint
+++ b/sandbox_common_core/src/main/resources/org/sandbox/jdt/triggerpattern/internal/arrays.sandbox-hint
@@ -1,5 +1,6 @@
 // arrays.sandbox-hint — Array Utility Patterns
-// Replaces verbose array patterns with more efficient alternatives
+// Replaces verbose array patterns with more efficient alternatives where this is
+// safe without type bindings.
 
 <!id: arrays>
 <!description: Array utility patterns and modernization>
@@ -7,29 +8,31 @@
 <!minJavaVersion: 8>
 <!tags: arrays, modernization>
 
-// Arrays.asList($arr).stream() → Arrays.stream($arr)
+@id: arrays.aslist-stream.to-arrays-stream
+@severity: info
 java.util.Arrays.asList($arr).stream() :: sourceVersionGE(8)
 => java.util.Arrays.stream($arr)
 ;;
 
-// Hint-only: Arrays.asList for contains check
-"Consider using Arrays.stream($arr).anyMatch() instead of Arrays.asList().contains()":
+@id: arrays.aslist-contains.review
+@severity: info
+"Consider Arrays.stream($arr).anyMatch(...) instead of Arrays.asList($arr).contains(...) when this is an array membership check.":
 java.util.Arrays.asList($arr).contains($x) :: sourceVersionGE(8)
 ;;
 
-// Hint-only: arr.clone() could use Arrays.copyOf
-"Consider using Arrays.copyOf($arr, $arr.length) instead of clone()":
+@id: arrays.clone.review
+@severity: info
+"Consider Arrays.copyOf($arr, $arr.length) instead of clone() when a typed copy is clearer.":
 $arr.clone()
 ;;
 
-// Hint-only: System.arraycopy could use Arrays.copyOf when applicable
-"Consider using Arrays.copyOf() instead of System.arraycopy() for full-array copies":
+@id: arrays.arraycopy-full-copy.review
+@severity: info
+"Consider Arrays.copyOf() instead of System.arraycopy() for simple full-array copies.":
 System.arraycopy($src, 0, $dst, 0, $src.length)
 ;;
 
-@id: arrays.compare.object-equals-to-arrays-equals
-@severity: warning
-java.util.Objects.equals($array1, $array2)
-:: instanceof($array1, "java.lang.Object[]") && instanceof($array2, "java.lang.Object[]")
-=> java.util.Arrays.equals($array1, $array2)
-;;
+// Do not add Objects.equals(array1, array2) -> Arrays.equals(array1, array2)
+// here without reliable type bindings. With binding-less mining, an array type
+// guard currently cannot distinguish Object[] from ordinary objects, producing
+// false positives for normal equals implementations.

--- a/sandbox_common_core/src/main/resources/org/sandbox/jdt/triggerpattern/internal/collection-performance.sandbox-hint
+++ b/sandbox_common_core/src/main/resources/org/sandbox/jdt/triggerpattern/internal/collection-performance.sandbox-hint
@@ -1,5 +1,5 @@
 // collection-performance.sandbox-hint — Collection performance patterns
-// Replaces verbose collection operations with more efficient alternatives
+// Replaces collection view operations with direct collection/map operations.
 
 <!id: collection-performance>
 <!description: Collection performance improvement patterns>
@@ -7,31 +7,42 @@
 <!minJavaVersion: 8>
 <!tags: collections, performance>
 
-
+@id: collection-performance.map-keyset-size.to-map-size
+@severity: info
 $map.keySet().size()
 => $map.size()
 ;;
 
+@id: collection-performance.map-values-size.to-map-size
+@severity: info
 $map.values().size()
 => $map.size()
 ;;
 
+@id: collection-performance.map-keyset-isempty.to-map-isempty
+@severity: info
 $map.keySet().isEmpty()
 => $map.isEmpty()
 ;;
 
+@id: collection-performance.map-values-isempty.to-map-isempty
+@severity: info
 $map.values().isEmpty()
 => $map.isEmpty()
 ;;
 
+@id: collection-performance.map-keyset-clear.to-map-clear
+@severity: info
 $map.keySet().clear()
 => $map.clear()
 ;;
 
+@id: collection-performance.map-values-clear.to-map-clear
+@severity: info
 $map.values().clear()
 => $map.clear()
 ;;
 
-$map.keySet().remove($k) :: elementKindMatches("", "EXPRESSION_STATEMENT")
-=> $map.remove($k)
-;;
+// Do not add keySet().remove(k) -> map.remove(k) here without a reliable
+// expression-statement guard. As a value expression, the boolean vs previous
+// mapped value return type is observably different.

--- a/sandbox_common_core/src/main/resources/org/sandbox/jdt/triggerpattern/internal/collections.sandbox-hint
+++ b/sandbox_common_core/src/main/resources/org/sandbox/jdt/triggerpattern/internal/collections.sandbox-hint
@@ -1,52 +1,40 @@
-// collections.sandbox-hint — Collections API improvements
-// Replaces verbose collection patterns with modern API equivalents.
+// collections.sandbox-hint — Collection API improvements
 //
-// Keep this active bundled library conservative. Broader migrations such as
-// Vector to ArrayList, Hashtable to HashMap, or singleton/unmodifiable factory
-// rewrites can change synchronization, null handling, or declared API types and
-// should remain staged candidates until they have stronger guards and tests.
+// Keep this active bundled library conservative. PR #1177 showed that broad
+// diamond-only constructor patterns dominate mining reports while adding little
+// actionable value:
+//   new ArrayList(...) -> new java.util.ArrayList<>(...)
+//   new HashSet(...)   -> new java.util.HashSet<>(...)
+//   new Hashtable(...) -> new java.util.Hashtable<>(...)
+//
+// Those rules are intentionally not part of the active library. They are mostly
+// style-only, duplicate between no-argument and variadic constructor patterns,
+// and produce noisy fully-qualified replacements. If such rules are needed for
+// experiments, keep them in a staged/mining candidate file with explicit tests.
 
 <!id: collections>
-<!description: Collection API improvements and modernization>
+<!description: Conservative collection API modernization>
 <!severity: info>
 <!minJavaVersion: 9>
-<!tags: collections, modernization>
+<!tags: collections, modernization, conservative>
 
-// Collections.emptyList() → List.of()
-java.util.Collections.emptyList()
+@id: collections.empty-list.to-list-of
+@severity: info
+"Use List.of() for an empty immutable list factory when Java 9+ is available.":
+java.util.Collections.emptyList() :: sourceVersionGE(9)
 => java.util.List.of()
 ;;
 
-// Collections.emptyMap() → Map.of()
-java.util.Collections.emptyMap()
+@id: collections.empty-map.to-map-of
+@severity: info
+"Use Map.of() for an empty immutable map factory when Java 9+ is available.":
+java.util.Collections.emptyMap() :: sourceVersionGE(9)
 => java.util.Map.of()
 ;;
 
-// Collections.emptySet() → Set.of()
-java.util.Collections.emptySet()
+@id: collections.empty-set.to-set-of
+@severity: info
+"Use Set.of() for an empty immutable set factory when Java 9+ is available.":
+java.util.Collections.emptySet() :: sourceVersionGE(9)
 => java.util.Set.of()
-;;
-
-new java.util.HashSet<$E$>()
-=> new java.util.HashSet<>()
-;;
-
-new java.util.HashSet<$E$>($args$)
-=> new java.util.HashSet<>($args$)
-;;
-
-new java.util.ArrayList<$E$>()
-=> new java.util.ArrayList<>()
-;;
-
-new java.util.ArrayList<$E$>($args$)
-=> new java.util.ArrayList<>($args$)
-;;
-
-new java.util.Hashtable<$K, $V$>()
-=> new java.util.Hashtable<>()
-;;
-
-new java.util.Hashtable<$K, $V$>($args$)
-=> new java.util.Hashtable<>($args$)
 ;;

--- a/sandbox_common_core/src/main/resources/org/sandbox/jdt/triggerpattern/internal/deprecations.sandbox-hint
+++ b/sandbox_common_core/src/main/resources/org/sandbox/jdt/triggerpattern/internal/deprecations.sandbox-hint
@@ -1,67 +1,86 @@
-// deprecations.sandbox-hint — Deprecated API Replacements
-// Identifies deprecated API usage and suggests modern alternatives
+// deprecations.sandbox-hint — Deprecated API replacements
+// Identifies deprecated API usage and suggests behaviour-preserving alternatives.
 
 <!id: deprecations>
 <!description: Deprecated API replacement suggestions>
 <!severity: warning>
 <!minJavaVersion: 8>
-<!tags: deprecations, modernization>
+<!tags: deprecations, modernization, correctness>
 
-// Character.isSpace($c) → Character.isWhitespace($c)
+@id: deprecations.character-is-space.to-is-whitespace
+@severity: warning
 java.lang.Character.isSpace($c)
 => java.lang.Character.isWhitespace($c)
 ;;
 
-// new Boolean($str) → Boolean.parseBoolean($str)
-new java.lang.Boolean($str)
-=> java.lang.Boolean.parseBoolean($str)
+@id: deprecations.boolean-constructor.to-valueof
+@severity: warning
+new java.lang.Boolean($value)
+=> java.lang.Boolean.valueOf($value)
 ;;
 
-// new Integer($str) → Integer.parseInt($str)
-new java.lang.Integer($str)
-=> java.lang.Integer.parseInt($str)
+@id: deprecations.integer-constructor.to-valueof
+@severity: warning
+new java.lang.Integer($value)
+=> java.lang.Integer.valueOf($value)
 ;;
 
-// new Long($str) → Long.parseLong($str)
-new java.lang.Long($str)
-=> java.lang.Long.parseLong($str)
+@id: deprecations.long-constructor.to-valueof
+@severity: warning
+new java.lang.Long($value)
+=> java.lang.Long.valueOf($value)
 ;;
 
-// new Short($str) → Short.parseShort($str)
-new java.lang.Short($str)
-=> java.lang.Short.parseShort($str)
+@id: deprecations.short-constructor.to-valueof
+@severity: warning
+new java.lang.Short($value)
+=> java.lang.Short.valueOf($value)
 ;;
 
-// new Byte($str) → Byte.parseByte($str)
-new java.lang.Byte($str)
-=> java.lang.Byte.parseByte($str)
+@id: deprecations.byte-constructor.to-valueof
+@severity: warning
+new java.lang.Byte($value)
+=> java.lang.Byte.valueOf($value)
 ;;
 
-// new Float($str) → Float.parseFloat($str)
-new java.lang.Float($str)
-=> java.lang.Float.parseFloat($str)
+@id: deprecations.float-constructor.to-valueof
+@severity: warning
+new java.lang.Float($value)
+=> java.lang.Float.valueOf($value)
 ;;
 
-// new Double($str) → Double.parseDouble($str)
-new java.lang.Double($str)
-=> java.lang.Double.parseDouble($str)
+@id: deprecations.double-constructor.to-valueof
+@severity: warning
+new java.lang.Double($value)
+=> java.lang.Double.valueOf($value)
 ;;
 
-// Hint-only: new Date(y, m, d) is deprecated
-"java.util.Date constructor is deprecated — consider using java.time.LocalDate.of() (Java 8+)":
+@id: deprecations.character-constructor.to-valueof
+@severity: warning
+new java.lang.Character($value)
+=> java.lang.Character.valueOf($value)
+;;
+
+@id: deprecations.date-ymd-constructor.consider-localdate
+@severity: warning
+"java.util.Date year/month/day constructor is deprecated — consider java.time.LocalDate.of(...).":
 new java.util.Date($y, $m, $d) :: sourceVersionGE(8)
 ;;
 
-// Hint-only: Runtime.exec(String) should use ProcessBuilder
-"Runtime.exec(String) is error-prone — consider using ProcessBuilder":
+@id: deprecations.runtime-exec-string.consider-processbuilder
+@severity: warning
+"Runtime.exec(String) is error-prone — consider ProcessBuilder with explicit arguments.":
 java.lang.Runtime.getRuntime().exec($cmd)
 ;;
 
-// Class.forName($name).newInstance() is deprecated since Java 9
-"Class.newInstance() is deprecated — use Constructor.newInstance() instead":
+@id: deprecations.class-forname-newinstance.consider-constructor-newinstance
+@severity: warning
+"Class.newInstance() is deprecated — use getDeclaredConstructor().newInstance() instead.":
 java.lang.Class.forName($name).newInstance() :: sourceVersionGE(9)
 ;;
 
-java.lang.Boolean.valueOf($str).booleanValue()
-=> java.lang.Boolean.parseBoolean($str)
+@id: deprecations.boolean-valueof-booleanvalue.to-parseboolean
+@severity: warning
+java.lang.Boolean.valueOf($value).booleanValue()
+=> java.lang.Boolean.parseBoolean($value)
 ;;

--- a/sandbox_common_core/src/main/resources/org/sandbox/jdt/triggerpattern/internal/io-performance.sandbox-hint
+++ b/sandbox_common_core/src/main/resources/org/sandbox/jdt/triggerpattern/internal/io-performance.sandbox-hint
@@ -1,5 +1,5 @@
-// io-performance.sandbox-hint — I/O Stream Performance
-// Detects double-buffering and unnecessary buffering in I/O streams
+// io-performance.sandbox-hint — I/O stream performance
+// Detects double-buffering and unnecessary buffering in I/O streams.
 
 <!id: io-performance>
 <!description: I/O stream performance patterns — detect double-buffering>
@@ -7,32 +7,38 @@
 <!minJavaVersion: 8>
 <!tags: performance, io>
 
-// Double-buffered InputStream
+@id: io-performance.double-buffered-inputstream
+@severity: warning
 new java.io.BufferedInputStream(new java.io.BufferedInputStream($x))
 => new java.io.BufferedInputStream($x)
 ;;
 
-// Double-buffered OutputStream
+@id: io-performance.double-buffered-outputstream
+@severity: warning
 new java.io.BufferedOutputStream(new java.io.BufferedOutputStream($x))
 => new java.io.BufferedOutputStream($x)
 ;;
 
-// Double-buffered Reader
+@id: io-performance.double-buffered-reader
+@severity: warning
 new java.io.BufferedReader(new java.io.BufferedReader($x))
 => new java.io.BufferedReader($x)
 ;;
 
-// Double-buffered Writer
+@id: io-performance.double-buffered-writer
+@severity: warning
 new java.io.BufferedWriter(new java.io.BufferedWriter($x))
 => new java.io.BufferedWriter($x)
 ;;
 
-// Hint-only: DataInputStream already buffers internally
-"DataInputStream already buffers internally — outer BufferedInputStream may be unnecessary":
+@id: io-performance.datainputstream-buffered-input.review
+@severity: info
+"DataInputStream already buffers primitive reads internally — review whether the extra BufferedInputStream is useful here.":
 new java.io.DataInputStream(new java.io.BufferedInputStream($x))
 ;;
 
-// Hint-only: ObjectOutputStream already buffers internally
-"ObjectOutputStream already buffers internally — outer BufferedOutputStream may be unnecessary":
+@id: io-performance.objectoutputstream-buffered-output.review
+@severity: info
+"ObjectOutputStream has its own block buffering — review whether the extra BufferedOutputStream is useful here.":
 new java.io.ObjectOutputStream(new java.io.BufferedOutputStream($x))
 ;;

--- a/sandbox_common_core/src/main/resources/org/sandbox/jdt/triggerpattern/internal/modernize-java9.sandbox-hint
+++ b/sandbox_common_core/src/main/resources/org/sandbox/jdt/triggerpattern/internal/modernize-java9.sandbox-hint
@@ -16,7 +16,7 @@
 java.util.Collections.unmodifiableList(java.util.Arrays.asList($args$)) :: sourceVersionGE(9)
 ;;
 
-@id: modernize-java8.map-getordefault-null.to-get
+@id: modernize-java9.map-getordefault-null.to-get
 @severity: info
 $map.getOrDefault($key, null)
 => $map.get($key)

--- a/sandbox_common_core/src/main/resources/org/sandbox/jdt/triggerpattern/internal/modernize-java9.sandbox-hint
+++ b/sandbox_common_core/src/main/resources/org/sandbox/jdt/triggerpattern/internal/modernize-java9.sandbox-hint
@@ -1,43 +1,41 @@
 // modernize-java9.sandbox-hint — Java 9+ API modernization
-// Replaces older API usage with Java 9+ equivalents
+//
+// Keep exact rewrites only where behaviour is preserved. API replacements that
+// can change null handling, mutability, evaluation order, or side effects are
+// kept as hint-only suggestions so mining reports remain actionable.
 
 <!id: modernize-java9>
-<!description: Java 9+ API modernization patterns>
+<!description: Conservative Java 9+ API modernization patterns>
 <!severity: info>
 <!minJavaVersion: 9>
-<!tags: modernization, java9>
+<!tags: modernization, java9, conservative>
 
-// Arrays.asList($args$) → List.of($args$) when unmodifiable usage
+@id: modernize-java9.unmodifiable-list-arrays-aslist.consider-list-of
+@severity: info
+"Consider List.of(...) for unmodifiableList(Arrays.asList(...)) when null elements are impossible.":
 java.util.Collections.unmodifiableList(java.util.Arrays.asList($args$)) :: sourceVersionGE(9)
-=> java.util.List.of($args$)
 ;;
 
-// new ArrayList<>(Arrays.asList($args$)) → new ArrayList<>(List.of($args$))
-new java.util.ArrayList<>(java.util.Arrays.asList($args$)) :: sourceVersionGE(9)
-=> new java.util.ArrayList<>(java.util.List.of($args$))
-;;
-
-// $map.getOrDefault($key, null) → $map.get($key)
+@id: modernize-java8.map-getordefault-null.to-get
+@severity: info
 $map.getOrDefault($key, null)
 => $map.get($key)
 ;;
 
-// $optional.isPresent() ? $optional.get() : $default → $optional.orElse($default)
-$optional.isPresent() ? $optional.get() : $default :: sourceVersionGE(9)
+@id: modernize-java9.optional-ternary.to-orelse
+@severity: info
+$optional.isPresent() ? $optional.get() : $default :: sourceVersionGE(9) && hasNoSideEffect($default)
 => $optional.orElse($default)
 ;;
 
-// $stream.collect(Collectors.toList()) → $stream.toList()
+@id: modernize-java16.stream-collect-tolist.consider-stream-tolist
+@severity: info
+"Consider Stream.toList() only when an unmodifiable result is acceptable.":
 $stream.collect(java.util.stream.Collectors.toList()) :: sourceVersionGE(16)
-=> $stream.toList()
 ;;
 
-// $stream.collect(Collectors.toUnmodifiableList()) → $stream.toList()
+@id: modernize-java16.stream-collect-tounmodifiablelist.consider-stream-tolist
+@severity: info
+"Consider Stream.toList() only when null-element behaviour is known to be acceptable.":
 $stream.collect(java.util.stream.Collectors.toUnmodifiableList()) :: sourceVersionGE(16)
-=> $stream.toList()
-;;
-
-// Hint-only: suggest InputStream.transferTo() for stream copy patterns
-"Consider using InputStream.transferTo() for stream copying (Java 9+)":
-$in.read($buf) :: sourceVersionGE(9) && notContains("transferTo")
 ;;

--- a/sandbox_common_core/src/main/resources/org/sandbox/jdt/triggerpattern/internal/probable-bugs.sandbox-hint
+++ b/sandbox_common_core/src/main/resources/org/sandbox/jdt/triggerpattern/internal/probable-bugs.sandbox-hint
@@ -1,5 +1,10 @@
 // probable-bugs.sandbox-hint — Probable Bug Patterns
-// Detects code patterns that are likely programming mistakes
+// Detects code patterns that are likely programming mistakes.
+//
+// Keep this bundled library binding-safe for mining. Rules that rely on
+// distinguishing arrays from ordinary objects must not be active until the
+// standalone mining parser provides reliable type bindings or a strict type
+// guard is available.
 
 <!id: probable-bugs>
 <!description: Probable bug detection patterns>
@@ -7,48 +12,38 @@
 <!minJavaVersion: 8>
 <!tags: bugs, correctness>
 
-// Hint-only: $x == $x on floating-point may be NaN check
-"Comparing a value to itself — use Double.isNaN() or Float.isNaN() for NaN checks":
+@id: probable-bugs.self-comparison.review
+@severity: warning
+"Comparing a value to itself — use Double.isNaN() or Float.isNaN() for intentional NaN checks.":
 $x == $x
 ;;
 
-// Hint-only: $x != $x on floating-point is NaN check
-"Value not equal to itself — use Double.isNaN() or Float.isNaN() instead":
+@id: probable-bugs.self-inequality.review
+@severity: warning
+"Value not equal to itself — use Double.isNaN() or Float.isNaN() for intentional NaN checks.":
 $x != $x
 ;;
 
-// Hint-only: $x.equals($x) is always true (reflexive)
-"Object.equals() with same argument on both sides — always true, probably a bug":
+@id: probable-bugs.reflexive-equals.review
+@severity: warning
+"Object.equals() with the same expression on both sides is always true and often indicates a copy-paste bug.":
 $x.equals($x)
 ;;
 
-// Hint-only: Math.max with identical arguments
-"Math.max() with identical arguments — probably a copy-paste bug":
+@id: probable-bugs.math-max-identical-args.review
+@severity: warning
+"Math.max() with identical arguments — probably a copy-paste bug.":
 java.lang.Math.max($a, $a)
 ;;
 
-// Hint-only: Math.min with identical arguments
-"Math.min() with identical arguments — probably a copy-paste bug":
+@id: probable-bugs.math-min-identical-args.review
+@severity: warning
+"Math.min() with identical arguments — probably a copy-paste bug.":
 java.lang.Math.min($a, $a)
 ;;
 
-// Hint-only: potential time overflow due to clock adjustments
-"System.currentTimeMillis() may go backwards due to clock adjustments — consider System.nanoTime() for elapsed time":
+@id: probable-bugs.currenttimemillis-negative-elapsed.review
+@severity: warning
+"System.currentTimeMillis() may go backwards due to clock adjustments — consider System.nanoTime() for elapsed time.":
 System.currentTimeMillis() - $start < 0
-;;
-
-$x == $x :: !instanceof($x, "double") && !instanceof($x, "float")
-=> true
-;;
-
-@id: arrays.correctness.array-object-equals
-@severity: error
-!$array1.equals($array2) :: instanceof($array1, "java.lang.Object[]") && instanceof($array2, "java.lang.Object[]")
-=> !java.util.Arrays.equals($array1, $array2)
-;;
-
-@id: arrays.correctness.array-object-equals-positive
-@severity: error
-$array1.equals($array2) :: instanceof($array1, "java.lang.Object[]") && instanceof($array2, "java.lang.Object[]")
-=> java.util.Arrays.equals($array1, $array2)
 ;;

--- a/sandbox_common_core/src/main/resources/org/sandbox/jdt/triggerpattern/internal/stream-performance.sandbox-hint
+++ b/sandbox_common_core/src/main/resources/org/sandbox/jdt/triggerpattern/internal/stream-performance.sandbox-hint
@@ -1,5 +1,5 @@
-// stream-performance.sandbox-hint — Stream API Performance
-// Identifies inefficient stream usage patterns and suggests more performant alternatives
+// stream-performance.sandbox-hint — Stream API performance
+// Identifies inefficient stream usage patterns and suggests more direct alternatives.
 
 <!id: stream-performance>
 <!description: Stream API performance optimization patterns>
@@ -7,42 +7,50 @@
 <!minJavaVersion: 8>
 <!tags: performance, streams>
 
-// $stream.filter($pred).findFirst().isPresent() → $stream.anyMatch($pred)
+@id: stream-performance.filter-findfirst-ispresent.to-anymatch
+@severity: info
 $stream.filter($pred).findFirst().isPresent() :: sourceVersionGE(8)
 => $stream.anyMatch($pred)
 ;;
 
-// $stream.filter($pred).findAny().isPresent() → $stream.anyMatch($pred)
+@id: stream-performance.filter-findany-ispresent.to-anymatch
+@severity: info
 $stream.filter($pred).findAny().isPresent() :: sourceVersionGE(8)
 => $stream.anyMatch($pred)
 ;;
 
-// $stream.filter($pred).count() > 0 → $stream.anyMatch($pred)
+@id: stream-performance.filter-count-positive.to-anymatch
+@severity: info
 $stream.filter($pred).count() > 0 :: sourceVersionGE(8)
 => $stream.anyMatch($pred)
 ;;
 
-// $stream.filter($pred).count() == 0 → $stream.noneMatch($pred)
+@id: stream-performance.filter-count-zero.to-nonematch
+@severity: info
 $stream.filter($pred).count() == 0 :: sourceVersionGE(8)
 => $stream.noneMatch($pred)
 ;;
 
-// $collection.stream().forEach($action) → $collection.forEach($action)
+@id: stream-performance.collection-stream-foreach.to-collection-foreach
+@severity: info
 $collection.stream().forEach($action) :: sourceVersionGE(8)
 => $collection.forEach($action)
 ;;
 
-// Hint-only: $stream.sorted() before collect may be unnecessary
-"Unnecessary sort before collect — consider removing sorted() if order does not matter":
+@id: stream-performance.sorted-before-collect.review
+@severity: info
+"Unnecessary sorted() before collect — consider removing it if encounter order is irrelevant.":
 $stream.sorted().collect($collector) :: sourceVersionGE(8)
 ;;
 
-// Hint-only: nested flatMap may indicate overly complex pipeline
-"Nested flatMap() calls — consider simplifying the stream pipeline":
+@id: stream-performance.nested-flatmap.review
+@severity: info
+"Nested flatMap() calls — consider simplifying the stream pipeline.":
 $stream.flatMap($f).flatMap($g) :: sourceVersionGE(8)
 ;;
 
-// Hint-only: IntStream.range for array iteration can use Arrays.stream
-"Consider using Arrays.stream($arr) instead of IntStream.range with array indexing":
+@id: stream-performance.intstream-range-array-index.review
+@severity: info
+"Consider Arrays.stream(...) instead of IntStream.range(...) for simple array iteration.":
 java.util.stream.IntStream.range(0, $arr.length).mapToObj($mapper) :: sourceVersionGE(8)
 ;;

--- a/sandbox_common_core/src/main/resources/org/sandbox/jdt/triggerpattern/internal/string-equals.sandbox-hint
+++ b/sandbox_common_core/src/main/resources/org/sandbox/jdt/triggerpattern/internal/string-equals.sandbox-hint
@@ -1,5 +1,7 @@
-// string-equals.sandbox-hint — String Equality Patterns
-// Identifies string equality anti-patterns and suggests improvements
+// string-equals.sandbox-hint — String equality patterns
+// Identifies string equality idioms that are worth reviewing.
+// Reflexive equals patterns are covered by probable-bugs.sandbox-hint to avoid
+// duplicate mining findings for the same source location.
 
 <!id: string-equals>
 <!description: String equality anti-patterns and null-safe comparisons>
@@ -7,22 +9,14 @@
 <!minJavaVersion: 8>
 <!tags: strings, correctness>
 
-// Hint-only: $str.equals($str) is always true (reflexive)
-"String.equals() with same variable on both sides — always true":
-$str.equals($str)
-;;
-
-// Hint-only: $str.equalsIgnoreCase($str) is always true (reflexive)
-"String.equalsIgnoreCase() with same variable on both sides — always true":
-$str.equalsIgnoreCase($str)
-;;
-
-// Hint-only: consider using equalsIgnoreCase for case-variant comparisons
-"Consider using equalsIgnoreCase() instead of multiple equals() with case variants":
+@id: string-equals.case-variants.consider-equalsignorecase
+@severity: info
+"Consider equalsIgnoreCase() instead of multiple equals() checks for known case variants.":
 $str.equals("yes") || $str.equals("YES")
 ;;
 
-// Hint-only: null check + isEmpty/isBlank pattern
-"Consider a utility method or String.isBlank() for null-or-empty checks (Java 11+)":
+@id: string-equals.null-or-empty.review
+@severity: info
+"Review null-or-empty string handling; String.isBlank() may be appropriate when Java 11+ and whitespace should count as empty.":
 $str == null || $str.isEmpty() :: sourceVersionGE(11)
 ;;

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/BundledHintRuleBehaviorTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/BundledHintRuleBehaviorTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.sandbox.jdt.triggerpattern.test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -75,6 +76,21 @@ class BundledHintRuleBehaviorTest extends HintRuleTestSupport {
 		assertFullReplacement(hintFile,
 				"class Test { Object m() { return java.util.Collections.emptySet(); } }", //$NON-NLS-1$
 				"class Test { Object m() { return java.util.Set.of(); } }"); //$NON-NLS-1$
+	}
+
+	@Test
+	void collectionsUsesStableRuleIdsForEmptyCollectionFactories() throws Exception {
+		HintFile hintFile = loadBundledHint("collections.sandbox-hint"); //$NON-NLS-1$
+
+		assertEquals("collections.empty-list.to-list-of", //$NON-NLS-1$
+				process(hintFile, "class Test { Object m() { return java.util.Collections.emptyList(); } }") //$NON-NLS-1$
+						.get(0).rule().getRuleId());
+		assertEquals("collections.empty-map.to-map-of", //$NON-NLS-1$
+				process(hintFile, "class Test { Object m() { return java.util.Collections.emptyMap(); } }") //$NON-NLS-1$
+						.get(0).rule().getRuleId());
+		assertEquals("collections.empty-set.to-set-of", //$NON-NLS-1$
+				process(hintFile, "class Test { Object m() { return java.util.Collections.emptySet(); } }") //$NON-NLS-1$
+						.get(0).rule().getRuleId());
 	}
 
 	@Test

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/BundledHintRuleBehaviorTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/BundledHintRuleBehaviorTest.java
@@ -78,6 +78,33 @@ class BundledHintRuleBehaviorTest extends HintRuleTestSupport {
 	}
 
 	@Test
+	void collectionsRespectsJava9SourceVersionGuard() throws Exception {
+		HintFile hintFile = loadBundledHint("collections.sandbox-hint"); //$NON-NLS-1$
+
+		assertNoMatch(hintFile,
+				"class Test { Object m() { return java.util.Collections.emptyList(); } }", //$NON-NLS-1$
+				"1.8"); //$NON-NLS-1$
+		assertFullReplacement(hintFile,
+				"class Test { Object m() { return java.util.Collections.emptyList(); } }", //$NON-NLS-1$
+				"class Test { Object m() { return java.util.List.of(); } }", //$NON-NLS-1$
+				"21"); //$NON-NLS-1$
+	}
+
+	@Test
+	void collectionsDoesNotRewriteDiamondOnlyConstructorNoise() throws Exception {
+		HintFile hintFile = loadBundledHint("collections.sandbox-hint"); //$NON-NLS-1$
+
+		assertNoMatch(hintFile,
+				"class Test { Object m() { return new java.util.ArrayList<String>(); } }"); //$NON-NLS-1$
+		assertNoMatch(hintFile,
+				"class Test { Object m() { return new java.util.ArrayList<String>(4); } }"); //$NON-NLS-1$
+		assertNoMatch(hintFile,
+				"class Test { Object m() { return new java.util.HashSet<String>(); } }"); //$NON-NLS-1$
+		assertNoMatch(hintFile,
+				"class Test { Object m() { return new java.util.Hashtable<String, String>(); } }"); //$NON-NLS-1$
+	}
+
+	@Test
 	void collectionsDoesNotRewriteSingletonCollectionsWithDifferentNullSemantics() throws Exception {
 		HintFile hintFile = loadBundledHint("collections.sandbox-hint"); //$NON-NLS-1$
 
@@ -93,6 +120,63 @@ class BundledHintRuleBehaviorTest extends HintRuleTestSupport {
 
 		assertNoMatch(hintFile,
 				"class Test { Object m() { return new java.util.Vector(); } }"); //$NON-NLS-1$
+	}
+
+	@Test
+	void modernizeJava9KeepsRiskyListFactoryMigrationHintOnly() throws Exception {
+		HintFile hintFile = loadBundledHint("modernize-java9.sandbox-hint"); //$NON-NLS-1$
+
+		assertHintOnlyMatch(hintFile,
+				"class Test { Object m() { return java.util.Collections.unmodifiableList(java.util.Arrays.asList(\"a\")); } }"); //$NON-NLS-1$
+	}
+
+	@Test
+	void modernizeJava9RewritesMapGetOrDefaultNullSafely() throws Exception {
+		HintFile hintFile = loadBundledHint("modernize-java9.sandbox-hint"); //$NON-NLS-1$
+
+		assertFullReplacement(hintFile,
+				"class Test { Object m(java.util.Map<String, String> map, String key) { return map.getOrDefault(key, null); } }", //$NON-NLS-1$
+				"class Test { Object m(java.util.Map<String, String> map, String key) { return map.get(key); } }"); //$NON-NLS-1$
+	}
+
+	@Test
+	void modernizeJava9DoesNotRewriteStreamToListWhenMutabilityNeedsReview() throws Exception {
+		HintFile hintFile = loadBundledHint("modernize-java9.sandbox-hint"); //$NON-NLS-1$
+
+		assertHintOnlyMatch(hintFile,
+				"class Test { Object m(java.util.List<String> items) { return items.stream().collect(java.util.stream.Collectors.toList()); } }"); //$NON-NLS-1$
+	}
+
+	@Test
+	void deprecationsUseValueOfForWrapperConstructors() throws Exception {
+		HintFile hintFile = loadBundledHint("deprecations.sandbox-hint"); //$NON-NLS-1$
+
+		assertFullReplacement(hintFile,
+				"class Test { Object m(String value) { return new java.lang.Boolean(value); } }", //$NON-NLS-1$
+				"class Test { Object m(String value) { return java.lang.Boolean.valueOf(value); } }"); //$NON-NLS-1$
+		assertFullReplacement(hintFile,
+				"class Test { Object m(String value) { return new java.lang.Integer(value); } }", //$NON-NLS-1$
+				"class Test { Object m(String value) { return java.lang.Integer.valueOf(value); } }"); //$NON-NLS-1$
+	}
+
+	@Test
+	void collectionPerformanceDoesNotRewriteKeySetRemoveBecauseReturnValueDiffers() throws Exception {
+		HintFile hintFile = loadBundledHint("collection-performance.sandbox-hint"); //$NON-NLS-1$
+
+		assertNoMatch(hintFile,
+				"class Test { Object m(java.util.Map<String, String> map, String key) { return map.keySet().remove(key); } }"); //$NON-NLS-1$
+		assertNoMatch(hintFile,
+				"class Test { void m(java.util.Map<String, String> map, String key) { map.keySet().remove(key); } }"); //$NON-NLS-1$
+	}
+
+	@Test
+	void stringEqualsDoesNotDuplicateReflexiveEqualsProbableBugRule() throws Exception {
+		HintFile stringEquals = loadBundledHint("string-equals.sandbox-hint"); //$NON-NLS-1$
+		HintFile probableBugs = loadBundledHint("probable-bugs.sandbox-hint"); //$NON-NLS-1$
+		String code = "class Test { boolean m(String value) { return value.equals(value); } }"; //$NON-NLS-1$
+
+		assertNoMatch(stringEquals, code);
+		assertHintOnlyMatch(probableBugs, code);
 	}
 
 	@Test

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/HintRuleTestSupport.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/HintRuleTestSupport.java
@@ -102,7 +102,7 @@ abstract class HintRuleTestSupport {
 				.filter(TransformationResult::hasReplacement)
 				.findFirst()
 				.orElseThrow(() -> new AssertionError("Expected at least one replacement")); //$NON-NLS-1$
-		String actualCode = replaceFirstLiteral(beforeCode, result.matchedText(), result.replacement());
+		String actualCode = replaceUsingOffset(beforeCode, result);
 		assertEquals(normalizeSource(expectedCode), normalizeSource(actualCode));
 	}
 
@@ -128,10 +128,12 @@ abstract class HintRuleTestSupport {
 		GuardFunctionResolverHolder.setResolver(guards::get);
 	}
 
-	private String replaceFirstLiteral(String source, String matchedText, String replacement) {
-		int index = source.indexOf(matchedText);
-		assertTrue(index >= 0, "Matched text not found in source: " + matchedText); //$NON-NLS-1$
-		return source.substring(0, index) + replacement + source.substring(index + matchedText.length());
+	private String replaceUsingOffset(String source, TransformationResult result) {
+		int offset = result.match().getOffset();
+		int length = result.match().getLength();
+		assertTrue(offset >= 0 && length >= 0 && offset + length <= source.length(),
+				"Invalid match range: offset=" + offset + ", length=" + length); //$NON-NLS-1$ //$NON-NLS-2$
+		return source.substring(0, offset) + result.replacement() + source.substring(offset + length);
 	}
 
 	private String normalizeSource(String source) {

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/HintRuleTestSupport.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/HintRuleTestSupport.java
@@ -45,6 +45,7 @@ abstract class HintRuleTestSupport {
 
 	private static final String BUNDLED_HINT_PREFIX =
 			"org/sandbox/jdt/triggerpattern/internal/"; //$NON-NLS-1$
+	private static final String DEFAULT_SOURCE_VERSION = "21"; //$NON-NLS-1$
 
 	protected HintFile loadBundledHint(String resourceName) throws Exception {
 		String resourcePath = BUNDLED_HINT_PREFIX + resourceName;
@@ -61,8 +62,12 @@ abstract class HintRuleTestSupport {
 	}
 
 	protected List<TransformationResult> process(HintFile hintFile, String code) {
+		return process(hintFile, code, DEFAULT_SOURCE_VERSION);
+	}
+
+	protected List<TransformationResult> process(HintFile hintFile, String code, String sourceVersion) {
 		BatchTransformationProcessor processor = new BatchTransformationProcessor(hintFile);
-		return processor.process(parseCode(code));
+		return processor.process(parseCode(code, sourceVersion), Map.of(JavaCore.COMPILER_SOURCE, sourceVersion));
 	}
 
 	/**
@@ -86,7 +91,12 @@ abstract class HintRuleTestSupport {
 	 * replacement fragment.
 	 */
 	protected void assertFullReplacement(HintFile hintFile, String beforeCode, String expectedCode) {
-		List<TransformationResult> results = process(hintFile, beforeCode);
+		assertFullReplacement(hintFile, beforeCode, expectedCode, DEFAULT_SOURCE_VERSION);
+	}
+
+	protected void assertFullReplacement(HintFile hintFile, String beforeCode, String expectedCode,
+			String sourceVersion) {
+		List<TransformationResult> results = process(hintFile, beforeCode, sourceVersion);
 		assertFalse(results.isEmpty(), "Expected at least one match"); //$NON-NLS-1$
 		TransformationResult result = results.stream()
 				.filter(TransformationResult::hasReplacement)
@@ -96,8 +106,19 @@ abstract class HintRuleTestSupport {
 		assertEquals(normalizeSource(expectedCode), normalizeSource(actualCode));
 	}
 
-	protected void assertNoMatch(HintFile hintFile, String code) {
+	protected void assertHintOnlyMatch(HintFile hintFile, String code) {
 		List<TransformationResult> results = process(hintFile, code);
+		assertFalse(results.isEmpty(), "Expected at least one hint-only match"); //$NON-NLS-1$
+		assertTrue(results.stream().noneMatch(TransformationResult::hasReplacement),
+				"Expected hint-only match, but at least one replacement was produced: " + results); //$NON-NLS-1$
+	}
+
+	protected void assertNoMatch(HintFile hintFile, String code) {
+		assertNoMatch(hintFile, code, DEFAULT_SOURCE_VERSION);
+	}
+
+	protected void assertNoMatch(HintFile hintFile, String code, String sourceVersion) {
+		List<TransformationResult> results = process(hintFile, code, sourceVersion);
 		assertTrue(results.isEmpty(), "Expected no match but got: " + results); //$NON-NLS-1$
 	}
 
@@ -117,12 +138,12 @@ abstract class HintRuleTestSupport {
 		return source.replaceAll("\\s+", " ").trim(); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
-	private CompilationUnit parseCode(String code) {
+	private CompilationUnit parseCode(String code, String sourceVersion) {
 		ASTParser astParser = ASTParser.newParser(AST.getJLSLatest());
 		astParser.setSource(code.toCharArray());
 		astParser.setKind(ASTParser.K_COMPILATION_UNIT);
 		Map<String, String> options = JavaCore.getOptions();
-		options.put(JavaCore.COMPILER_SOURCE, "17"); //$NON-NLS-1$
+		options.put(JavaCore.COMPILER_SOURCE, sourceVersion);
 		astParser.setCompilerOptions(options);
 		return (CompilationUnit) astParser.createAST(null);
 	}

--- a/sandbox_common_test/src/org/sandbox/jdt/triggerpattern/test/BundledLibrariesTest.java
+++ b/sandbox_common_test/src/org/sandbox/jdt/triggerpattern/test/BundledLibrariesTest.java
@@ -50,8 +50,8 @@ public class BundledLibrariesTest {
 		HintFile hintFile = loadBundledLibrary("collections.sandbox-hint"); //$NON-NLS-1$
 		assertNotNull(hintFile, "collections library should be loadable"); //$NON-NLS-1$
 		assertEquals("collections", hintFile.getId()); //$NON-NLS-1$
-		assertTrue(hintFile.getRules().size() >= 5,
-				"collections library should have at least 5 rules, found: " + hintFile.getRules().size()); //$NON-NLS-1$
+		assertTrue(hintFile.getRules().size() >= 3,
+				"collections library should have at least 3 rules, found: " + hintFile.getRules().size()); //$NON-NLS-1$
 	}
 
 	@Test

--- a/sandbox_mining_cli/src/main/java/org/sandbox/mining/MiningCli.java
+++ b/sandbox_mining_cli/src/main/java/org/sandbox/mining/MiningCli.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.sandbox.jdt.triggerpattern.api.GuardFunction;
 import org.sandbox.jdt.triggerpattern.api.GuardFunctionResolverHolder;
@@ -61,7 +62,6 @@ public class MiningCli {
 	private static final String FORMAT_MARKDOWN = "markdown"; //$NON-NLS-1$
 	private static final String FORMAT_JSON = "json"; //$NON-NLS-1$
 	private static final String FORMAT_BOTH = "both"; //$NON-NLS-1$
-	private static final String COMPILER_SOURCE_OPTION = "org.eclipse.jdt.core.compiler.source"; //$NON-NLS-1$
 
 	/** Map of bundled hint names to their classpath resource paths. */
 	private static final Map<String, String> BUNDLED_HINTS = Map.ofEntries(
@@ -140,7 +140,7 @@ public class MiningCli {
 		} else {
 			config = new MiningConfig();
 		}
-		Map<String, String> compilerOptions = Map.of(COMPILER_SOURCE_OPTION, config.getSourceVersion());
+		Map<String, String> compilerOptions = Map.of(JavaCore.COMPILER_SOURCE, config.getSourceVersion());
 
 		// Override with ad-hoc repo if specified
 		List<RepoEntry> repos;
@@ -340,7 +340,8 @@ public class MiningCli {
 			return;
 		}
 		try {
-			Files.walk(dir)
+			try (var stream = Files.walk(dir)) {
+				stream
 					.sorted((a, b) -> b.compareTo(a)) // delete children first
 					.forEach(p -> {
 						try {
@@ -349,6 +350,7 @@ public class MiningCli {
 							// ignore cleanup errors
 						}
 					});
+			}
 		} catch (IOException e) {
 			// ignore cleanup errors
 		}
@@ -362,5 +364,6 @@ public class MiningCli {
 		System.out.println("  --output <dir>     Output directory (default: mining-results)"); //$NON-NLS-1$
 		System.out.println("  --format <fmt>     markdown|json|both (default: both)"); //$NON-NLS-1$
 		System.out.println("  --dry-run          Only count matches"); //$NON-NLS-1$
+		System.out.println("  --help             Show this help"); //$NON-NLS-1$
 	}
 }

--- a/sandbox_mining_cli/src/main/java/org/sandbox/mining/MiningCli.java
+++ b/sandbox_mining_cli/src/main/java/org/sandbox/mining/MiningCli.java
@@ -57,25 +57,35 @@ import org.sandbox.mining.scanner.StandaloneAstParser;
  */
 public class MiningCli {
 
-	private static final String DEFAULT_OUTPUT = "mining-results";
-	private static final String FORMAT_MARKDOWN = "markdown";
-	private static final String FORMAT_JSON = "json";
-	private static final String FORMAT_BOTH = "both";
+	private static final String DEFAULT_OUTPUT = "mining-results"; //$NON-NLS-1$
+	private static final String FORMAT_MARKDOWN = "markdown"; //$NON-NLS-1$
+	private static final String FORMAT_JSON = "json"; //$NON-NLS-1$
+	private static final String FORMAT_BOTH = "both"; //$NON-NLS-1$
+	private static final String COMPILER_SOURCE_OPTION = "org.eclipse.jdt.core.compiler.source"; //$NON-NLS-1$
 
 	/** Map of bundled hint names to their classpath resource paths. */
-	private static final Map<String, String> BUNDLED_HINTS = Map.of(
-		"collections", "/org/sandbox/jdt/triggerpattern/internal/collections.sandbox-hint",
-		"modernize-java11", "/org/sandbox/jdt/triggerpattern/internal/modernize-java11.sandbox-hint",
-		"modernize-java9", "/org/sandbox/jdt/triggerpattern/internal/modernize-java9.sandbox-hint",
-		"performance", "/org/sandbox/jdt/triggerpattern/internal/performance.sandbox-hint"
-	);
+	private static final Map<String, String> BUNDLED_HINTS = Map.ofEntries(
+			Map.entry("arrays", "/org/sandbox/jdt/triggerpattern/internal/arrays.sandbox-hint"), //$NON-NLS-1$ //$NON-NLS-2$
+			Map.entry("collection-performance", "/org/sandbox/jdt/triggerpattern/internal/collection-performance.sandbox-hint"), //$NON-NLS-1$ //$NON-NLS-2$
+			Map.entry("collections", "/org/sandbox/jdt/triggerpattern/internal/collections.sandbox-hint"), //$NON-NLS-1$ //$NON-NLS-2$
+			Map.entry("deprecations", "/org/sandbox/jdt/triggerpattern/internal/deprecations.sandbox-hint"), //$NON-NLS-1$ //$NON-NLS-2$
+			Map.entry("deprecated-api", "/org/sandbox/jdt/triggerpattern/internal/deprecations.sandbox-hint"), //$NON-NLS-1$ //$NON-NLS-2$
+			Map.entry("io-performance", "/org/sandbox/jdt/triggerpattern/internal/io-performance.sandbox-hint"), //$NON-NLS-1$ //$NON-NLS-2$
+			Map.entry("modernize-java11", "/org/sandbox/jdt/triggerpattern/internal/modernize-java11.sandbox-hint"), //$NON-NLS-1$ //$NON-NLS-2$
+			Map.entry("modernize-java9", "/org/sandbox/jdt/triggerpattern/internal/modernize-java9.sandbox-hint"), //$NON-NLS-1$ //$NON-NLS-2$
+			Map.entry("performance", "/org/sandbox/jdt/triggerpattern/internal/performance.sandbox-hint"), //$NON-NLS-1$ //$NON-NLS-2$
+			Map.entry("probable-bugs", "/org/sandbox/jdt/triggerpattern/internal/probable-bugs.sandbox-hint"), //$NON-NLS-1$ //$NON-NLS-2$
+			Map.entry("stream-performance", "/org/sandbox/jdt/triggerpattern/internal/stream-performance.sandbox-hint"), //$NON-NLS-1$ //$NON-NLS-2$
+			Map.entry("string-equals", "/org/sandbox/jdt/triggerpattern/internal/string-equals.sandbox-hint"), //$NON-NLS-1$ //$NON-NLS-2$
+			Map.entry("string-isblank", "/org/sandbox/jdt/triggerpattern/internal/string-isblank.sandbox-hint"), //$NON-NLS-1$ //$NON-NLS-2$
+			Map.entry("try-with-resources", "/org/sandbox/jdt/triggerpattern/internal/try-with-resources.sandbox-hint")); //$NON-NLS-1$ //$NON-NLS-2$
 
 	public static void main(String[] args) {
 		try {
 			int exitCode = run(args);
 			System.exit(exitCode);
 		} catch (Exception e) {
-			System.err.println("Error: " + e.getMessage());
+			System.err.println("Error: " + e.getMessage()); //$NON-NLS-1$
 			e.printStackTrace();
 			System.exit(1);
 		}
@@ -92,29 +102,29 @@ public class MiningCli {
 
 		for (int i = 0; i < args.length; i++) {
 			switch (args[i]) {
-			case "--config":
+			case "--config": //$NON-NLS-1$
 				configPath = args[++i];
 				break;
-			case "--hints":
+			case "--hints": //$NON-NLS-1$
 				hintsDir = args[++i];
 				break;
-			case "--repo":
+			case "--repo": //$NON-NLS-1$
 				repoUrl = args[++i];
 				break;
-			case "--output":
+			case "--output": //$NON-NLS-1$
 				outputDir = args[++i];
 				break;
-			case "--format":
+			case "--format": //$NON-NLS-1$
 				format = args[++i];
 				break;
-			case "--dry-run":
+			case "--dry-run": //$NON-NLS-1$
 				dryRun = true;
 				break;
-			case "--help":
+			case "--help": //$NON-NLS-1$
 				printUsage();
 				return 0;
 			default:
-				System.err.println("Unknown option: " + args[i]);
+				System.err.println("Unknown option: " + args[i]); //$NON-NLS-1$
 				printUsage();
 				return 1;
 			}
@@ -130,29 +140,31 @@ public class MiningCli {
 		} else {
 			config = new MiningConfig();
 		}
+		Map<String, String> compilerOptions = Map.of(COMPILER_SOURCE_OPTION, config.getSourceVersion());
 
 		// Override with ad-hoc repo if specified
 		List<RepoEntry> repos;
 		if (repoUrl != null) {
-			RepoEntry entry = new RepoEntry(repoUrl, "main", List.of());
+			RepoEntry entry = new RepoEntry(repoUrl, "main", List.of()); //$NON-NLS-1$
 			repos = List.of(entry);
 		} else {
 			repos = config.getRepositories();
 		}
 
 		if (repos.isEmpty()) {
-			System.err.println("No repositories to scan. Use --config or --repo.");
+			System.err.println("No repositories to scan. Use --config or --repo."); //$NON-NLS-1$
 			return 1;
 		}
 
 		// Load hint files
 		List<HintFile> hintFiles = loadHintFiles(config, hintsDir);
 		if (hintFiles.isEmpty()) {
-			System.err.println("No hint files found. Check your configuration.");
+			System.err.println("No hint files found. Check your configuration."); //$NON-NLS-1$
 			return 1;
 		}
 
-		System.out.println("Mining with " + hintFiles.size() + " hint file(s) against " + repos.size() + " repository(ies).");
+		System.out.println("Mining with " + hintFiles.size() + " hint file(s) against " + repos.size() //$NON-NLS-1$ //$NON-NLS-2$
+				+ " repository(ies), source level " + config.getSourceVersion() + '.'); //$NON-NLS-1$
 
 		// Set up scanner
 		StandaloneAstParser astParser = new StandaloneAstParser();
@@ -164,18 +176,19 @@ public class MiningCli {
 
 		for (RepoEntry repo : repos) {
 			String repoName = extractRepoName(repo.getUrl());
-			System.out.println("Scanning: " + repoName + " ...");
+			System.out.println("Scanning: " + repoName + " ..."); //$NON-NLS-1$ //$NON-NLS-2$
 
-			Path tempDir = Files.createTempDirectory("mining-" + repoName);
+			Path tempDir = Files.createTempDirectory("mining-" + repoName); //$NON-NLS-1$
 			try {
 				cloner.shallowClone(repo.getUrl(), repo.getBranch(), tempDir);
-				MiningReport repoReport = scanner.scan(repoName, tempDir, repo.getPaths(), hintFiles);
+				MiningReport repoReport = scanner.scan(repoName, tempDir, repo.getPaths(), hintFiles, compilerOptions);
 				totalReport.merge(repoReport);
 
 				int matchCount = repoReport.getMatches().size();
-				System.out.println("  Found " + matchCount + " match(es) in " + repoReport.getFileCounts().getOrDefault(repoName, 0) + " file(s).");
+				System.out.println("  Found " + matchCount + " match(es) in " //$NON-NLS-1$ //$NON-NLS-2$
+						+ repoReport.getFileCounts().getOrDefault(repoName, 0) + " file(s)."); //$NON-NLS-1$
 			} catch (Exception e) {
-				System.err.println("  Error scanning " + repoName + ": " + e.getMessage());
+				System.err.println("  Error scanning " + repoName + ": " + e.getMessage()); //$NON-NLS-1$ //$NON-NLS-2$
 				totalReport.addError(repoName, e.getMessage());
 				totalReport.addFileCount(repoName, 0);
 			} finally {
@@ -189,7 +202,7 @@ public class MiningCli {
 			writeReports(totalReport, output, format);
 		}
 
-		System.out.println("\nTotal: " + totalReport.getMatches().size() + " match(es) found.");
+		System.out.println("\nTotal: " + totalReport.getMatches().size() + " match(es) found."); //$NON-NLS-1$ //$NON-NLS-2$
 		return 0;
 	}
 
@@ -209,7 +222,7 @@ public class MiningCli {
 			Path hintsPath = Path.of(hintsDirOverride);
 			if (Files.isDirectory(hintsPath)) {
 				try (var stream = Files.walk(hintsPath)) {
-					List<Path> hintPaths = stream.filter(p -> p.toString().endsWith(".sandbox-hint")).toList();
+					List<Path> hintPaths = stream.filter(p -> p.toString().endsWith(".sandbox-hint")).toList(); //$NON-NLS-1$
 					for (Path p : hintPaths) {
 						String content = Files.readString(p, StandardCharsets.UTF_8);
 						hintFiles.add(parser.parse(content));
@@ -221,20 +234,20 @@ public class MiningCli {
 
 		// Load hints from configuration
 		for (String hint : config.getHints()) {
-			if (hint.startsWith("bundled:")) {
-				String name = hint.substring("bundled:".length());
+			if (hint.startsWith("bundled:")) { //$NON-NLS-1$
+				String name = hint.substring("bundled:".length()); //$NON-NLS-1$
 				HintFile hf = loadBundledHint(parser, name);
 				if (hf != null) {
 					hintFiles.add(hf);
 				}
-			} else if (hint.startsWith("path:")) {
-				String path = hint.substring("path:".length());
+			} else if (hint.startsWith("path:")) { //$NON-NLS-1$
+				String path = hint.substring("path:".length()); //$NON-NLS-1$
 				Path p = Path.of(path);
 				if (Files.isRegularFile(p)) {
 					String content = Files.readString(p, StandardCharsets.UTF_8);
 					hintFiles.add(parser.parse(content));
 				} else {
-					System.err.println("Warning: Hint file not found: " + path);
+					System.err.println("Warning: Hint file not found: " + path); //$NON-NLS-1$
 				}
 			} else {
 				// Try as bundled first, then as path
@@ -252,7 +265,7 @@ public class MiningCli {
 			}
 		}
 
-		// If no hints configured, load all bundled hints
+		// If no hints configured, load all bundled hints known to the mining CLI.
 		if (hintFiles.isEmpty()) {
 			for (String name : BUNDLED_HINTS.keySet()) {
 				HintFile hf = loadBundledHint(parser, name);
@@ -268,32 +281,32 @@ public class MiningCli {
 	private static HintFile loadBundledHint(HintFileParser parser, String name) {
 		String resourcePath = BUNDLED_HINTS.get(name);
 		if (resourcePath == null) {
-			System.err.println("Warning: Unknown bundled hint: " + name);
+			System.err.println("Warning: Unknown bundled hint: " + name); //$NON-NLS-1$
 			return null;
 		}
 		try (InputStream is = MiningCli.class.getResourceAsStream(resourcePath)) {
 			if (is == null) {
-				System.err.println("Warning: Bundled hint resource not found: " + resourcePath);
+				System.err.println("Warning: Bundled hint resource not found: " + resourcePath); //$NON-NLS-1$
 				return null;
 			}
 			try (Reader reader = new InputStreamReader(is, StandardCharsets.UTF_8)) {
 				return parser.parse(reader);
 			}
 		} catch (IOException e) {
-			System.err.println("Warning: Error loading bundled hint " + name + ": " + e.getMessage());
+			System.err.println("Warning: Error loading bundled hint " + name + ": " + e.getMessage()); //$NON-NLS-1$ //$NON-NLS-2$
 			return null;
 		} catch (HintParseException e) {
-			System.err.println("Warning: Error parsing bundled hint " + name + ": " + e.getMessage());
+			System.err.println("Warning: Error parsing bundled hint " + name + ": " + e.getMessage()); //$NON-NLS-1$ //$NON-NLS-2$
 			return null;
 		}
 	}
 
 	static String extractRepoName(String url) {
 		if (url == null) {
-			return "unknown";
+			return "unknown"; //$NON-NLS-1$
 		}
 		String name = url;
-		if (name.endsWith(".git")) {
+		if (name.endsWith(".git")) { //$NON-NLS-1$
 			name = name.substring(0, name.length() - 4);
 		}
 		int lastSlash = name.lastIndexOf('/');
@@ -307,49 +320,47 @@ public class MiningCli {
 		switch (format) {
 		case FORMAT_MARKDOWN:
 			new MarkdownReporter().write(report, outputDir);
-			System.out.println("Report written to " + outputDir.resolve("report.md"));
+			System.out.println("Report written to " + outputDir.resolve("report.md")); //$NON-NLS-1$ //$NON-NLS-2$
 			break;
 		case FORMAT_JSON:
 			new JsonReporter().write(report, outputDir);
-			System.out.println("Report written to " + outputDir.resolve("report.json"));
+			System.out.println("Report written to " + outputDir.resolve("report.json")); //$NON-NLS-1$ //$NON-NLS-2$
 			break;
 		case FORMAT_BOTH:
 		default:
 			new MarkdownReporter().write(report, outputDir);
 			new JsonReporter().write(report, outputDir);
-			System.out.println("Reports written to " + outputDir);
+			System.out.println("Reports written to " + outputDir); //$NON-NLS-1$
 			break;
 		}
 	}
 
 	private static void deleteDirectory(Path dir) {
+		if (dir == null || !Files.exists(dir)) {
+			return;
+		}
 		try {
-			if (Files.exists(dir)) {
-				try (var stream = Files.walk(dir)) {
-					stream.sorted(java.util.Comparator.reverseOrder()).forEach(p -> {
+			Files.walk(dir)
+					.sorted((a, b) -> b.compareTo(a)) // delete children first
+					.forEach(p -> {
 						try {
-							Files.delete(p);
+							Files.deleteIfExists(p);
 						} catch (IOException e) {
-							// Ignore cleanup errors
+							// ignore cleanup errors
 						}
 					});
-				}
-			}
 		} catch (IOException e) {
-			// Ignore cleanup errors
+			// ignore cleanup errors
 		}
 	}
 
 	private static void printUsage() {
-		System.out.println("Usage: java -jar sandbox-mining-cli.jar [options]");
-		System.out.println();
-		System.out.println("Options:");
-		System.out.println("  --config <path>    Path to repos.yml configuration file");
-		System.out.println("  --hints <dir>      Directory with .sandbox-hint files (overrides config)");
-		System.out.println("  --repo <url>       Single repo to scan (ad-hoc mode, overrides config)");
-		System.out.println("  --output <dir>     Output directory for reports (default: mining-results)");
-		System.out.println("  --format <fmt>     Report format: markdown|json|both (default: both)");
-		System.out.println("  --dry-run          Only count matches, don't generate candidate files");
-		System.out.println("  --help             Show this help message");
+		System.out.println("Usage: java -jar sandbox-mining-cli.jar [options]"); //$NON-NLS-1$
+		System.out.println("  --config <path>    Path to repos.yml configuration file"); //$NON-NLS-1$
+		System.out.println("  --hints <dir>      Directory with .sandbox-hint files"); //$NON-NLS-1$
+		System.out.println("  --repo <url>       Single repo to scan"); //$NON-NLS-1$
+		System.out.println("  --output <dir>     Output directory (default: mining-results)"); //$NON-NLS-1$
+		System.out.println("  --format <fmt>     markdown|json|both (default: both)"); //$NON-NLS-1$
+		System.out.println("  --dry-run          Only count matches"); //$NON-NLS-1$
 	}
 }

--- a/sandbox_mining_cli/src/main/java/org/sandbox/mining/config/MiningConfig.java
+++ b/sandbox_mining_cli/src/main/java/org/sandbox/mining/config/MiningConfig.java
@@ -32,6 +32,7 @@ public class MiningConfig {
 	private List<RepoEntry> repositories = Collections.emptyList();
 	private int maxFilesPerRepo = 5000;
 	private int timeoutPerRepoMinutes = 10;
+	private String sourceVersion = "1.8"; //$NON-NLS-1$
 
 	public MiningConfig() {
 	}
@@ -72,29 +73,29 @@ public class MiningConfig {
 			return config;
 		}
 
-		Map<String, Object> mining = (Map<String, Object>) root.get("mining");
+		Map<String, Object> mining = (Map<String, Object>) root.get("mining"); //$NON-NLS-1$
 		if (mining == null) {
 			return config;
 		}
 
 		// Parse hints
-		Object hintsObj = mining.get("hints");
+		Object hintsObj = mining.get("hints"); //$NON-NLS-1$
 		if (hintsObj instanceof List<?> hintsList) {
 			config.hints = hintsList.stream().map(Object::toString).toList();
 		}
 
 		// Parse repositories
-		Object reposObj = mining.get("repositories");
+		Object reposObj = mining.get("repositories"); //$NON-NLS-1$
 		if (reposObj instanceof List<?> reposList) {
 			config.repositories = reposList.stream().map(obj -> {
 				if (obj instanceof Map<?, ?> map) {
 					RepoEntry entry = new RepoEntry();
-					entry.setUrl((String) map.get("url"));
-					Object branchObj = map.get("branch");
+					entry.setUrl((String) map.get("url")); //$NON-NLS-1$
+					Object branchObj = map.get("branch"); //$NON-NLS-1$
 					if (branchObj != null) {
 						entry.setBranch(branchObj.toString());
 					}
-					Object pathsObj = map.get("paths");
+					Object pathsObj = map.get("paths"); //$NON-NLS-1$
 					if (pathsObj instanceof List<?> pathsList) {
 						entry.setPaths(pathsList.stream().map(Object::toString).toList());
 					}
@@ -105,15 +106,19 @@ public class MiningConfig {
 		}
 
 		// Parse settings
-		Object settingsObj = mining.get("settings");
+		Object settingsObj = mining.get("settings"); //$NON-NLS-1$
 		if (settingsObj instanceof Map<?, ?> settings) {
-			Object maxFiles = settings.get("max-files-per-repo");
+			Object maxFiles = settings.get("max-files-per-repo"); //$NON-NLS-1$
 			if (maxFiles instanceof Number n) {
 				config.maxFilesPerRepo = n.intValue();
 			}
-			Object timeout = settings.get("timeout-per-repo-minutes");
+			Object timeout = settings.get("timeout-per-repo-minutes"); //$NON-NLS-1$
 			if (timeout instanceof Number n) {
 				config.timeoutPerRepoMinutes = n.intValue();
+			}
+			Object source = settings.get("source-version"); //$NON-NLS-1$
+			if (source != null && !source.toString().isBlank()) {
+				config.sourceVersion = source.toString();
 			}
 		}
 
@@ -150,5 +155,13 @@ public class MiningConfig {
 
 	public void setTimeoutPerRepoMinutes(int timeoutPerRepoMinutes) {
 		this.timeoutPerRepoMinutes = timeoutPerRepoMinutes;
+	}
+
+	public String getSourceVersion() {
+		return sourceVersion;
+	}
+
+	public void setSourceVersion(String sourceVersion) {
+		this.sourceVersion = sourceVersion != null && !sourceVersion.isBlank() ? sourceVersion : "1.8"; //$NON-NLS-1$
 	}
 }

--- a/sandbox_mining_cli/src/main/java/org/sandbox/mining/config/MiningConfig.java
+++ b/sandbox_mining_cli/src/main/java/org/sandbox/mining/config/MiningConfig.java
@@ -117,8 +117,11 @@ public class MiningConfig {
 				config.timeoutPerRepoMinutes = n.intValue();
 			}
 			Object source = settings.get("source-version"); //$NON-NLS-1$
-			if (source != null && !source.toString().isBlank()) {
-				config.sourceVersion = source.toString();
+			if (source != null) {
+				String trimmedSource = source.toString().trim();
+				if (!trimmedSource.isBlank()) {
+					config.sourceVersion = trimmedSource;
+				}
 			}
 		}
 
@@ -162,6 +165,7 @@ public class MiningConfig {
 	}
 
 	public void setSourceVersion(String sourceVersion) {
-		this.sourceVersion = sourceVersion != null && !sourceVersion.isBlank() ? sourceVersion : "1.8"; //$NON-NLS-1$
+		String trimmedSource = sourceVersion != null ? sourceVersion.trim() : ""; //$NON-NLS-1$
+		this.sourceVersion = !trimmedSource.isBlank() ? trimmedSource : "1.8"; //$NON-NLS-1$
 	}
 }

--- a/sandbox_mining_cli/src/main/java/org/sandbox/mining/scanner/SourceScanner.java
+++ b/sandbox_mining_cli/src/main/java/org/sandbox/mining/scanner/SourceScanner.java
@@ -22,6 +22,7 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.sandbox.jdt.triggerpattern.api.BatchTransformationProcessor;
@@ -34,6 +35,8 @@ import org.sandbox.mining.report.MiningReport;
  * Scans directories for Java source files and runs transformation rules against them.
  */
 public class SourceScanner {
+
+	private static final Map<String, String> NO_COMPILER_OPTIONS = Map.of();
 
 	private final StandaloneAstParser parser;
 	private final int maxFiles;
@@ -81,7 +84,7 @@ public class SourceScanner {
 					if (javaFiles.size() >= maxFiles) {
 						return FileVisitResult.TERMINATE;
 					}
-					if (file.toString().endsWith(".java")) {
+					if (file.toString().endsWith(".java")) { //$NON-NLS-1$
 						javaFiles.add(file);
 					}
 					return FileVisitResult.CONTINUE;
@@ -98,7 +101,7 @@ public class SourceScanner {
 	}
 
 	/**
-	 * Scans all Java files using the given hint file and produces a mining report.
+	 * Scans all Java files using the given hint files and produces a mining report.
 	 *
 	 * @param repoName  name of the repository being scanned
 	 * @param rootDir   the root directory of the cloned repository
@@ -109,37 +112,57 @@ public class SourceScanner {
 	 */
 	public MiningReport scan(String repoName, Path rootDir, List<String> subPaths, List<HintFile> hintFiles)
 			throws IOException {
-			MiningReport report = new MiningReport();
-			List<Path> javaFiles = findJavaFiles(rootDir, subPaths);
-			report.addFileCount(repoName, javaFiles.size());
+		return scan(repoName, rootDir, subPaths, hintFiles, NO_COMPILER_OPTIONS);
+	}
 
-			for (HintFile hintFile : hintFiles) {
-				BatchTransformationProcessor processor = new BatchTransformationProcessor(hintFile);
+	/**
+	 * Scans all Java files using the given hint files and compiler options, producing
+	 * a mining report. Compiler options are forwarded to guard evaluation so rules
+	 * such as {@code sourceVersionGE(11)} behave like they do in Eclipse cleanup
+	 * execution.
+	 *
+	 * @param repoName        name of the repository being scanned
+	 * @param rootDir         the root directory of the cloned repository
+	 * @param subPaths        optional sub-paths to restrict scanning to
+	 * @param hintFiles       list of parsed hint files to apply
+	 * @param compilerOptions compiler options for guard evaluation
+	 * @return the mining report with all matches
+	 * @throws IOException if file reading fails
+	 */
+	public MiningReport scan(String repoName, Path rootDir, List<String> subPaths, List<HintFile> hintFiles,
+			Map<String, String> compilerOptions) throws IOException {
+		MiningReport report = new MiningReport();
+		Map<String, String> effectiveCompilerOptions = compilerOptions != null ? compilerOptions : NO_COMPILER_OPTIONS;
+		List<Path> javaFiles = findJavaFiles(rootDir, subPaths);
+		report.addFileCount(repoName, javaFiles.size());
 
-				for (Path javaFile : javaFiles) {
-					String source = Files.readString(javaFile, StandardCharsets.UTF_8);
-					CompilationUnit cu = parser.parse(source);
-					List<TransformationResult> results = processor.process(cu);
+		for (HintFile hintFile : hintFiles) {
+			BatchTransformationProcessor processor = new BatchTransformationProcessor(hintFile);
 
-					for (TransformationResult result : results) {
-						String relativePath = rootDir.relativize(javaFile).toString();
-						int line = cu.getLineNumber(result.match().getOffset());
-						String hintFileName = hintFile.getId() != null ? hintFile.getId() : "unknown";
-						TransformationRule rule = result.rule();
-						String ruleName = rule.getDescription();
-						if (ruleName == null) {
-							ruleName = rule.getRuleId();
-						}
-						if (ruleName == null) {
-							int ruleIndex = hintFile.getRules().indexOf(rule);
-							ruleName = ruleIndex >= 0 ? hintFileName + (ruleIndex + 1) : hintFileName;
-						}
-						report.addMatch(repoName, hintFileName, ruleName, relativePath, line, result.matchedText(),
-								result.hasReplacement() ? result.replacement() : null);
+			for (Path javaFile : javaFiles) {
+				String source = Files.readString(javaFile, StandardCharsets.UTF_8);
+				CompilationUnit cu = parser.parse(source);
+				List<TransformationResult> results = processor.process(cu, effectiveCompilerOptions);
+
+				for (TransformationResult result : results) {
+					String relativePath = rootDir.relativize(javaFile).toString();
+					int line = cu.getLineNumber(result.match().getOffset());
+					String hintFileName = hintFile.getId() != null ? hintFile.getId() : "unknown"; //$NON-NLS-1$
+					TransformationRule rule = result.rule();
+					String ruleName = rule.getRuleId();
+					if (ruleName == null || ruleName.isBlank()) {
+						ruleName = rule.getDescription();
 					}
+					if (ruleName == null || ruleName.isBlank()) {
+						int ruleIndex = hintFile.getRules().indexOf(rule);
+						ruleName = ruleIndex >= 0 ? hintFileName + (ruleIndex + 1) : hintFileName;
+					}
+					report.addMatch(repoName, hintFileName, ruleName, relativePath, line, result.matchedText(),
+							result.hasReplacement() ? result.replacement() : null);
 				}
 			}
+		}
 
-			return report;
+		return report;
 	}
 }

--- a/sandbox_mining_cli/src/test/java/org/sandbox/mining/config/MiningConfigTest.java
+++ b/sandbox_mining_cli/src/test/java/org/sandbox/mining/config/MiningConfigTest.java
@@ -56,4 +56,26 @@ class MiningConfigTest {
 
 		assertEquals("1.8", config.getSourceVersion()); //$NON-NLS-1$
 	}
+
+	@Test
+	void trimsConfiguredSourceVersion() {
+		String yaml = """
+				mining:
+				  settings:
+				    source-version: " 21 "
+				"""; //$NON-NLS-1$
+
+		MiningConfig config = MiningConfig.parse(new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+
+		assertEquals("21", config.getSourceVersion()); //$NON-NLS-1$
+	}
+
+	@Test
+	void trimsSourceVersionSetterInput() {
+		MiningConfig config = new MiningConfig();
+
+		config.setSourceVersion(" 21 "); //$NON-NLS-1$
+
+		assertEquals("21", config.getSourceVersion()); //$NON-NLS-1$
+	}
 }

--- a/sandbox_mining_cli/src/test/java/org/sandbox/mining/config/MiningConfigTest.java
+++ b/sandbox_mining_cli/src/test/java/org/sandbox/mining/config/MiningConfigTest.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Carsten Hammer
+ *******************************************************************************/
+package org.sandbox.mining.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+class MiningConfigTest {
+
+	@Test
+	void parsesConfiguredSourceVersionForGuardEvaluation() {
+		String yaml = """
+				mining:
+				  settings:
+				    source-version: "21"
+				"""; //$NON-NLS-1$
+
+		MiningConfig config = MiningConfig.parse(new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+
+		assertEquals("21", config.getSourceVersion()); //$NON-NLS-1$
+	}
+
+	@Test
+	void defaultsSourceVersionToJava8WhenUnspecified() {
+		String yaml = """
+				mining:
+				  settings:
+				    max-files-per-repo: 10
+				"""; //$NON-NLS-1$
+
+		MiningConfig config = MiningConfig.parse(new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+
+		assertEquals("1.8", config.getSourceVersion()); //$NON-NLS-1$
+	}
+}

--- a/sandbox_mining_cli/src/test/java/org/sandbox/mining/config/MiningConfigTest.java
+++ b/sandbox_mining_cli/src/test/java/org/sandbox/mining/config/MiningConfigTest.java
@@ -47,4 +47,13 @@ class MiningConfigTest {
 
 		assertEquals("1.8", config.getSourceVersion()); //$NON-NLS-1$
 	}
+
+	@Test
+	void defaultsSourceVersionToJava8WhenBlank() {
+		MiningConfig config = new MiningConfig();
+
+		config.setSourceVersion(" "); //$NON-NLS-1$
+
+		assertEquals("1.8", config.getSourceVersion()); //$NON-NLS-1$
+	}
 }

--- a/sandbox_mining_cli/src/test/java/org/sandbox/mining/scanner/SourceScannerTest.java
+++ b/sandbox_mining_cli/src/test/java/org/sandbox/mining/scanner/SourceScannerTest.java
@@ -51,6 +51,8 @@ class SourceScannerTest {
 				StandardCharsets.UTF_8);
 		HintFile hintFile = new HintFileParser().parse("""
 				<!id: source-version-test>
+				@id: source-version-test.empty-list
+				@severity: info
 				java.util.Collections.emptyList() :: sourceVersionGE(9)
 				=> java.util.List.of()
 				;;
@@ -64,6 +66,6 @@ class SourceScannerTest {
 
 		assertEquals(0, java8Report.getMatches().size());
 		assertEquals(1, java21Report.getMatches().size());
-		assertEquals("source-version-test1", java21Report.getMatches().get(0).ruleName()); //$NON-NLS-1$
+		assertEquals("source-version-test.empty-list", java21Report.getMatches().get(0).ruleName()); //$NON-NLS-1$
 	}
 }

--- a/sandbox_mining_cli/src/test/java/org/sandbox/mining/scanner/SourceScannerTest.java
+++ b/sandbox_mining_cli/src/test/java/org/sandbox/mining/scanner/SourceScannerTest.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Carsten Hammer
+ *******************************************************************************/
+package org.sandbox.mining.scanner;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.jdt.core.JavaCore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.sandbox.jdt.triggerpattern.api.GuardFunction;
+import org.sandbox.jdt.triggerpattern.api.GuardFunctionResolverHolder;
+import org.sandbox.jdt.triggerpattern.api.HintFile;
+import org.sandbox.jdt.triggerpattern.internal.BuiltInGuards;
+import org.sandbox.jdt.triggerpattern.internal.HintFileParser;
+import org.sandbox.mining.report.MiningReport;
+
+class SourceScannerTest {
+
+	@TempDir
+	Path tempDir;
+
+	@BeforeEach
+	void setUp() {
+		java.util.HashMap<String, GuardFunction> guards = new java.util.HashMap<>();
+		BuiltInGuards.registerAll(guards);
+		GuardFunctionResolverHolder.setResolver(guards::get);
+	}
+
+	@Test
+	void forwardsCompilerOptionsToSourceVersionGuards() throws Exception {
+		Files.writeString(tempDir.resolve("Test.java"), //$NON-NLS-1$
+				"class Test { Object m() { return java.util.Collections.emptyList(); } }", //$NON-NLS-1$
+				StandardCharsets.UTF_8);
+		HintFile hintFile = new HintFileParser().parse("""
+				<!id: source-version-test>
+				java.util.Collections.emptyList() :: sourceVersionGE(9)
+				=> java.util.List.of()
+				;;
+				"""); //$NON-NLS-1$
+		SourceScanner scanner = new SourceScanner(new StandaloneAstParser(), 100);
+
+		MiningReport java8Report = scanner.scan("repo", tempDir, List.of(), List.of(hintFile), //$NON-NLS-1$
+				Map.of(JavaCore.COMPILER_SOURCE, "1.8")); //$NON-NLS-1$
+		MiningReport java21Report = scanner.scan("repo", tempDir, List.of(), List.of(hintFile), //$NON-NLS-1$
+				Map.of(JavaCore.COMPILER_SOURCE, "21")); //$NON-NLS-1$
+
+		assertEquals(0, java8Report.getMatches().size());
+		assertEquals(1, java21Report.getMatches().size());
+		assertEquals("source-version-test1", java21Report.getMatches().get(0).ruleName()); //$NON-NLS-1$
+	}
+}


### PR DESCRIPTION
## Summary

This PR addresses the quality issues exposed by mining report PR #1177.

### Hint quality changes

- Removes broad diamond-only `ArrayList` / `HashSet` / `Hashtable` constructor rewrites from the active `collections` hint bundle.
- Keeps only guarded empty collection factory rewrites in `collections`.
- Makes Java 9/16 modernization hints conservative by turning behaviour-changing cases into hint-only review findings.
- Fixes deprecated wrapper-constructor replacements to use `valueOf(...)` instead of changing object-producing constructors into primitive parsers.
- Adds stable rule IDs to several active performance/deprecation hints so reports no longer fall back to names like `collections7`.
- Removes duplicate reflexive string-equals findings from `string-equals`; those belong to `probable-bugs`.

### Mining pipeline changes

- Loads the curated bundled hints referenced by `.github/refactoring-mining/repos.yml`.
- Forwards configured compiler source level into guard evaluation, so `sourceVersionGE(...)` behaves deterministically during mining.
- Uses rule IDs before descriptions in generated mining reports.
- Excludes broad style-only `collections` from the nightly mining configuration.

## Context

PR #1177 showed that the previous setup rewarded high match count over actionable findings. Most results came from repeated collection modernization patterns such as `new ArrayList(...) -> new java.util.ArrayList<>(...)`, including overlapping no-arg and variadic constructor rules. This PR reduces that noise and makes future reports better suited for triage into DSL-based quickfix work.