### PR TITLE
Detect and migrate safe int-state if/else patterns to enums

### DIFF
--- a/sandbox_int_to_enum/ARCHITECTURE.md
+++ b/sandbox_int_to_enum/ARCHITECTURE.md
@@ -1,203 +1,169 @@
-# Architecture: Int to Enum/Switch Refactoring Plugin
+# Architecture: Int-to-Enum Refactoring
 
-## Overview
+## Purpose
 
-This plugin provides a cleanup that automatically refactors integer constant-based if-else chains into enum-based switch statements. This transformation improves code maintainability, type safety, and readability.
+The plugin identifies legacy Java designs in which integers encode a finite state domain and replaces provably safe cases with an enum.
 
-## Problem Statement
+This is a semantic refactoring rather than a textual pattern replacement. Integer constants may represent states, bit masks, protocol values, persisted identifiers, error codes, array indexes, or arithmetic values. A valid migration must therefore prove how declarations and values flow through the program before changing their type.
 
-Code that uses integer constants in if-else chains is less type-safe and harder to maintain:
+## Transformation layers
+
+### 1. Conservative single-file cleanup
+
+The existing Eclipse cleanup extension receives one `CleanUpContext` for one compilation unit and returns an `ICleanUpFix`. The if/else implementation therefore accepts only candidates whose complete relevant data flow is local and private.
+
+Current safe candidate:
 
 ```java
-public static final int STATUS_PENDING = 0;
-public static final int STATUS_APPROVED = 1;
-public static final int STATUS_REJECTED = 2;
+private static final int STATUS_PENDING = 0;
+private static final int STATUS_APPROVED = 1;
 
-public void handleStatus(int status) {
+private void process(int status) {
     if (status == STATUS_PENDING) {
-        // handle pending
+        handlePending();
     } else if (status == STATUS_APPROVED) {
-        // handle approved
-    } else if (status == STATUS_REJECTED) {
-        // handle rejected
+        handleApproved();
     }
 }
 ```
 
-## Solution
+The detector validates bindings, constant values, all parameter references, all constant references, and every call to the private method. It then generates a private nested enum and rewrites the proven call sites and comparisons.
 
-The plugin transforms integer constant-based code in two ways:
+The if/else structure is preserved. Conversion to switch is not required for type safety and can introduce control-flow hazards involving unlabeled `break`, `continue`, abrupt completion, or unreachable statements.
 
-### 1. Switch with int constants → Switch with enum (Implemented)
+### 2. Existing switch prototype
 
-When code already has a switch statement using int constants:
+`SwitchIntToEnumHelper` detects integer switch cases and creates a nested enum. It predates the conservative if/else detector and still requires hardening so that it applies the same whole-reference and API-visibility safety rules.
+
+### 3. Future project-wide refactoring
+
+Public and package-visible constants, interface methods, overridden methods, fields, return values, and callers in other files require coordinated multi-file changes.
+
+There are two viable integration paths:
+
+- a new multi-file cleanup lifecycle in JDT UI; or
+- a dedicated LTK `Refactoring` contributed by this plugin.
+
+A dedicated refactoring can be implemented outside JDT UI and return an LTK `CompositeChange`. Appearing as a standard item in the Java Clean Up profile requires JDT UI infrastructure because the current `ICleanUpFix` contract is compilation-unit based.
+
+## Package structure
+
+### `org.sandbox.jdt.internal.corext.fix`
+
+- `IntToEnumFixCore` selects the transformation helper and creates rewrite operations.
+
+### `org.sandbox.jdt.internal.corext.fix.helper`
+
+- `AbstractTool<T>` defines detection, rewrite, and preview hooks.
+- `IntToEnumHelper` implements conservative binding-based if/else detection and migration.
+- `SwitchIntToEnumHelper` implements the existing switch prototype.
+
+### `org.sandbox.jdt.internal.ui.fix`
+
+- `IntToEnumCleanUp` is the UI wrapper.
+- `IntToEnumCleanUpCore` integrates with the single-file cleanup lifecycle.
+
+### `org.sandbox.jdt.internal.ui.preferences.cleanup`
+
+Contains the cleanup profile and save-action configuration UI.
+
+## If/else candidate analysis
+
+### Constant group discovery
+
+The current single-file detector collects fields that are:
+
+- `private`;
+- `static`;
+- `final`;
+- primitive `int`;
+- compile-time constants with an `Integer` value.
+
+Candidate constants must share an underscore-delimited prefix, such as `STATUS_`. The prefix produces the enum type name and the suffix produces each enum constant name.
+
+The detector rejects:
+
+- fewer than two constants;
+- duplicate numeric values;
+- invalid generated identifiers;
+- a generated enum name that conflicts with an existing nested type.
+
+### State-carrier discovery
+
+The recognised state carrier is currently a plain `int` parameter of a private method. Every branch condition in the root if/else-if chain must be an equality comparison between the same parameter binding and one of the constant bindings. Operand order may be reversed.
+
+Examples accepted by the condition matcher:
 
 ```java
-public static final int STATUS_PENDING = 0;
-public static final int STATUS_APPROVED = 1;
-public static final int STATUS_REJECTED = 2;
-
-public void handleStatus(int status) {
-    switch (status) {
-        case STATUS_PENDING:
-            // handle pending
-            break;
-        case STATUS_APPROVED:
-            // handle approved
-            break;
-        case STATUS_REJECTED:
-            // handle rejected
-            break;
-    }
-}
+status == STATUS_PENDING
+STATUS_APPROVED == status
 ```
 
-Is transformed into:
+More complex boolean expressions are rejected rather than partially rewritten.
 
-```java
-public enum Status {
-    PENDING, APPROVED, REJECTED
-}
+### Whole-reference validation
 
-public void handleStatus(Status status) {
-    switch (status) {
-        case PENDING:
-            // handle pending
-            break;
-        case APPROVED:
-            // handle approved
-            break;
-        case REJECTED:
-            // handle rejected
-            break;
-    }
-}
-```
+Before producing a rewrite operation, the detector traverses the complete compilation unit and proves that:
 
-### 2. If-else chain with int constants → Switch with enum (Planned)
+- the state parameter is referenced only by the recognised comparisons;
+- group constants are referenced only by their declarations, recognised comparisons, and proven call arguments;
+- every call to the private method passes a constant from the group;
+- the method is not used through a method reference or another unsupported construct.
 
-When code uses if-else chains comparing against int constants:
+A single unsupported reference rejects the entire candidate. The cleanup never performs a partial migration.
 
-```java
-public static final int STATUS_PENDING = 0;
-public static final int STATUS_APPROVED = 1;
-public static final int STATUS_REJECTED = 2;
+### Rewrite
 
-public void handleStatus(int status) {
-    if (status == STATUS_PENDING) {
-        // handle pending
-    } else if (status == STATUS_APPROVED) {
-        // handle approved
-    } else if (status == STATUS_REJECTED) {
-        // handle rejected
-    }
-}
-```
+For an accepted candidate, one `CompilationUnitRewriteOperationWithSourceRange`:
 
-Will be transformed into an enum with switch statement (not yet implemented).
+1. inserts a private nested enum before the first migrated field;
+2. removes complete constant field declarations or only the migrated fragments;
+3. changes the private method parameter from `int` to the enum type;
+4. replaces constant references in comparisons with qualified enum constants;
+5. replaces every proven call argument with the corresponding enum constant.
 
-## Implementation Design
+The edit remains one compilation-unit change and participates in normal cleanup preview and undo.
 
-### Package Structure
+## Why public API migration is different
 
-Following the standard Eclipse JDT cleanup plugin pattern with helper structure:
+A source file cannot prove that a public constant or method is unused elsewhere. Binary clients may also depend on compile-time inlined constants or an integer method signature. A project-wide migration must consider:
 
-- `org.sandbox.jdt.internal.corext.fix` - Core transformation logic
-  - `IntToEnumFixCore` - Enum containing transformation operations following JfaceCleanUpFixCore pattern
-  - Uses helper pattern for transformation logic
-  - Uses ReferenceHolder from sandbox_common for tracking patterns
+- JDT search results across source roots;
+- method hierarchies, interfaces, overrides, and implementations;
+- callers, assignments, fields, locals, return values, and method references;
+- persisted and wire-format integer values;
+- reflection, JNI, generated code, and external binaries;
+- compatibility adapters or deprecated bridge constants.
 
-- `org.sandbox.jdt.internal.corext.fix.helper` - Helper classes for transformation
-  - `AbstractTool<T>` - Base class with common helper methods (addImport, getUsedVariableNames)
-  - `IntToEnumHelper` - If-else chain transformation logic (placeholder)
-  - `SwitchIntToEnumHelper` - Switch statement transformation logic (implemented)
-  - `IntConstantHolder` - Data structure for tracking int constants and their usage
+This analysis must finish before any edit is applied, and all edits should be presented and committed as one atomic `CompositeChange`.
 
-- `org.sandbox.jdt.internal.ui.fix` - UI wrapper
-  - `IntToEnumCleanUp` - Wrapper class extending AbstractCleanUpCoreWrapper
-  - `IntToEnumCleanUpCore` - Core cleanup implementation using CompilationUnitRewriteOperationWithSourceRange
+## Reusable future model
 
-- `org.sandbox.jdt.internal.ui.preferences.cleanup` - UI configuration
-  - `SandboxCodeTabPage` - Configuration UI
-  - `DefaultCleanUpOptionsInitializer` - Default options
-  - `SaveActionCleanUpOptionsInitializer` - Save action options
+The next architectural step is to extract candidate discovery from `IntToEnumHelper` into a reusable semantic model containing:
 
-### Detection Pattern
+- constant group and numeric-value semantics;
+- state carriers;
+- comparison and switch sites;
+- producer and consumer edges;
+- required edits per compilation unit;
+- explicit rejection reasons and confidence level.
 
-The plugin detects:
-1. Multiple `static final int` constants in the same class with a common name prefix
-2. Switch statements that use these constants as case labels (SWITCH_INT_TO_ENUM)
-3. If-else chains that compare a variable against these constants (IF_ELSE_TO_SWITCH, planned)
+That model can support:
 
-### Transformation Steps
-
-#### SWITCH_INT_TO_ENUM (Implemented)
-1. **Detect Constants**: Find `static final int` field declarations
-2. **Find Switch Statements**: Locate switch statements referencing these constants as case labels
-3. **Validate**: Ensure at least 2 constants with a common prefix are used
-4. **Create Enum**: Generate enum type from constant names (prefix → enum name, suffix → value)
-5. **Replace Fields**: Remove old int constant field declarations
-6. **Update Cases**: Replace constant references in switch cases with enum values
-7. **Update Types**: Change method parameter types from int to the new enum type
-
-#### IF_ELSE_TO_SWITCH (Planned)
-1. **Detect Pattern**: Find int constants used in if-else chains using AST visitors
-2. **Analyze Scope**: Determine which constants belong together
-3. **Create Enum**: Generate enum type with appropriate name and values
-4. **Convert If-Else to Switch**: Transform if-else chain into switch statement using enum
-5. **Update Variable Types**: Change parameter/variable types from int to enum
-
-### Helper Pattern Implementation
-
-Following the established pattern from JFaceCleanUpFixCore:
-
-- **IntToEnumFixCore enum** holds AbstractTool instances (IntToEnumHelper, SwitchIntToEnumHelper)
-- **ReferenceHolder<Integer, IntConstantHolder>** from sandbox_common stores found patterns
-- **AbstractTool.find()** discovers patterns and creates CompilationUnitRewriteOperationWithSourceRange
-- **AbstractTool.rewrite()** performs the actual AST transformation
-- **TightSourceRangeComputer** ensures proper source range tracking for refactoring
-
-This pattern provides:
-- Clear separation of concerns (detection vs transformation)
-- Reusability of common utilities from sandbox_common
-- Consistency with other cleanup plugins in the repository
-- Type-safe tracking of transformation candidates
-
-### Constraints and Limitations
-
-- Only processes constants defined in the same compilation unit
-- Requires at least 2 constants with a common prefix to trigger
-- Constants must share a common underscore-delimited prefix (e.g., `STATUS_*`)
-- Does not process constants used in other contexts (arithmetic, etc.)
-- Conservative approach - only transforms obvious cases
-
-## Eclipse JDT Integration
-
-This plugin follows the standard pattern for Eclipse JDT cleanups:
-
-1. Registered via `org.eclipse.jdt.ui.cleanUps` extension point
-2. Integrates with Eclipse's cleanup framework
-3. Can be enabled in cleanup preferences
-4. Can be used as a save action
+- the conservative cleanup;
+- a report-only inspection or marker;
+- a quick assist for one candidate;
+- a project-wide LTK refactoring;
+- future JDT UI multi-file cleanup integration.
 
 ## Portability to Eclipse JDT
 
-The package structure maps directly to Eclipse JDT internal packages:
-- `org.sandbox.jdt.internal.*` → `org.eclipse.jdt.internal.*`
-
-When porting to Eclipse JDT:
-1. Replace package names
-2. Merge constants into `CleanUpConstants`
-3. Update extension point registrations
-4. Add tests to JDT test suite
+The helper and candidate-analysis code can be moved from `org.sandbox.jdt.internal.*` to the corresponding JDT internal packages. Standard cleanup-profile integration for project-wide candidates additionally needs a JDT UI API and lifecycle change. The dedicated-refactoring approach does not.
 
 ## Dependencies
 
-- Eclipse JDT Core - AST manipulation
-- Eclipse JDT UI - Cleanup framework integration
-- Eclipse JDT Core Manipulation - Rewrite operations
-- sandbox_common - Shared constants and utilities
-
-## Future Enhancements
-
-See TODO.md for planned improvements and known limitations.
+- Eclipse JDT Core DOM and bindings
+- Eclipse JDT Core Manipulation rewrite infrastructure
+- Eclipse JDT UI cleanup APIs
+- Eclipse LTK refactoring framework
+- `sandbox_common` helper infrastructure

--- a/sandbox_int_to_enum/ARCHITECTURE.md
+++ b/sandbox_int_to_enum/ARCHITECTURE.md
@@ -8,11 +8,9 @@ This is a semantic refactoring rather than a textual pattern replacement. Intege
 
 ## Transformation layers
 
-### 1. Conservative single-file cleanup
+### 1. Implemented local detector
 
-The existing Eclipse cleanup extension receives one `CleanUpContext` for one compilation unit and returns an `ICleanUpFix`. The if/else implementation therefore accepts only candidates whose complete relevant data flow is local and private.
-
-Current safe candidate:
+The first implementation recognises candidates whose complete relevant data flow is contained in one compilation unit and is private.
 
 ```java
 private static final int STATUS_PENDING = 0;
@@ -31,26 +29,53 @@ The detector validates bindings, constant values, all parameter references, all 
 
 The if/else structure is preserved. Conversion to switch is not required for type safety and can introduce control-flow hazards involving unlabeled `break`, `continue`, abrupt completion, or unreachable statements.
 
-### 2. Existing switch prototype
+### 2. Selected-scope multi-file cleanup
 
-`SwitchIntToEnumHelper` detects integer switch cases and creates a nested enum. It predates the conservative if/else detector and still requires hardening so that it applies the same whole-reference and API-visibility safety rules.
+The standard cleanup API is per-file only at the final edit boundary, but its lifecycle is project-aware:
 
-### 3. Future project-wide refactoring
+1. `ICleanUp.checkPreConditions(IJavaProject, ICompilationUnit[], ...)` receives every compilation unit selected for the project.
+2. The same cleanup instance is invoked later through `createFix(CleanUpContext)` for each target unit.
+3. Each fix returns a local `CompilationUnitChange`.
+4. `CleanUpRefactoring` collects all local changes into one LTK change tree, validates all modified resources, previews them together, and applies and undoes them atomically.
 
-Public and package-visible constants, interface methods, overridden methods, fields, return values, and callers in other files require coordinated multi-file changes.
+Consequently, a project-wide semantic plan can be calculated without changing JDT UI when all affected compilation units are already selected. The cleanup stores an immutable plan keyed by Java project, then emits only the current file's part of that plan from `createFix`.
 
-There are two viable integration paths:
+The plan must store stable Java element handles, binding keys, and semantic edit descriptors rather than retaining AST nodes between parser passes. The current AST may already include edits from earlier cleanups in the fixpoint pipeline, so every planned edit must be re-resolved and validated before it is emitted.
 
-- a new multi-file cleanup lifecycle in JDT UI; or
-- a dedicated LTK `Refactoring` contributed by this plugin.
+### 3. Automatic target-scope expansion
 
-A dedicated refactoring can be implemented outside JDT UI and return an LTK `CompositeChange`. Appearing as a standard item in the Java Clean Up profile requires JDT UI infrastructure because the current `ICleanUpFix` contract is compilation-unit based.
+The existing lifecycle cannot add compilation units that were not part of the original cleanup selection. This matters when cleanup starts on one class or package but analysis discovers callers, interfaces, implementations, suites, or shared helpers elsewhere in the project.
+
+A minimal patched `org.eclipse.jdt.ui` bundle can extend `CleanUpRefactoring` before precondition checking:
+
+1. detect cleanups implementing a Sandbox-owned scope-provider SPI;
+2. request additional related compilation units;
+3. compute a transitive, deduplicated target closure;
+4. add those units to the existing target set;
+5. continue through the unchanged precondition, batch parser, working-copy fixpoint, overlap handling, preview, validation, apply, and undo pipeline.
+
+Example experimental SPI in `sandbox_common`:
+
+```java
+public interface IMultiFileCleanUpScopeProvider {
+    Collection<ICompilationUnit> expandScope(
+        IJavaProject project,
+        Collection<ICompilationUnit> initialScope,
+        IProgressMonitor monitor) throws CoreException;
+}
+```
+
+This approach is deliberately narrower than making a cleanup return an arbitrary `CompositeChange`. The current cleanup refactoring already knows how to combine per-file changes correctly; the missing capability is mainly target discovery.
+
+### 4. Dedicated LTK refactoring
+
+A dedicated refactoring remains useful when the operation needs interactive choices such as enum naming, compatibility bridge methods, preservation of integer adapters, persistence mappings, or partial/excluded source roots. It is not required merely to coordinate edits across Java files already included in a cleanup run.
 
 ## Package structure
 
 ### `org.sandbox.jdt.internal.corext.fix`
 
-- `IntToEnumFixCore` selects the transformation helper and creates rewrite operations.
+- `IntToEnumFixCore` selects transformation helpers and creates rewrite operations.
 
 ### `org.sandbox.jdt.internal.corext.fix.helper`
 
@@ -61,17 +86,25 @@ A dedicated refactoring can be implemented outside JDT UI and return an LTK `Com
 ### `org.sandbox.jdt.internal.ui.fix`
 
 - `IntToEnumCleanUp` is the UI wrapper.
-- `IntToEnumCleanUpCore` integrates with the single-file cleanup lifecycle.
+- `IntToEnumCleanUpCore` integrates with the cleanup lifecycle.
 
-### `org.sandbox.jdt.internal.ui.preferences.cleanup`
+### `sandbox_common`
 
-Contains the cleanup profile and save-action configuration UI.
+The planned multi-file infrastructure should live here so it can be shared by `sandbox_int_to_enum`, `sandbox_junit_cleanup`, and later migrations.
+
+Proposed reusable concepts:
+
+- `AbstractPlannedMultiFileCleanUp<P>` or an equivalent composition-based coordinator;
+- `PlanResult<P>` containing an immutable plan and `RefactoringStatus`;
+- per-compilation-unit edit descriptors;
+- explicit rejection diagnostics;
+- optional `IMultiFileCleanUpScopeProvider` for the patched JDT UI bundle.
 
 ## If/else candidate analysis
 
 ### Constant group discovery
 
-The current single-file detector collects fields that are:
+The current detector collects fields that are:
 
 - `private`;
 - `static`;
@@ -91,8 +124,6 @@ The detector rejects:
 ### State-carrier discovery
 
 The recognised state carrier is currently a plain `int` parameter of a private method. Every branch condition in the root if/else-if chain must be an equality comparison between the same parameter binding and one of the constant bindings. Operand order may be reversed.
-
-Examples accepted by the condition matcher:
 
 ```java
 status == STATUS_PENDING
@@ -122,11 +153,20 @@ For an accepted candidate, one `CompilationUnitRewriteOperationWithSourceRange`:
 4. replaces constant references in comparisons with qualified enum constants;
 5. replaces every proven call argument with the corresponding enum constant.
 
-The edit remains one compilation-unit change and participates in normal cleanup preview and undo.
+## Project-wide candidate model
 
-## Why public API migration is different
+The next step is to extract discovery from `IntToEnumHelper` into an immutable semantic model containing:
 
-A source file cannot prove that a public constant or method is unused elsewhere. Binary clients may also depend on compile-time inlined constants or an integer method signature. A project-wide migration must consider:
+- constant group and numeric-value semantics;
+- declarations and generated names;
+- state carriers;
+- comparison and switch sites;
+- producer and consumer edges;
+- required edits per compilation unit;
+- compatibility boundaries;
+- explicit rejection reasons and confidence level.
+
+Project-wide analysis must consider:
 
 - JDT search results across source roots;
 - method hierarchies, interfaces, overrides, and implementations;
@@ -135,35 +175,51 @@ A source file cannot prove that a public constant or method is unused elsewhere.
 - reflection, JNI, generated code, and external binaries;
 - compatibility adapters or deprecated bridge constants.
 
-This analysis must finish before any edit is applied, and all edits should be presented and committed as one atomic `CompositeChange`.
+Where numeric identity must remain stable, the generated enum must use an explicit value field and conversion method rather than `ordinal()`.
 
-## Reusable future model
+## Ordering and fixpoint behaviour
 
-The next architectural step is to extract candidate discovery from `IntToEnumHelper` into a reusable semantic model containing:
+A multi-file migration plan can become stale if unrelated cleanups structurally change the same sources before it runs. The implementation must therefore:
 
-- constant group and numeric-value semantics;
-- state carriers;
-- comparison and switch sites;
-- producer and consumer edges;
-- required edits per compilation unit;
-- explicit rejection reasons and confidence level.
+- use cleanup ordering (`runAfter`) so semantic migrations run late;
+- request fresh ASTs where necessary;
+- resolve planned locations by binding key or Java model handle against the current working copy;
+- fail the whole candidate if any required edit no longer matches;
+- clear all per-run plan state after success, failure, or cancellation.
 
-That model can support:
+## Save-action boundary
 
-- the conservative cleanup;
-- a report-only inspection or marker;
-- a quick assist for one candidate;
-- a project-wide LTK refactoring;
-- future JDT UI multi-file cleanup integration.
+The JDT save participant calls `checkPreConditions` with only the saved compilation unit. Multi-file migration must therefore not run as a save action. Local transformations may remain available on save, while project-wide planning is enabled only for explicit cleanup runs or the headless batch application.
 
-## Portability to Eclipse JDT
+## Headless application
 
-The helper and candidate-analysis code can be moved from `org.sandbox.jdt.internal.*` to the corresponding JDT internal packages. Standard cleanup-profile integration for project-wide candidates additionally needs a JDT UI API and lifecycle change. The dedicated-refactoring approach does not.
+`sandbox_cleanup_application` currently creates one `CleanUpRefactoring` per file. Multi-file support requires it to collect and group all selected compilation units by Java project, add the entire group to one refactoring, and apply/check/diff the resulting composite change as one transaction.
+
+## OSGi delivery
+
+`org.eclipse.jdt.ui` is a singleton bundle. A normal fragment cannot override an existing host class because the host bundle class path is searched first. The Sandbox product should therefore install a patched higher-version `org.eclipse.jdt.ui` bundle through a p2 feature patch or its custom target/product.
+
+Keep the experimental scope-provider SPI in a Sandbox package. The public `org.eclipse.jdt.ui.cleanup` package is supplied by the singleton `org.eclipse.jdt.core.manipulation` bundle; adding a new interface there would unnecessarily require patching that bundle too.
+
+## Relationship to JDT UI PR 68
+
+PR 68 demonstrates that the cleanup orchestration can be changed, but its API and execution path are broader than necessary. It should be reduced to scope expansion and reuse the existing fixpoint pipeline. In particular, the implementation should not:
+
+- hold every AST context for the whole project longer than required;
+- run multi-file changes outside the normal working-copy lifecycle;
+- swallow `CoreException` and continue a supposedly atomic migration;
+- introduce independent-selection/recomputation APIs before the preview UI supports them.
+
+## Reuse by JUnit migration
+
+The shared planned-cleanup infrastructure is also required by `sandbox_junit_cleanup`, especially for migrations involving test superclass/subclass relationships, suites and referenced test classes, named rules or `ExternalResource` implementations declared in other files, lifecycle contracts, method sources, and helper APIs used by several tests.
+
+Both plugins should produce an immutable semantic plan first and emit one validated local fix per affected compilation unit.
 
 ## Dependencies
 
-- Eclipse JDT Core DOM and bindings
+- Eclipse JDT Core DOM, Java model, search, and bindings
 - Eclipse JDT Core Manipulation rewrite infrastructure
-- Eclipse JDT UI cleanup APIs
+- Eclipse JDT UI cleanup and refactoring infrastructure
 - Eclipse LTK refactoring framework
-- `sandbox_common` helper infrastructure
+- `sandbox_common` shared infrastructure

--- a/sandbox_int_to_enum/META-INF/MANIFEST.MF
+++ b/sandbox_int_to_enum/META-INF/MANIFEST.MF
@@ -22,6 +22,7 @@ Require-Bundle: org.eclipse.core.runtime,
 Bundle-ActivationPolicy: lazy
 Eclipse-RegisterBuddy: org.eclipse.jdt.core.manipulation
 Eclipse-BuddyPolicy: global
-Import-Package: org.sandbox.jdt.internal.common,
+Import-Package: javax.lang.model,
+ org.sandbox.jdt.internal.common,
  org.sandbox.jdt.internal.corext.fix2,
  org.sandbox.jdt.internal.corext.util

--- a/sandbox_int_to_enum/README.md
+++ b/sandbox_int_to_enum/README.md
@@ -15,7 +15,7 @@ A group of similarly named integer constants is not sufficient evidence for an e
 
 ## Implemented safe if/else migration
 
-The ordinary single-file cleanup currently transforms a candidate only when all of the following are true:
+The current implementation transforms a candidate only when all of the following are true:
 
 1. At least two `private static final int` constants share an underscore-delimited prefix, such as `STATUS_*`.
 2. Their compile-time integer values are distinct.
@@ -26,7 +26,7 @@ The ordinary single-file cleanup currently transforms a candidate only when all 
 7. The constants have no unsupported remaining references.
 8. The generated enum name and constants are valid and do not conflict with an existing nested type.
 
-The visibility restrictions are intentional. A normal `ICleanUp` receives one compilation unit at a time and cannot prove that public or package-visible constants and method signatures have no references in other files.
+These restrictions describe the first implemented detector, not a fundamental restriction of the Eclipse cleanup framework. The existing `ICleanUp` lifecycle calls `checkPreConditions(IJavaProject, ICompilationUnit[], ...)` with all selected compilation units and then invokes the same cleanup instance once per target unit. A cleanup can therefore prepare an immutable project-wide migration plan and return one local `CompilationUnitChange` for each file. `CleanUpRefactoring` already combines those changes into one preview, apply operation, and undo.
 
 ## Example
 
@@ -80,9 +80,9 @@ public class OrderProcessor {
 
 The cleanup deliberately preserves the existing control flow. Replacing an if/else chain with a switch is a separate transformation and can change the meaning of unlabeled `break` statements or create unreachable statements in branches that complete abruptly.
 
-## Cases intentionally rejected
+## Cases currently rejected
 
-The single-file cleanup does not currently migrate:
+The implemented detector does not yet migrate:
 
 - public, protected, or package-visible constants or method signatures;
 - parameters passed arbitrary integer expressions rather than recognised constants;
@@ -98,21 +98,25 @@ A rejected candidate is left unchanged.
 
 A complete migration of legacy APIs requires project-wide reference analysis and coordinated edits to declarations, callers, implementations, overrides, fields, locals, tests, serialization boundaries, and possibly external compatibility adapters.
 
-This cannot be implemented safely as an ordinary third-party cleanup because `ICleanUpFix#createChange` returns a single `CompilationUnitChange`. Two viable designs are:
+There are two stages:
 
-1. add explicit multi-file cleanup support to JDT UI; or
-2. implement a dedicated LTK refactoring in this plugin that produces a `CompositeChange`.
+1. **Selected-scope multi-file cleanup without a JDT UI patch.** During `checkPreConditions`, analyse all compilation units already selected for cleanup and build a shared immutable plan. During `createFix`, emit only the planned edits for the current `CleanUpContext`. The existing cleanup refactoring collects all per-file changes atomically.
+2. **Automatic scope expansion with a small patched JDT UI bundle.** Before precondition checking, a patched `CleanUpRefactoring` asks participating cleanups for additional related compilation units and adds them to the normal target set. The existing parsing, fixpoint, overlap, preview, validation, apply, and undo pipeline remains in use.
 
-The semantic candidate detector should remain independent of the UI path so it can be reused by both the conservative cleanup and the future project-wide refactoring.
+A dedicated LTK refactoring remains useful for interactive naming and compatibility choices, but it is not required merely to coordinate changes across already selected Java files.
+
+The reusable planning infrastructure is tracked in issue #1206 and is intended for both this plugin and `sandbox_junit_cleanup`.
+
+## Save actions
+
+The local transformation may remain available as a save action. Project-wide migration must be restricted to explicit cleanup runs because the save participant supplies only the saved compilation unit and should not silently edit other files.
 
 ## Usage
 
 1. Open **Preferences → Java → Code Style → Clean Up**.
 2. Create or edit a cleanup profile.
 3. Enable **Convert int constants to enum/switch**.
-4. Run the cleanup on selected Java sources.
-
-The transformation can also be enabled as a save action, although project-wide migrations should not run as save actions.
+4. Run the cleanup on selected Java sources, a package, source folder, or project.
 
 ## Requirements
 

--- a/sandbox_int_to_enum/README.md
+++ b/sandbox_int_to_enum/README.md
@@ -1,134 +1,129 @@
-# Int to Enum/Switch Refactoring Plugin
+# Int-to-Enum Refactoring Plugin
 
 ## Overview
 
-This Eclipse plugin provides an automated cleanup that transforms integer constant-based if-else chains into type-safe enum-based switch statements.
+This Eclipse plugin detects legacy Java code in which integer constants represent a closed set of states and migrates provably safe cases to an enum.
 
-## Implementation Status
+The implementation has two transformation paths:
 
-**Note:** This plugin has a complete structural implementation following repository patterns, but the actual transformation logic is currently a placeholder. The transformation from int constants to enums is a complex refactoring that requires:
+- **If/else state detection** — implemented conservatively with binding and usage analysis.
+- **Integer switch migration** — existing experimental prototype for switch statements.
 
-- Sophisticated AST pattern matching and analysis
-- Multi-step coordinated AST rewrites
-- Type propagation and scope analysis
-- Careful handling of edge cases
+## Why this needs semantic analysis
 
-The current implementation:
-- ✅ Follows all repository patterns (helper structure, ReferenceHolder, etc.)
-- ✅ Integrates with Eclipse cleanup framework
-- ✅ Has proper UI and configuration
-- ⚠️ Returns no transformation operations (prevents incorrect changes)
-- 📋 Includes extensive documentation for future implementation
+A group of similarly named integer constants is not sufficient evidence for an enum. Integers may be used as bit masks, protocol values, persisted identifiers, arithmetic operands, public API values, or values crossing file boundaries. The cleanup therefore analyses bindings and all relevant references before changing a type.
 
-See [TODO.md](TODO.md) for detailed implementation notes and [ARCHITECTURE.md](ARCHITECTURE.md) for design details.
+## Implemented safe if/else migration
 
-## Features
+The ordinary single-file cleanup currently transforms a candidate only when all of the following are true:
 
-- Detects integer constants used in if-else chains
-- Automatically generates appropriate enum types
-- Converts if-else chains to switch statements
-- Updates variable types and method signatures
-- Improves code maintainability and type safety
+1. At least two `private static final int` constants share an underscore-delimited prefix, such as `STATUS_*`.
+2. Their compile-time integer values are distinct.
+3. A `private` method has an `int` parameter compared with those constants in an `if`/`else if` chain.
+4. All comparisons refer to the same parameter binding.
+5. Every use of that parameter is one of the recognised comparisons.
+6. Every call site in the compilation unit passes one of the recognised constants.
+7. The constants have no unsupported remaining references.
+8. The generated enum name and constants are valid and do not conflict with an existing nested type.
 
-## Example Transformation
+The visibility restrictions are intentional. A normal `ICleanUp` receives one compilation unit at a time and cannot prove that public or package-visible constants and method signatures have no references in other files.
 
-### Before:
+## Example
+
+### Before
+
 ```java
 public class OrderProcessor {
-    public static final int STATUS_PENDING = 0;
-    public static final int STATUS_APPROVED = 1;
-    public static final int STATUS_REJECTED = 2;
-    
-    public void processOrder(int status) {
+    private static final int STATUS_PENDING = 0;
+    private static final int STATUS_APPROVED = 1;
+    private static final int STATUS_REJECTED = 2;
+
+    public void run() {
+        process(STATUS_PENDING);
+    }
+
+    private void process(int status) {
         if (status == STATUS_PENDING) {
-            System.out.println("Order pending");
+            handlePending();
         } else if (status == STATUS_APPROVED) {
-            System.out.println("Order approved");
+            handleApproved();
         } else if (status == STATUS_REJECTED) {
-            System.out.println("Order rejected");
+            handleRejected();
         }
     }
 }
 ```
 
-### After:
+### After
+
 ```java
 public class OrderProcessor {
-    public enum Status {
+    private enum Status {
         PENDING, APPROVED, REJECTED
     }
-    
-    public void processOrder(Status status) {
-        switch (status) {
-            case PENDING:
-                System.out.println("Order pending");
-                break;
-            case APPROVED:
-                System.out.println("Order approved");
-                break;
-            case REJECTED:
-                System.out.println("Order rejected");
-                break;
+
+    public void run() {
+        process(Status.PENDING);
+    }
+
+    private void process(Status status) {
+        if (status == Status.PENDING) {
+            handlePending();
+        } else if (status == Status.APPROVED) {
+            handleApproved();
+        } else if (status == Status.REJECTED) {
+            handleRejected();
         }
     }
 }
 ```
 
-## Benefits
+The cleanup deliberately preserves the existing control flow. Replacing an if/else chain with a switch is a separate transformation and can change the meaning of unlabeled `break` statements or create unreachable statements in branches that complete abruptly.
 
-1. **Type Safety**: Enums provide compile-time type checking
-2. **Maintainability**: Clear intent and self-documenting code
-3. **IDE Support**: Better autocomplete and refactoring support
-4. **Extensibility**: Easy to add new values and behavior
+## Cases intentionally rejected
+
+The single-file cleanup does not currently migrate:
+
+- public, protected, or package-visible constants or method signatures;
+- parameters passed arbitrary integer expressions rather than recognised constants;
+- constants used in arithmetic, persistence, return values, method arguments, or unrelated comparisons;
+- duplicate integer values used as aliases;
+- bit flags, which generally require a different model such as `EnumSet`;
+- state flows spanning multiple methods or compilation units;
+- existing nested types that conflict with the generated enum name.
+
+A rejected candidate is left unchanged.
+
+## Project-wide migration
+
+A complete migration of legacy APIs requires project-wide reference analysis and coordinated edits to declarations, callers, implementations, overrides, fields, locals, tests, serialization boundaries, and possibly external compatibility adapters.
+
+This cannot be implemented safely as an ordinary third-party cleanup because `ICleanUpFix#createChange` returns a single `CompilationUnitChange`. Two viable designs are:
+
+1. add explicit multi-file cleanup support to JDT UI; or
+2. implement a dedicated LTK refactoring in this plugin that produces a `CompositeChange`.
+
+The semantic candidate detector should remain independent of the UI path so it can be reused by both the conservative cleanup and the future project-wide refactoring.
 
 ## Usage
 
-### Via Eclipse Cleanup
+1. Open **Preferences → Java → Code Style → Clean Up**.
+2. Create or edit a cleanup profile.
+3. Enable **Convert int constants to enum/switch**.
+4. Run the cleanup on selected Java sources.
 
-1. Open Eclipse Preferences
-2. Navigate to Java → Code Style → Clean Up
-3. Create or edit a cleanup profile
-4. Enable "Convert int constants to enum/switch"
-5. Run cleanup on your code
-
-### As Save Action
-
-1. Open Eclipse Preferences
-2. Navigate to Java → Editor → Save Actions
-3. Enable "Perform the selected actions on save"
-4. Enable "Additional actions"
-5. Configure to include "Convert int constants to enum/switch"
-
-## Configuration Options
-
-Currently, this cleanup exposes a single boolean option in the Eclipse Clean Up profile:
-
-- **Convert int constants to enum/switch**: Enables or disables the int-to-enum/switch refactoring.
-
-More fine-grained options such as minimum number of constants, scope filtering, or preserving original constants are planned enhancements and are tracked in [TODO.md](TODO.md).
+The transformation can also be enabled as a save action, although project-wide migrations should not run as save actions.
 
 ## Requirements
 
 - Eclipse 2025-12 or later
 - Java 21 or later
 
-## Limitations
+## Technical documentation
 
-- Only transforms constants defined in the same compilation unit
-- Requires constants to be used in a clear if-else or switch pattern
-- Does not transform constants used in arithmetic operations
-- Conservative approach - only transforms obvious cases
-
-## Technical Details
-
-For architecture and implementation details, see [ARCHITECTURE.md](ARCHITECTURE.md).
-
-For planned improvements and known issues, see [TODO.md](TODO.md).
+- [Architecture](ARCHITECTURE.md)
+- [Implementation roadmap and limitations](TODO.md)
 
 ## License
 
 Eclipse Public License 2.0
-
-## Contributing
-
-This is part of the Sandbox project for Eclipse JDT experiments. Contributions following Eclipse JDT patterns are welcome.

--- a/sandbox_int_to_enum/TODO.md
+++ b/sandbox_int_to_enum/TODO.md
@@ -1,205 +1,134 @@
-# TODO: Int to Enum/Switch Refactoring Plugin
+# Int-to-Enum Refactoring Roadmap
 
-## Current Implementation Status
+## Current implementation
 
 ### Completed
-- [x] Basic plugin structure created
-- [x] Documentation files (ARCHITECTURE.md, TODO.md, README.md)
-- [x] Refactored to follow repository patterns
-- [x] Helper structure (AbstractTool, IntToEnumHelper) following JFace pattern
-- [x] Using ReferenceHolder from sandbox_common
-- [x] CompilationUnitRewriteOperationWithSourceRange implementation
-- [x] Proper static imports and code organization
-- [x] IntConstantHolder data structure defined
-- [x] SwitchIntToEnumHelper - converts switch statements using int constants to use enums
-- [x] Pattern detection: finds static final int fields and switch statements referencing them
-- [x] Enum generation from common constant name prefix
-- [x] Switch case label updates from int constants to enum values
-- [x] Method parameter type updates from int to enum
-- [x] Test for switch int to enum basic transformation
-- [x] Test for single constant (no transformation expected)
 
-### Implementation Complexity Note
+- [x] Eclipse cleanup integration and preference UI
+- [x] Helper-based cleanup architecture using `CompilationUnitRewriteOperationWithSourceRange`
+- [x] Existing integer-switch prototype
+- [x] Binding-based detection of private integer state constants
+- [x] Detection of if/else-if chains comparing one private method parameter with a constant group
+- [x] Support for equality operands in either order
+- [x] Common-prefix enum naming
+- [x] Validation of distinct compile-time integer values
+- [x] Validation of generated Java identifiers and nested-type name conflicts
+- [x] Whole-compilation-unit reference validation for constants, the state parameter, and the private method
+- [x] Propagation to proven private method call sites
+- [x] Removal of migrated constant fields or individual declaration fragments
+- [x] Tests for positive migration and conservative rejection
+- [x] Documentation of the single-file safety boundary
 
-**The actual transformation logic is marked as a placeholder for the following reasons:**
+## Safety model
 
-1. **Complexity of Transformation**: Converting int constants to enum with switch statements requires:
-   - Complex AST pattern matching across multiple node types
-   - Sophisticated scope and type analysis
-   - Coordinated multi-step AST rewrites
-   - Careful handling of data flow and control flow
-   
-2. **Required Analysis**:
-   - Find all int constant declarations with common prefixes
-   - Analyze if-else chains to identify which constants are related
-   - Determine variable types and propagate enum type through code
-   - Handle edge cases (constants used in calculations, comparisons, etc.)
-   
-3. **Multiple Coordinated Changes**:
-   - Generate new enum declaration
-   - Remove or replace int constant fields
-   - Convert if-else to switch (with proper break statements)
-   - Update method parameters from `int` to enum type
-   - Update variable declarations
-   - Add imports if needed
-   
-4. **Edge Cases**:
-   - Constants used outside of if-else chains
-   - Mixed usage (some constants in if-else, others in calculations)
-   - Constants from different scopes or classes
-   - Integer values used without named constants
+The current if/else migration intentionally accepts only candidates whose complete source-level data flow can be proven inside one compilation unit:
 
-### Current State
-- [x] Switch int to enum transformation (SwitchIntToEnumHelper - fully implemented)
-- [x] Core transformation structure (Placeholder implementation with extensive comments)
-  - Structure is in place but returns no operations for IF_ELSE_TO_SWITCH
-  - Prevents incorrect transformations
-  - Demonstrates intended architecture
-- [ ] If-else to switch transformation (IntToEnumHelper - placeholder)
-  - [ ] AST visitor for if-else pattern detection
-  - [ ] If-else to switch conversion
-  - [ ] Enum generation logic
+- constants are `private static final int` compile-time constants;
+- the method is private;
+- the state parameter is used only in recognised comparisons;
+- all calls pass one of the recognised constants;
+- constants have no other references;
+- values are distinct and are not treated as aliases.
 
-### Next Steps for Full Implementation
-- [ ] Implement if-else pattern detection in IntToEnumHelper.find() method
-  - [ ] Use AstProcessorBuilder for field and if-statement visitors
-  - [ ] Detect public static final int constants
-  - [ ] Find if-else chains comparing against constants
-  - [ ] Group related constants by common prefixes
-  
-- [ ] Implement if-else to switch transformation in IntToEnumHelper.rewrite() method
-  - [ ] Generate enum declaration from constants
-  - [ ] Create switch statement from if-else chain
-  - [ ] Update variable types
-  - [ ] Handle break statements and fall-through
+This is narrower than the eventual feature, but it is suitable for an ordinary cleanup because it does not guess about references in other files.
 
-- [ ] Enhanced switch int to enum support
-  - [ ] Handle switch expressions (not just switch statements)
-  - [ ] Handle local variable type updates (not just method parameters)
-  - [ ] Handle constants from other classes (qualified name references)
-  
-- [ ] Comprehensive testing
-  - [ ] Test with various constant patterns
-  - [ ] Test edge cases
-  - [ ] Verify no regressions
+## High-priority next steps
 
+### 1. Extract a reusable semantic candidate model
 
-## Known Limitations
+- [ ] Separate candidate discovery from AST rewriting
+- [ ] Represent constant groups, state carriers, comparison sites, call sites, and rejection reasons explicitly
+- [ ] Produce diagnostics explaining why a potential candidate was rejected
+- [ ] Reuse the same model for if/else chains, switches, quick assists, and project-wide refactoring
 
-1. **Pattern Detection**
-   - Currently only detects simple switch statements with direct constant references in case labels
-   - If-else chain detection not yet implemented
-   - Does not handle complex boolean expressions
-   - Does not handle switch expressions (only switch statements)
+### 2. Harden the existing switch prototype
 
-2. **Scope Analysis**
-   - Only processes constants in the same class
-   - Does not follow constant references across compilation units
-   - Conservative approach may miss some valid transformation opportunities
+- [ ] Apply the same visibility and whole-reference safety checks as the if/else implementation
+- [ ] Propagate method call arguments before changing a parameter type
+- [ ] Reject public API changes in single-file cleanup mode
+- [ ] Support qualified constant references
+- [ ] Add switch-expression support
+- [ ] Add tests for method references, unsupported call arguments, and external-use risks
 
-3. **Naming**
-   - Enum name generation is heuristic-based
-   - May not always produce ideal names
-   - No user interaction for name selection in automated mode
+### 3. Support additional state carriers within one file
 
-## Future Enhancements
+- [ ] Local variables initialized and assigned only from one constant group
+- [ ] Private fields whose reads and writes are fully contained in one compilation unit
+- [ ] Multiple if/else chains using the same state carrier
+- [ ] Multiple private methods participating in one closed state flow
+- [ ] Return values when every producer and consumer is locally provable
 
-### High Priority
+### 4. Detect patterns that must not become a plain enum
 
-1. **Improved Pattern Detection**
-   - Handle nested if-else chains
-   - Detect constants used in multiple methods
-   - Support for package-private and private constants
+- [ ] Bit flags and masks: recommend `EnumSet` or retain the integer representation
+- [ ] Persisted or wire-protocol values: generate an enum with an explicit numeric value and `fromValue`
+- [ ] Aliased integer constants: preserve aliases or reject with an explanation
+- [ ] Ordered/ranged arithmetic: reject plain enum migration
+- [ ] JNI, reflection, serialization, annotations, and compile-time constant consumers
 
-2. **Better Enum Naming**
-   - Analyze constant name patterns (e.g., STATUS_*, ERROR_*)
-   - Generate more meaningful enum names
-   - Detect common prefixes and use them for enum name
+## Project-wide refactoring
 
-3. **Safety Checks**
-   - Verify no arithmetic operations on constants
-   - Check for external references before transformation
-   - Validate that all constant usages can be converted
+### Architectural requirement
 
-### Medium Priority
+`ICleanUpFix#createChange` returns a single `CompilationUnitChange`. Therefore, a third-party ordinary cleanup cannot atomically coordinate declaration and reference changes across several compilation units.
 
-4. **Configuration Options**
-   - Minimum number of constants to trigger transformation (default: 2)
-   - Allow/disallow transformation of public constants
-   - Option to preserve original constants as deprecated
+A full migration should use one of these approaches:
 
-5. **Enhanced Transformations**
-   - Support for int constants with associated string values (name/value pairs)
-   - Handle constants with bit flags (suggest EnumSet instead)
-   - Support for ordinal-based enums when order matters
+1. **JDT UI multi-file cleanup API**
+   - revise the proposal in `carstenartur/eclipse.jdt.ui#68` into a small, focused API change;
+   - integrate candidate collection with `CleanUpRefactoring` lifecycle and preview;
+   - return an LTK `CompositeChange` with unified preview and undo.
 
-### Low Priority
+2. **Dedicated plugin refactoring**
+   - add an Eclipse command and LTK `Refactoring` implementation in this project;
+   - use JDT search and hierarchy APIs to collect affected compilation units;
+   - expose a wizard with candidate selection, compatibility options, and preview;
+   - keep the ordinary cleanup as the conservative single-file variant.
 
-6. **IDE Integration**
-   - Quick fix for individual if-else chains
-   - Preview dialog showing before/after
-   - Undo/redo support in IDE
+The second path is possible outside JDT UI and is likely the fastest way to validate the feature. Integration into the standard Clean Up profile requires changes in JDT UI.
 
-7. **Advanced Features**
-   - Support for migrating existing enum-like patterns
-   - Generate enum methods (toString, fromValue, etc.)
-   - Handle legacy code with minimal disruption
+### Project-wide analysis tasks
 
-## Testing Requirements
+- [ ] Find all references with JDT `SearchEngine`
+- [ ] Follow method declarations, overrides, implementations, and interface contracts
+- [ ] Propagate types through parameters, return values, fields, locals, assignments, and calls
+- [ ] Detect reflection and binary/external API compatibility risks
+- [ ] Decide whether to preserve deprecated integer adapter constants
+- [ ] Handle tests and generated sources
+- [ ] Produce one atomic `CompositeChange`
+- [ ] Add cancellation and progress reporting
+- [ ] Add integration tests using at least three compilation units
 
-### Test Cases Needed
+## User-facing configuration
 
-1. **Basic Transformation**
-   - Simple if-else with 2 constants
-   - If-else with 3+ constants
-   - If-else with else clause
+- [ ] Minimum number of states
+- [ ] Preserve numeric values in the enum
+- [ ] Keep deprecated integer compatibility constants
+- [ ] Include package-visible APIs
+- [ ] Include public APIs only with explicit confirmation
+- [ ] Preserve if/else or convert to switch
+- [ ] Report-only analysis mode
 
-2. **Edge Cases**
-   - Constants with no usages (should not transform)
-   - Constants used in arithmetic (should not transform)
-   - Mixed usage (if-else + arithmetic) (should not transform)
+## Test matrix
 
-3. **Negative Tests**
-   - Single constant (should not trigger)
-   - Constants from different classes
-   - Switch statement on int (already optimal)
+- [x] Disabled cleanup
+- [x] Basic private if/else chain
+- [x] Reversed equality operands
+- [x] Proven private call-site propagation
+- [x] Public API rejection
+- [x] Arbitrary call argument rejection
+- [x] Unrelated constant-use rejection
+- [ ] Multiple constant fragments in one field declaration
+- [ ] Qualified references (`Type.STATUS_PENDING`)
+- [ ] Parenthesized comparisons and arguments
+- [ ] Duplicate values
+- [ ] Existing nested enum-name conflict
+- [ ] Method references
+- [ ] Recursive calls
+- [ ] Multiple candidate groups in one type
+- [ ] Local variables and private fields
+- [ ] Multi-file interface/implementation/caller scenario
 
-4. **Complex Scenarios**
-   - Multiple if-else chains using same constants
-   - Nested if-else structures
-   - Constants with annotations
+## DSL status
 
-## Open Questions
-
-1. Should we transform constants that are part of a public API?
-2. How to handle constants with associated data (name-value pairs)?
-3. Should we generate equals/hashCode for the enum?
-4. How to handle backward compatibility when constants are in public API?
-
-## Performance Considerations
-
-- AST traversal should be efficient for large files
-- Pattern matching should be optimized
-- Transformation should be atomic (all or nothing)
-
-## Documentation Needs
-
-- User-facing documentation for Eclipse Help
-- Example transformations in README.md
-- Configuration guide for cleanup preferences
-
-## TriggerPattern DSL Integration
-
-### Status: ❌ Not expressible in DSL
-
-The int-to-enum cleanup requires complex multi-statement pattern detection and
-code generation that cannot be expressed in the `.sandbox-hint` DSL:
-
-- **Multi-statement pattern detection**: Identifying if-else chains or switch statements using int constants
-- **Enum generation**: Creating new enum type declarations
-- **Cross-method analysis**: Tracking integer constant usage across the class
-- **Switch/if-else restructuring**: Converting control flow to enum-based patterns
-
-### Required DSL Extensions (for future work)
-- [ ] Multi-statement pattern matching
-- [ ] Code generation patterns (new type creation)
+The transformation is not currently expressible in the `.sandbox-hint` DSL. It requires binding-aware, multi-statement and eventually multi-file analysis plus new type generation. The DSL could participate only after gaining semantic candidate aggregation and coordinated change support.

--- a/sandbox_int_to_enum/src/org/sandbox/jdt/internal/corext/fix/helper/IntToEnumHelper.java
+++ b/sandbox_int_to_enum/src/org/sandbox/jdt/internal/corext/fix/helper/IntToEnumHelper.java
@@ -15,15 +15,46 @@ package org.sandbox.jdt.internal.corext.fix.helper;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import javax.lang.model.SourceVersion;
+
+import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
 import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.EnumConstantDeclaration;
+import org.eclipse.jdt.core.dom.EnumDeclaration;
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.FieldAccess;
 import org.eclipse.jdt.core.dom.FieldDeclaration;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.IVariableBinding;
 import org.eclipse.jdt.core.dom.IfStatement;
+import org.eclipse.jdt.core.dom.InfixExpression;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.Modifier;
+import org.eclipse.jdt.core.dom.Name;
+import org.eclipse.jdt.core.dom.ParenthesizedExpression;
+import org.eclipse.jdt.core.dom.PrimitiveType;
+import org.eclipse.jdt.core.dom.QualifiedName;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
 import org.eclipse.jdt.core.dom.SwitchStatement;
+import org.eclipse.jdt.core.dom.Type;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 import org.eclipse.text.edits.TextEditGroup;
@@ -31,110 +62,553 @@ import org.sandbox.jdt.internal.common.ReferenceHolder;
 import org.sandbox.jdt.internal.corext.fix.IntToEnumFixCore;
 
 /**
- * Helper class for converting int constants to enum with switch statements.
- * 
- * <p>This is a simplified implementation that handles basic patterns:</p>
- * <ul>
- * <li>Detects public static final int constant declarations</li>
- * <li>Finds if-else chains that compare against these constants</li>
- * <li>Generates enum types with appropriate names</li>
- * <li>Converts if-else chains to switch statements</li>
- * </ul>
- * 
- * <p><b>Note:</b> This implementation focuses on the core transformation pattern
- * and may not handle all edge cases. Future enhancements can add more sophisticated
- * pattern matching and type inference.</p>
+ * Converts an enum-like group of private integer constants used by a private
+ * method parameter in an if/else chain to a nested enum.
+ *
+ * <p>The detector deliberately accepts only candidates whose complete data flow
+ * can be proven inside the current compilation unit. In particular, constants
+ * and the migrated method must be private, every use of the state parameter must
+ * be one of the recognised equality comparisons, and every call site must pass
+ * one of the recognised constants. This keeps the ordinary single-file cleanup
+ * safe while leaving project-wide API migrations to a future multi-file
+ * refactoring.</p>
  */
 public class IntToEnumHelper extends AbstractTool<ReferenceHolder<Integer, IntToEnumHelper.IntConstantHolder>> {
 
-	/**
-	 * Holder for int constant pattern data.
-	 * Tracks int constant declarations and their usage in if-else chains or switch statements.
-	 */
+	/** Data required to perform one int-to-enum migration. */
 	public static class IntConstantHolder {
-		/** The if-statement that uses these constants (for if-else to switch conversion) */
+		/** Root if-statement of the recognised chain. */
 		public IfStatement ifStatement;
-		/** The switch statement that uses these constants (for switch int to enum conversion) */
+		/** Switch statement used by the switch-specific helper. */
 		public SwitchStatement switchStatement;
-		/** Map of constant names to their field declarations */
-		public Map<String, FieldDeclaration> constantFields = new HashMap<>();
-		/** List of constant names in order they appear */
+		/** Map of constant names to their field declarations. */
+		public Map<String, FieldDeclaration> constantFields = new LinkedHashMap<>();
+		/** Constant names in declaration order. */
 		public List<String> constantNames = new ArrayList<>();
-		/** The variable being compared (e.g., "status") */
+		/** Name of the migrated state parameter. */
 		public String comparedVariable;
-		/** Set of nodes already processed */
+		/** Set of nodes already processed by the cleanup. */
 		public Set<ASTNode> nodesProcessed;
+		/** Private method containing the state parameter. */
+		public MethodDeclaration method;
+		/** Parameter whose type is changed from int to the generated enum. */
+		public SingleVariableDeclaration parameter;
+		/** Type into which the nested enum is inserted. */
+		public TypeDeclaration enclosingType;
+		/** Constant expressions in conditions and call sites to replace. */
+		public Map<Expression, String> constantReferences = new LinkedHashMap<>();
+	}
+
+	private static final class ConstantInfo {
+		private final String name;
+		private final FieldDeclaration field;
+		private final IVariableBinding binding;
+		private final int value;
+
+		private ConstantInfo(String name, FieldDeclaration field, IVariableBinding binding, int value) {
+			this.name = name;
+			this.field = field;
+			this.binding = binding;
+			this.value = value;
+		}
+	}
+
+	private static final class Comparison {
+		private final IVariableBinding stateBinding;
+		private final Expression stateExpression;
+		private final ConstantInfo constant;
+		private final Expression constantExpression;
+
+		private Comparison(IVariableBinding stateBinding, Expression stateExpression, ConstantInfo constant,
+				Expression constantExpression) {
+			this.stateBinding = stateBinding;
+			this.stateExpression = stateExpression;
+			this.constant = constant;
+			this.constantExpression = constantExpression;
+		}
+	}
+
+	private static final class Candidate {
+		private final IntConstantHolder holder = new IntConstantHolder();
+		private final List<IfStatement> chain = new ArrayList<>();
+		private final Set<Expression> stateReferences = new LinkedHashSet<>();
+		private IVariableBinding stateBinding;
+		private IMethodBinding methodBinding;
+		private int parameterIndex;
 	}
 
 	@Override
 	public void find(IntToEnumFixCore fixcore, CompilationUnit compilationUnit,
 			Set<CompilationUnitRewriteOperationWithSourceRange> operations, Set<ASTNode> nodesprocessed) {
-		
-		// Note: This is a simplified implementation
-		// A full implementation would need more sophisticated pattern matching
-		// For now, this demonstrates the structure without implementing complex logic
-		
-		// The actual implementation would:
-		// 1. Use AstProcessorBuilder to find all public static final int fields
-		// 2. Find if-else statements comparing against these fields
-		// 3. Group related constants
-		// 4. Create rewrite operations
-		
-		// Since this is a complex transformation requiring significant AST manipulation,
-		// we'll keep this as a placeholder that returns no operations for now
-		// This prevents the cleanup from making incorrect transformations
+		compilationUnit.accept(new ASTVisitor() {
+			@Override
+			public boolean visit(IfStatement node) {
+				if (nodesprocessed.contains(node) || isElseIf(node)) {
+					return true;
+				}
+
+				Candidate candidate = createCandidate(compilationUnit, node);
+				if (candidate == null) {
+					return true;
+				}
+
+				candidate.holder.nodesProcessed = nodesprocessed;
+				ReferenceHolder<Integer, IntConstantHolder> dataholder = new ReferenceHolder<>();
+				dataholder.put(0, candidate.holder);
+				operations.add(fixcore.rewrite(dataholder));
+				nodesprocessed.addAll(candidate.chain);
+				return false;
+			}
+		});
 	}
 
+	private static Candidate createCandidate(CompilationUnit compilationUnit, IfStatement root) {
+		MethodDeclaration method = findEnclosingMethod(root);
+		TypeDeclaration enclosingType = findEnclosingType(root);
+		if (method == null || enclosingType == null || !Modifier.isPrivate(method.getModifiers())) {
+			return null;
+		}
+
+		Map<String, ConstantInfo> constantsByBinding = collectPrivateIntConstants(enclosingType);
+		if (constantsByBinding.size() < 2) {
+			return null;
+		}
+
+		Candidate candidate = new Candidate();
+		Set<String> usedNames = new LinkedHashSet<>();
+		IfStatement current = root;
+		while (current != null) {
+			Comparison comparison = parseComparison(current.getExpression(), constantsByBinding);
+			if (comparison == null) {
+				return null;
+			}
+			if (candidate.stateBinding == null) {
+				candidate.stateBinding = comparison.stateBinding;
+			} else if (!sameVariable(candidate.stateBinding, comparison.stateBinding)) {
+				return null;
+			}
+			if (!usedNames.add(comparison.constant.name)) {
+				return null;
+			}
+
+			candidate.chain.add(current);
+			candidate.stateReferences.add(comparison.stateExpression);
+			candidate.holder.constantReferences.put(comparison.constantExpression, comparison.constant.name);
+			current = current.getElseStatement() instanceof IfStatement next ? next : null;
+		}
+
+		if (usedNames.size() < 2) {
+			return null;
+		}
+
+		SingleVariableDeclaration parameter = findParameter(method, candidate.stateBinding);
+		if (parameter == null || !isPlainInt(parameter)) {
+			return null;
+		}
+
+		IMethodBinding methodBinding = method.resolveBinding();
+		if (methodBinding == null) {
+			return null;
+		}
+		candidate.methodBinding = methodBinding.getMethodDeclaration();
+		candidate.parameterIndex = findParameterIndex(method, parameter);
+		if (candidate.parameterIndex < 0) {
+			return null;
+		}
+
+		List<String> usedNameList = new ArrayList<>(usedNames);
+		String prefix = SwitchIntToEnumHelper.findCommonPrefix(usedNameList);
+		if (prefix == null) {
+			return null;
+		}
+		String enumName = SwitchIntToEnumHelper.prefixToEnumName(prefix);
+		if (!isValidIdentifier(enumName) || hasNestedTypeNamed(enclosingType, enumName)) {
+			return null;
+		}
+
+		Map<String, ConstantInfo> enumConstants = constantsForPrefix(constantsByBinding, prefix);
+		if (enumConstants.size() < 2 || !enumConstants.keySet().containsAll(usedNames)
+				|| !hasDistinctValues(enumConstants.values())) {
+			return null;
+		}
+		for (String constantName : enumConstants.keySet()) {
+			String enumConstantName = constantName.substring(prefix.length());
+			if (!isValidIdentifier(enumConstantName)) {
+				return null;
+			}
+		}
+
+		candidate.holder.ifStatement = root;
+		candidate.holder.method = method;
+		candidate.holder.parameter = parameter;
+		candidate.holder.enclosingType = enclosingType;
+		candidate.holder.comparedVariable = parameter.getName().getIdentifier();
+		for (ConstantInfo info : enumConstants.values()) {
+			candidate.holder.constantNames.add(info.name);
+			candidate.holder.constantFields.put(info.name, info.field);
+		}
+
+		if (!collectCallSiteReplacements(compilationUnit, candidate, enumConstants)
+				|| !validateAllReferences(compilationUnit, candidate, enumConstants)) {
+			return null;
+		}
+		return candidate;
+	}
+
+	private static boolean collectCallSiteReplacements(CompilationUnit compilationUnit, Candidate candidate,
+			Map<String, ConstantInfo> enumConstants) {
+		AtomicBoolean valid = new AtomicBoolean(true);
+		compilationUnit.accept(new ASTVisitor() {
+			@Override
+			public boolean visit(MethodInvocation node) {
+				if (!valid.get()) {
+					return false;
+				}
+				IMethodBinding binding = node.resolveMethodBinding();
+				if (binding == null || !candidate.methodBinding.isEqualTo(binding.getMethodDeclaration())) {
+					return true;
+				}
+				if (candidate.parameterIndex >= node.arguments().size()) {
+					valid.set(false);
+					return false;
+				}
+				Expression argument = (Expression) node.arguments().get(candidate.parameterIndex);
+				ConstantInfo constant = resolveConstant(argument, enumConstants);
+				if (constant == null) {
+					valid.set(false);
+					return false;
+				}
+				candidate.holder.constantReferences.put(unparenthesize(argument), constant.name);
+				return true;
+			}
+		});
+		return valid.get();
+	}
+
+	private static boolean validateAllReferences(CompilationUnit compilationUnit, Candidate candidate,
+			Map<String, ConstantInfo> enumConstants) {
+		AtomicBoolean valid = new AtomicBoolean(true);
+		compilationUnit.accept(new ASTVisitor() {
+			@Override
+			public boolean visit(SimpleName node) {
+				if (!valid.get()) {
+					return false;
+				}
+				IBinding binding = node.resolveBinding();
+				if (binding instanceof IVariableBinding variableBinding) {
+					ConstantInfo constant = enumConstants.get(bindingKey(variableBinding));
+					if (constant != null) {
+						if (isDeclarationName(node)) {
+							return true;
+						}
+						Expression reference = containingExpression(node);
+						if (!candidate.holder.constantReferences.containsKey(reference)) {
+							valid.set(false);
+							return false;
+						}
+					} else if (sameVariable(candidate.stateBinding, variableBinding)
+							&& node != candidate.holder.parameter.getName()
+							&& !candidate.stateReferences.contains(containingExpression(node))) {
+						valid.set(false);
+						return false;
+					}
+				} else if (binding instanceof IMethodBinding methodBinding
+						&& candidate.methodBinding.isEqualTo(methodBinding.getMethodDeclaration())
+						&& node != candidate.holder.method.getName()
+						&& !(node.getParent() instanceof MethodInvocation invocation && invocation.getName() == node)) {
+					valid.set(false);
+					return false;
+				}
+				return true;
+			}
+		});
+		return valid.get();
+	}
+
+	private static Map<String, ConstantInfo> collectPrivateIntConstants(TypeDeclaration typeDeclaration) {
+		Map<String, ConstantInfo> result = new LinkedHashMap<>();
+		for (FieldDeclaration field : typeDeclaration.getFields()) {
+			int modifiers = field.getModifiers();
+			if (!Modifier.isPrivate(modifiers) || !Modifier.isStatic(modifiers) || !Modifier.isFinal(modifiers)
+					|| !isInt(field.getType())) {
+				continue;
+			}
+			for (Object fragmentObject : field.fragments()) {
+				VariableDeclarationFragment fragment = (VariableDeclarationFragment) fragmentObject;
+				IVariableBinding binding = fragment.resolveBinding();
+				Object constantValue = binding == null ? null : binding.getConstantValue();
+				String key = bindingKey(binding);
+				if (key != null && constantValue instanceof Integer value) {
+					result.put(key, new ConstantInfo(fragment.getName().getIdentifier(), field,
+							binding.getVariableDeclaration(), value.intValue()));
+				}
+			}
+		}
+		return result;
+	}
+
+	private static Map<String, ConstantInfo> constantsForPrefix(Map<String, ConstantInfo> constantsByBinding,
+			String prefix) {
+		Map<String, ConstantInfo> result = new LinkedHashMap<>();
+		for (ConstantInfo info : constantsByBinding.values()) {
+			if (info.name.startsWith(prefix)) {
+				result.put(info.name, info);
+			}
+		}
+		return result;
+	}
+
+	private static Comparison parseComparison(Expression expression, Map<String, ConstantInfo> constantsByBinding) {
+		Expression unwrapped = unparenthesize(expression);
+		if (!(unwrapped instanceof InfixExpression infix)
+				|| infix.getOperator() != InfixExpression.Operator.EQUALS
+				|| !infix.extendedOperands().isEmpty()) {
+			return null;
+		}
+
+		Expression left = unparenthesize(infix.getLeftOperand());
+		Expression right = unparenthesize(infix.getRightOperand());
+		ConstantInfo leftConstant = resolveConstant(left, constantsByBinding);
+		ConstantInfo rightConstant = resolveConstant(right, constantsByBinding);
+		IVariableBinding leftVariable = resolveVariable(left);
+		IVariableBinding rightVariable = resolveVariable(right);
+
+		if (leftConstant != null && rightVariable != null && rightConstant == null) {
+			return new Comparison(rightVariable, right, leftConstant, left);
+		}
+		if (rightConstant != null && leftVariable != null && leftConstant == null) {
+			return new Comparison(leftVariable, left, rightConstant, right);
+		}
+		return null;
+	}
+
+	private static ConstantInfo resolveConstant(Expression expression, Map<String, ConstantInfo> constantsByBinding) {
+		IVariableBinding binding = resolveVariable(unparenthesize(expression));
+		return binding == null ? null : constantsByBinding.get(bindingKey(binding));
+	}
+
+	private static IVariableBinding resolveVariable(Expression expression) {
+		Expression unwrapped = unparenthesize(expression);
+		IBinding binding = null;
+		if (unwrapped instanceof Name name) {
+			binding = name.resolveBinding();
+		} else if (unwrapped instanceof FieldAccess fieldAccess) {
+			binding = fieldAccess.resolveFieldBinding();
+		}
+		return binding instanceof IVariableBinding variableBinding ? variableBinding.getVariableDeclaration() : null;
+	}
+
+	private static Expression unparenthesize(Expression expression) {
+		Expression current = expression;
+		while (current instanceof ParenthesizedExpression parenthesized) {
+			current = parenthesized.getExpression();
+		}
+		return current;
+	}
+
+	private static Expression containingExpression(SimpleName name) {
+		ASTNode parent = name.getParent();
+		if (parent instanceof QualifiedName qualifiedName && qualifiedName.getName() == name) {
+			return qualifiedName;
+		}
+		if (parent instanceof FieldAccess fieldAccess && fieldAccess.getName() == name) {
+			return fieldAccess;
+		}
+		return name;
+	}
+
+	private static boolean isDeclarationName(SimpleName name) {
+		return name.getParent() instanceof VariableDeclarationFragment fragment && fragment.getName() == name;
+	}
+
+	private static SingleVariableDeclaration findParameter(MethodDeclaration method, IVariableBinding binding) {
+		for (Object parameterObject : method.parameters()) {
+			SingleVariableDeclaration parameter = (SingleVariableDeclaration) parameterObject;
+			IVariableBinding parameterBinding = parameter.resolveBinding();
+			if (sameVariable(binding, parameterBinding)) {
+				return parameter;
+			}
+		}
+		return null;
+	}
+
+	private static int findParameterIndex(MethodDeclaration method, SingleVariableDeclaration parameter) {
+		for (int i = 0; i < method.parameters().size(); i++) {
+			if (method.parameters().get(i) == parameter) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	private static boolean isPlainInt(SingleVariableDeclaration parameter) {
+		return !parameter.isVarargs() && parameter.extraDimensions().isEmpty() && isInt(parameter.getType());
+	}
+
+	private static boolean isInt(Type type) {
+		return type.isPrimitiveType()
+				&& ((PrimitiveType) type).getPrimitiveTypeCode() == PrimitiveType.INT;
+	}
+
+	private static boolean hasDistinctValues(Iterable<ConstantInfo> constants) {
+		Set<Integer> values = new HashSet<>();
+		for (ConstantInfo constant : constants) {
+			if (!values.add(Integer.valueOf(constant.value))) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private static boolean hasNestedTypeNamed(TypeDeclaration enclosingType, String name) {
+		if (enclosingType.getName().getIdentifier().equals(name)) {
+			return true;
+		}
+		for (Object declaration : enclosingType.bodyDeclarations()) {
+			if (declaration instanceof AbstractTypeDeclaration typeDeclaration
+					&& typeDeclaration.getName().getIdentifier().equals(name)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static boolean isValidIdentifier(String name) {
+		return SourceVersion.isIdentifier(name) && !SourceVersion.isKeyword(name);
+	}
+
+	private static boolean sameVariable(IVariableBinding first, IVariableBinding second) {
+		return first != null && second != null
+				&& first.getVariableDeclaration().isEqualTo(second.getVariableDeclaration());
+	}
+
+	private static String bindingKey(IVariableBinding binding) {
+		return binding == null ? null : binding.getVariableDeclaration().getKey();
+	}
+
+	private static boolean isElseIf(IfStatement statement) {
+		return statement.getParent() instanceof IfStatement parent && parent.getElseStatement() == statement;
+	}
+
+	private static MethodDeclaration findEnclosingMethod(ASTNode node) {
+		ASTNode current = node.getParent();
+		while (current != null) {
+			if (current instanceof MethodDeclaration methodDeclaration) {
+				return methodDeclaration;
+			}
+			current = current.getParent();
+		}
+		return null;
+	}
+
+	private static TypeDeclaration findEnclosingType(ASTNode node) {
+		ASTNode current = node.getParent();
+		while (current != null) {
+			if (current instanceof TypeDeclaration typeDeclaration) {
+				return typeDeclaration;
+			}
+			current = current.getParent();
+		}
+		return null;
+	}
+
+	@SuppressWarnings("unchecked")
 	@Override
 	public void rewrite(IntToEnumFixCore fixCore, ReferenceHolder<Integer, IntConstantHolder> holder,
 			CompilationUnitRewrite cuRewrite, TextEditGroup group) {
-		
-		// Note: This is a simplified implementation placeholder
-		// A full implementation would:
-		// 1. Generate enum declaration from constant fields
-		// 2. Remove old int constant field declarations
-		// 3. Convert if-else chain to switch statement
-		// 4. Update variable types from int to enum
-		// 5. Update method parameters and return types
-		
-		// This complex transformation requires:
-		// - Careful scope analysis
-		// - Type propagation
-		// - Multiple coordinated AST rewrites
-		// - Handling of edge cases (e.g., constants used in other contexts)
-		
-		// For now, we keep this as a placeholder to maintain code structure
+		for (IntConstantHolder data : holder.values()) {
+			if (data.ifStatement == null || data.parameter == null || data.enclosingType == null
+					|| data.constantNames.size() < 2) {
+				continue;
+			}
+
+			String prefix = SwitchIntToEnumHelper.findCommonPrefix(data.constantNames);
+			if (prefix == null) {
+				continue;
+			}
+			String enumName = SwitchIntToEnumHelper.prefixToEnumName(prefix);
+			AST ast = cuRewrite.getRoot().getAST();
+			ASTRewrite rewrite = cuRewrite.getASTRewrite();
+
+			EnumDeclaration enumDeclaration = ast.newEnumDeclaration();
+			enumDeclaration.setName(ast.newSimpleName(enumName));
+			enumDeclaration.modifiers().add(ast.newModifier(Modifier.ModifierKeyword.PRIVATE_KEYWORD));
+			for (String constantName : data.constantNames) {
+				EnumConstantDeclaration enumConstant = ast.newEnumConstantDeclaration();
+				enumConstant.setName(ast.newSimpleName(constantName.substring(prefix.length())));
+				enumDeclaration.enumConstants().add(enumConstant);
+			}
+
+			ListRewrite bodyRewrite = rewrite.getListRewrite(data.enclosingType,
+					TypeDeclaration.BODY_DECLARATIONS_PROPERTY);
+			FieldDeclaration firstField = data.constantFields.values().iterator().next();
+			bodyRewrite.insertBefore(enumDeclaration, firstField, group);
+			removeConstantFields(rewrite, bodyRewrite, data, group);
+
+			Type enumType = ast.newSimpleType(ast.newSimpleName(enumName));
+			rewrite.replace(data.parameter.getType(), enumType, group);
+			for (Map.Entry<Expression, String> reference : data.constantReferences.entrySet()) {
+				String enumConstantName = reference.getValue().substring(prefix.length());
+				Name replacement = ast.newName(enumName + "." + enumConstantName); //$NON-NLS-1$
+				rewrite.replace(reference.getKey(), replacement, group);
+			}
+		}
+	}
+
+	private static void removeConstantFields(ASTRewrite rewrite, ListRewrite bodyRewrite, IntConstantHolder data,
+			TextEditGroup group) {
+		Set<FieldDeclaration> fieldsToRemove = new LinkedHashSet<>(data.constantFields.values());
+		for (FieldDeclaration field : fieldsToRemove) {
+			boolean removeWholeField = true;
+			for (Object fragmentObject : field.fragments()) {
+				VariableDeclarationFragment fragment = (VariableDeclarationFragment) fragmentObject;
+				if (!data.constantFields.containsKey(fragment.getName().getIdentifier())) {
+					removeWholeField = false;
+					break;
+				}
+			}
+			if (removeWholeField) {
+				bodyRewrite.remove(field, group);
+			} else {
+				ListRewrite fragmentRewrite = rewrite.getListRewrite(field, FieldDeclaration.FRAGMENTS_PROPERTY);
+				for (Object fragmentObject : field.fragments()) {
+					VariableDeclarationFragment fragment = (VariableDeclarationFragment) fragmentObject;
+					if (data.constantFields.containsKey(fragment.getName().getIdentifier())) {
+						fragmentRewrite.remove(fragment, group);
+					}
+				}
+			}
+		}
 	}
 
 	@Override
 	public String getPreview(boolean afterRefactoring) {
 		if (!afterRefactoring) {
 			return """
-					// Before:
-					public static final int STATUS_PENDING = 0;
-					public static final int STATUS_APPROVED = 1;
-					
-					if (status == STATUS_PENDING) {
-					    // handle pending
-					} else if (status == STATUS_APPROVED) {
-					    // handle approved
+					private static final int STATUS_PENDING = 0;
+					private static final int STATUS_APPROVED = 1;
+
+					private void process(int status) {
+					    if (status == STATUS_PENDING) {
+					        handlePending();
+					    } else if (status == STATUS_APPROVED) {
+					        handleApproved();
+					    }
 					}
-					""";
+					"""; //$NON-NLS-1$
 		}
 		return """
-				// After:
-				public enum Status {
+				private enum Status {
 				    PENDING, APPROVED
 				}
-				
-				switch (status) {
-				    case PENDING:
-				        // handle pending
-				        break;
-				    case APPROVED:
-				        // handle approved
-				        break;
+
+				private void process(Status status) {
+				    if (status == Status.PENDING) {
+				        handlePending();
+				    } else if (status == Status.APPROVED) {
+				        handleApproved();
+				    }
 				}
-				""";
+				"""; //$NON-NLS-1$
 	}
 }

--- a/sandbox_int_to_enum/src/org/sandbox/jdt/internal/corext/fix/helper/IntToEnumHelper.java
+++ b/sandbox_int_to_enum/src/org/sandbox/jdt/internal/corext/fix/helper/IntToEnumHelper.java
@@ -14,7 +14,6 @@
 package org.sandbox.jdt.internal.corext.fix.helper;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -102,13 +101,11 @@ public class IntToEnumHelper extends AbstractTool<ReferenceHolder<Integer, IntTo
 	private static final class ConstantInfo {
 		private final String name;
 		private final FieldDeclaration field;
-		private final IVariableBinding binding;
 		private final int value;
 
-		private ConstantInfo(String name, FieldDeclaration field, IVariableBinding binding, int value) {
+		private ConstantInfo(String name, FieldDeclaration field, int value) {
 			this.name = name;
 			this.field = field;
-			this.binding = binding;
 			this.value = value;
 		}
 	}
@@ -216,8 +213,7 @@ public class IntToEnumHelper extends AbstractTool<ReferenceHolder<Integer, IntTo
 			return null;
 		}
 
-		List<String> usedNameList = new ArrayList<>(usedNames);
-		String prefix = SwitchIntToEnumHelper.findCommonPrefix(usedNameList);
+		String prefix = SwitchIntToEnumHelper.findCommonPrefix(new ArrayList<>(usedNames));
 		if (prefix == null) {
 			return null;
 		}
@@ -227,15 +223,17 @@ public class IntToEnumHelper extends AbstractTool<ReferenceHolder<Integer, IntTo
 		}
 
 		Map<String, ConstantInfo> enumConstants = constantsForPrefix(constantsByBinding, prefix);
-		if (enumConstants.size() < 2 || !enumConstants.keySet().containsAll(usedNames)
-				|| !hasDistinctValues(enumConstants.values())) {
-			return null;
-		}
-		for (String constantName : enumConstants.keySet()) {
-			String enumConstantName = constantName.substring(prefix.length());
+		Set<String> enumConstantNames = new LinkedHashSet<>();
+		for (ConstantInfo info : enumConstants.values()) {
+			enumConstantNames.add(info.name);
+			String enumConstantName = info.name.substring(prefix.length());
 			if (!isValidIdentifier(enumConstantName)) {
 				return null;
 			}
+		}
+		if (enumConstants.size() < 2 || !enumConstantNames.containsAll(usedNames)
+				|| !hasDistinctValues(enumConstants.values())) {
+			return null;
 		}
 
 		candidate.holder.ifStatement = root;
@@ -339,8 +337,7 @@ public class IntToEnumHelper extends AbstractTool<ReferenceHolder<Integer, IntTo
 				Object constantValue = binding == null ? null : binding.getConstantValue();
 				String key = bindingKey(binding);
 				if (key != null && constantValue instanceof Integer value) {
-					result.put(key, new ConstantInfo(fragment.getName().getIdentifier(), field,
-							binding.getVariableDeclaration(), value.intValue()));
+					result.put(key, new ConstantInfo(fragment.getName().getIdentifier(), field, value.intValue()));
 				}
 			}
 		}
@@ -350,9 +347,9 @@ public class IntToEnumHelper extends AbstractTool<ReferenceHolder<Integer, IntTo
 	private static Map<String, ConstantInfo> constantsForPrefix(Map<String, ConstantInfo> constantsByBinding,
 			String prefix) {
 		Map<String, ConstantInfo> result = new LinkedHashMap<>();
-		for (ConstantInfo info : constantsByBinding.values()) {
-			if (info.name.startsWith(prefix)) {
-				result.put(info.name, info);
+		for (Map.Entry<String, ConstantInfo> entry : constantsByBinding.entrySet()) {
+			if (entry.getValue().name.startsWith(prefix)) {
+				result.put(entry.getKey(), entry.getValue());
 			}
 		}
 		return result;

--- a/sandbox_int_to_enum_test/src/org/eclipse/jdt/ui/tests/quickfix/Java22/IntToEnumCleanUpTest.java
+++ b/sandbox_int_to_enum_test/src/org/eclipse/jdt/ui/tests/quickfix/Java22/IntToEnumCleanUpTest.java
@@ -16,7 +16,6 @@ package org.eclipse.jdt.ui.tests.quickfix.Java22;
 import java.util.Hashtable;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -56,10 +55,10 @@ public class IntToEnumCleanUpTest {
 				package test1;
 				
 				public class E1 {
-				    public static final int STATUS_PENDING = 0;
-				    public static final int STATUS_APPROVED = 1;
+				    private static final int STATUS_PENDING = 0;
+				    private static final int STATUS_APPROVED = 1;
 				    
-				    public void process(int status) {
+				    private void process(int status) {
 				        if (status == STATUS_PENDING) {
 				            System.out.println("Pending");
 				        } else if (status == STATUS_APPROVED) {
@@ -69,28 +68,30 @@ public class IntToEnumCleanUpTest {
 				}
 				""";
 		ICompilationUnit cu = pack.createCompilationUnit("E1.java", given, false, null);
-		
-		// Cleanup disabled - no transformation expected
 		context.disable(MYCleanUpConstants.INT_TO_ENUM_CLEANUP);
 		context.assertRefactoringHasNoChange(new ICompilationUnit[] { cu });
 	}
 
-	@Disabled("Transformation logic not yet implemented - test documents expected behavior")
 	@Test
-	public void testBasicIfElseToEnumSwitch() throws CoreException {
+	public void testBasicIfElseIntStateToEnum() throws CoreException {
 		IPackageFragment pack = context.getSourceFolder().createPackageFragment("test1", false, null);
 		String given = """
 				package test1;
 				
 				public class E2 {
-				    public static final int STATUS_PENDING = 0;
-				    public static final int STATUS_APPROVED = 1;
-				    public static final int STATUS_REJECTED = 2;
+				    private static final int STATUS_PENDING = 0;
+				    private static final int STATUS_APPROVED = 1;
+				    private static final int STATUS_REJECTED = 2;
 				    
-				    public void process(int status) {
+				    public void run() {
+				        process(STATUS_PENDING);
+				        process(STATUS_REJECTED);
+				    }
+				    
+				    private void process(int status) {
 				        if (status == STATUS_PENDING) {
 				            System.out.println("Pending");
-				        } else if (status == STATUS_APPROVED) {
+				        } else if (STATUS_APPROVED == status) {
 				            System.out.println("Approved");
 				        } else if (status == STATUS_REJECTED) {
 				            System.out.println("Rejected");
@@ -98,11 +99,112 @@ public class IntToEnumCleanUpTest {
 				    }
 				}
 				""";
-		
+
 		ICompilationUnit cu = pack.createCompilationUnit("E2.java", given, false, null);
 		context.enable(MYCleanUpConstants.INT_TO_ENUM_CLEANUP);
-		
-		// If-else to enum transformation not yet implemented
+
+		String expected = "package test1;\n"
+				+ "\n"
+				+ "public class E2 {\n"
+				+ "    private enum Status {\n"
+				+ "\t\tPENDING, APPROVED, REJECTED\n"
+				+ "\t}\n"
+				+ "\n"
+				+ "    public void run() {\n"
+				+ "        process(Status.PENDING);\n"
+				+ "        process(Status.REJECTED);\n"
+				+ "    }\n"
+				+ "    \n"
+				+ "\tprivate void process(Status status) {\n"
+				+ "        if (status == Status.PENDING) {\n"
+				+ "            System.out.println(\"Pending\");\n"
+				+ "        } else if (Status.APPROVED == status) {\n"
+				+ "            System.out.println(\"Approved\");\n"
+				+ "        } else if (status == Status.REJECTED) {\n"
+				+ "            System.out.println(\"Rejected\");\n"
+				+ "        }\n"
+				+ "    }\n"
+				+ "}\n";
+		context.assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected }, null);
+	}
+
+	@Test
+	public void testNoTransformPublicApiWithoutMultiFileAnalysis() throws CoreException {
+		IPackageFragment pack = context.getSourceFolder().createPackageFragment("test1", false, null);
+		String given = """
+				package test1;
+				
+				public class EPublic {
+				    public static final int STATUS_PENDING = 0;
+				    public static final int STATUS_APPROVED = 1;
+				    
+				    public void process(int status) {
+				        if (status == STATUS_PENDING) {
+				            System.out.println("Pending");
+				        } else if (status == STATUS_APPROVED) {
+				            System.out.println("Approved");
+				        }
+				    }
+				}
+				""";
+		ICompilationUnit cu = pack.createCompilationUnit("EPublic.java", given, false, null);
+		context.enable(MYCleanUpConstants.INT_TO_ENUM_CLEANUP);
+		context.assertRefactoringHasNoChange(new ICompilationUnit[] { cu });
+	}
+
+	@Test
+	public void testNoTransformWhenCallSiteDoesNotUseKnownConstant() throws CoreException {
+		IPackageFragment pack = context.getSourceFolder().createPackageFragment("test1", false, null);
+		String given = """
+				package test1;
+				
+				public class ECall {
+				    private static final int STATUS_PENDING = 0;
+				    private static final int STATUS_APPROVED = 1;
+				    
+				    public void run(int status) {
+				        process(status);
+				    }
+				    
+				    private void process(int status) {
+				        if (status == STATUS_PENDING) {
+				            System.out.println("Pending");
+				        } else if (status == STATUS_APPROVED) {
+				            System.out.println("Approved");
+				        }
+				    }
+				}
+				""";
+		ICompilationUnit cu = pack.createCompilationUnit("ECall.java", given, false, null);
+		context.enable(MYCleanUpConstants.INT_TO_ENUM_CLEANUP);
+		context.assertRefactoringHasNoChange(new ICompilationUnit[] { cu });
+	}
+
+	@Test
+	public void testNoTransformWhenConstantHasAnotherUse() throws CoreException {
+		IPackageFragment pack = context.getSourceFolder().createPackageFragment("test1", false, null);
+		String given = """
+				package test1;
+				
+				public class EOtherUse {
+				    private static final int STATUS_PENDING = 0;
+				    private static final int STATUS_APPROVED = 1;
+				    
+				    private void process(int status) {
+				        if (status == STATUS_PENDING) {
+				            System.out.println("Pending");
+				        } else if (status == STATUS_APPROVED) {
+				            System.out.println("Approved");
+				        }
+				    }
+				    
+				    private int defaultStatus() {
+				        return STATUS_PENDING;
+				    }
+				}
+				""";
+		ICompilationUnit cu = pack.createCompilationUnit("EOtherUse.java", given, false, null);
+		context.enable(MYCleanUpConstants.INT_TO_ENUM_CLEANUP);
 		context.assertRefactoringHasNoChange(new ICompilationUnit[] { cu });
 	}
 
@@ -135,9 +237,6 @@ public class IntToEnumCleanUpTest {
 		ICompilationUnit cu = pack.createCompilationUnit("E3.java", given, false, null);
 		context.enable(MYCleanUpConstants.INT_TO_ENUM_CLEANUP);
 
-		// Expected output matches Eclipse ASTRewrite formatting:
-		// - Newly generated enum body/closing and method use tabs
-		// - Existing code (switch body) keeps original 4-space indentation
 		String expected = "package test1;\n"
 				+ "\n"
 				+ "public class E3 {\n"
@@ -212,7 +311,6 @@ public class IntToEnumCleanUpTest {
 		ICompilationUnit cu = pack.createCompilationUnit("E5.java", given, false, null);
 		context.enable(MYCleanUpConstants.INT_TO_ENUM_CLEANUP);
 
-		// Switch selector is a local variable, not a method parameter - skip
 		context.assertRefactoringHasNoChange(new ICompilationUnit[] { cu });
 	}
 
@@ -245,7 +343,6 @@ public class IntToEnumCleanUpTest {
 		ICompilationUnit cu = pack.createCompilationUnit("E6.java", given, false, null);
 		context.enable(MYCleanUpConstants.INT_TO_ENUM_CLEANUP);
 
-		// Constants referenced outside the switch - skip to avoid broken references
 		context.assertRefactoringHasNoChange(new ICompilationUnit[] { cu });
 	}
 
@@ -274,7 +371,6 @@ public class IntToEnumCleanUpTest {
 		ICompilationUnit cu = pack.createCompilationUnit("E7.java", given, false, null);
 		context.enable(MYCleanUpConstants.INT_TO_ENUM_CLEANUP);
 
-		// Constants have no underscore-delimited prefix - skip
 		context.assertRefactoringHasNoChange(new ICompilationUnit[] { cu });
 	}
 }


### PR DESCRIPTION
## Summary

Implements the previously empty `IntToEnumHelper` so the cleanup can discover enum-like integer state encodings rather than relying only on the existing switch prototype.

## Implemented detection

The cleanup now recognises a conservative local pattern when:

- at least two `private static final int` constants share an underscore-delimited prefix;
- the constants have distinct compile-time integer values;
- a `private` method has an `int` parameter compared to those constants in an if/else-if chain;
- every use of the parameter is one of the recognised equality comparisons;
- every call site in the compilation unit passes one of the recognised constants;
- the constants have no remaining unsupported uses;
- the generated enum name does not conflict with an existing nested type.

## Transformation

- creates a private nested enum;
- removes the migrated integer constants;
- changes the private method parameter type;
- replaces constants in comparisons and all proven call sites;
- preserves the existing if/else control flow rather than introducing potentially unsafe `break` semantics.

## Corrected multi-file architecture

The implementation in this PR is local, but that is not a fundamental limitation of `ICleanUp`.

The existing cleanup lifecycle already calls `checkPreConditions(IJavaProject, ICompilationUnit[], ...)` with all selected compilation units and subsequently invokes the same cleanup instance once per target file. A future cleanup can therefore build one immutable project-wide migration plan during precondition checking and return one local `CompilationUnitChange` from each `createFix(CleanUpContext)` invocation. `CleanUpRefactoring` already combines those file changes into one preview, apply operation, and undo.

A patched JDT UI bundle is needed only to expand the target set automatically when analysis discovers related files that were not part of the original cleanup selection. The proposed patch should be much smaller than `carstenartur/eclipse.jdt.ui#68`: add target-scope expansion before precondition checking, then reuse the existing parser, working-copy fixpoint, overlap handling, preview, validation, apply, and undo pipeline.

The reusable design for both int-to-enum and JUnit migration is specified in #1206.

## Tests

Adds coverage for:

- automatic if/else detection and call-site propagation;
- reversed comparison operands;
- disabled cleanup;
- public API rejection by the current local detector;
- unsupported call arguments;
- unrelated constant uses;
- existing switch behaviour.

## Documentation

README and architecture documentation now distinguish:

1. the implemented local detector;
2. selected-scope multi-file planning on the current cleanup API;
3. optional automatic scope expansion through a patched `org.eclipse.jdt.ui` bundle;
4. dedicated LTK refactoring for interactive naming and compatibility choices.
