### PR TITLE
Diagnostic: extract PR 1239 Maven failure

### DIFF
--- a/.github/diagnose-1239-trigger.txt
+++ b/.github/diagnose-1239-trigger.txt
@@ -1,0 +1,1 @@
+Trigger the one-shot diagnostic workflow.

--- a/.github/diagnose-1239-trigger.txt
+++ b/.github/diagnose-1239-trigger.txt
@@ -1,1 +1,1 @@
-Trigger the one-shot diagnostic workflow.
+Trigger the updated one-shot diagnostic workflow.

--- a/.github/workflows/diagnose-1239-build.yml
+++ b/.github/workflows/diagnose-1239-build.yml
@@ -31,20 +31,22 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/jobs/88732643922/logs" \
             --output failed-job.log
-      - name: Extract exact SpotBugs context
+      - name: Extract failing SpotBugs finding
         run: |
           python3 - <<'PY'
           from pathlib import Path
 
           lines = Path('failed-job.log').read_text(errors='replace').splitlines()
-          selected = set()
-          for index, line in enumerate(lines):
-              if ('Total bugs:' in line or 'spotbugs' in line.lower() or
-                      'BUILD FAILURE' in line or 'Failed to execute goal' in line):
-                  selected.update(range(max(0, index - 4), min(len(lines), index + 22)))
-          excerpt = '\n'.join(f'{index + 1:05d}: {lines[index]}' for index in sorted(selected))
+          matches = [index for index, line in enumerate(lines) if 'Total bugs: 1' in line]
+          if len(matches) != 1:
+              raise SystemExit(f'Expected exactly one failing SpotBugs summary, found {len(matches)}')
+          index = matches[0]
+          excerpt = '\n'.join(
+              f'{line_index + 1:05d}: {lines[line_index]}'
+              for line_index in range(max(0, index - 8), min(len(lines), index + 28))
+          )
           Path('summary.md').write_text(
-              '### Exact SpotBugs diagnosis\n\n```text\n' + excerpt[-30000:] + '\n```\n'
+              '### Exact SpotBugs diagnosis\n\n```text\n' + excerpt + '\n```\n'
           )
           print(excerpt)
           PY

--- a/.github/workflows/diagnose-1239-build.yml
+++ b/.github/workflows/diagnose-1239-build.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - qa/diagnose-1239-build
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/diagnose-1239-build.yml
+      - .github/diagnose-1239-trigger.txt
 
 permissions:
   actions: read

--- a/.github/workflows/diagnose-1239-build.yml
+++ b/.github/workflows/diagnose-1239-build.yml
@@ -31,27 +31,20 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/jobs/88732643922/logs" \
             --output failed-job.log
-      - name: Extract relevant failure context
+      - name: Extract exact SpotBugs context
         run: |
           python3 - <<'PY'
           from pathlib import Path
-          import re
 
           lines = Path('failed-job.log').read_text(errors='replace').splitlines()
-          pattern = re.compile(
-              r'\[ERROR\]|BUILD FAILURE|Failed to execute goal|cannot find symbol|Compilation failure|'
-              r'There are test failures|Failures: [1-9]|Errors: [1-9]|Reactor Summary',
-              re.IGNORECASE,
-          )
           selected = set()
           for index, line in enumerate(lines):
-              if pattern.search(line):
-                  selected.update(range(max(0, index - 6), min(len(lines), index + 12)))
-          if not selected:
-              selected.update(range(max(0, len(lines) - 250), len(lines)))
+              if ('Total bugs:' in line or 'spotbugs' in line.lower() or
+                      'BUILD FAILURE' in line or 'Failed to execute goal' in line):
+                  selected.update(range(max(0, index - 4), min(len(lines), index + 22)))
           excerpt = '\n'.join(f'{index + 1:05d}: {lines[index]}' for index in sorted(selected))
           Path('summary.md').write_text(
-              '### Automated Maven failure diagnosis\n\n```text\n' + excerpt[-50000:] + '\n```\n'
+              '### Exact SpotBugs diagnosis\n\n```text\n' + excerpt[-30000:] + '\n```\n'
           )
           print(excerpt)
           PY

--- a/.github/workflows/diagnose-1239-build.yml
+++ b/.github/workflows/diagnose-1239-build.yml
@@ -1,0 +1,46 @@
+name: Diagnose PR 1239 build
+
+on:
+  push:
+    branches:
+      - qa/diagnose-1239-build
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  diagnose:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download failed Maven job log
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          curl --fail --silent --show-error --location \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/jobs/88732643922/logs" \
+            --output failed-job.log
+      - name: Print relevant failure context
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+          import re
+
+          lines = Path('failed-job.log').read_text(errors='replace').splitlines()
+          pattern = re.compile(
+              r'\[ERROR\]|BUILD FAILURE|Failed to execute goal|cannot find symbol|Compilation failure|'
+              r'There are test failures|Failures: [1-9]|Errors: [1-9]|Reactor Summary',
+              re.IGNORECASE,
+          )
+          selected = set()
+          for index, line in enumerate(lines):
+              if pattern.search(line):
+                  selected.update(range(max(0, index - 6), min(len(lines), index + 12)))
+          if not selected:
+              selected.update(range(max(0, len(lines) - 250), len(lines)))
+          for index in sorted(selected):
+              print(f'{index + 1:05d}: {lines[index]}')
+          PY

--- a/.github/workflows/diagnose-1239-build.yml
+++ b/.github/workflows/diagnose-1239-build.yml
@@ -8,6 +8,8 @@ on:
 permissions:
   actions: read
   contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
   diagnose:
@@ -23,7 +25,7 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/jobs/88732643922/logs" \
             --output failed-job.log
-      - name: Print relevant failure context
+      - name: Extract relevant failure context
         run: |
           python3 - <<'PY'
           from pathlib import Path
@@ -41,6 +43,13 @@ jobs:
                   selected.update(range(max(0, index - 6), min(len(lines), index + 12)))
           if not selected:
               selected.update(range(max(0, len(lines) - 250), len(lines)))
-          for index in sorted(selected):
-              print(f'{index + 1:05d}: {lines[index]}')
+          excerpt = '\n'.join(f'{index + 1:05d}: {lines[index]}' for index in sorted(selected))
+          Path('summary.md').write_text(
+              '### Automated Maven failure diagnosis\n\n```text\n' + excerpt[-50000:] + '\n```\n'
+          )
+          print(excerpt)
           PY
+      - name: Post diagnosis to PR 1239
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh api "repos/${GITHUB_REPOSITORY}/issues/1239/comments" --method POST --raw-field body="$(cat summary.md)"


### PR DESCRIPTION
Temporary diagnostic PR. Downloads the completed failed Maven job log for #1239, extracts only the relevant failure context, and posts it to #1239. No product changes; close immediately after diagnosis.