### PR TITLE
Require explicit opt-in for project-wide Int-to-Enum cleanup

### DIFF
--- a/sandbox_int_to_enum/README.md
+++ b/sandbox_int_to_enum/README.md
@@ -4,18 +4,21 @@
 
 This Eclipse plugin detects legacy Java code in which integer constants represent a closed set of states and migrates provably safe cases to an enum.
 
-The implementation has two transformation paths:
+The implementation has three deliberately separated capabilities:
 
-- **If/else state detection** — implemented conservatively with binding and usage analysis.
-- **Integer switch migration** — existing experimental prototype for switch statements.
+- **Local if/else state detection** — binding-based migration when the complete state flow is contained in one compilation unit.
+- **Complete-project coordinated migration** — a narrow package-scoped method/caller migration that runs only when every project source compilation unit is in scope.
+- **Integer switch migration** — the existing experimental prototype for switch statements.
+
+Local cleanup does not automatically request project sources. Complete-project analysis is an explicit, disabled-by-default option because it can inspect and modify additional files and is materially more expensive.
 
 ## Why this needs semantic analysis
 
 A group of similarly named integer constants is not sufficient evidence for an enum. Integers may be used as bit masks, protocol values, persisted identifiers, arithmetic operands, public API values, or values crossing file boundaries. The cleanup therefore analyses bindings and all relevant references before changing a type.
 
-## Implemented safe if/else migration
+## Implemented safe local if/else migration
 
-The current implementation transforms a candidate only when all of the following are true:
+The local implementation transforms a candidate only when all of the following are true:
 
 1. At least two `private static final int` constants share an underscore-delimited prefix, such as `STATUS_*`.
 2. Their compile-time integer values are distinct.
@@ -26,7 +29,7 @@ The current implementation transforms a candidate only when all of the following
 7. The constants have no unsupported remaining references.
 8. The generated enum name and constants are valid and do not conflict with an existing nested type.
 
-These restrictions describe the first implemented detector, not a fundamental restriction of the Eclipse cleanup framework. The existing `ICleanUp` lifecycle calls `checkPreConditions(IJavaProject, ICompilationUnit[], ...)` with all selected compilation units and then invokes the same cleanup instance once per target unit. A cleanup can therefore prepare an immutable project-wide migration plan and return one local `CompilationUnitChange` for each file. `CleanUpRefactoring` already combines those changes into one preview, apply operation, and undo.
+These restrictions describe the local detector, not a fundamental restriction of the Eclipse cleanup framework. The existing `ICleanUp` lifecycle calls `checkPreConditions(IJavaProject, ICompilationUnit[], ...)` with all target compilation units and then invokes the same cleanup instance once per target unit. A cleanup can therefore prepare an immutable project-wide migration plan and return one local `CompilationUnitChange` for each file. `CleanUpRefactoring` combines those changes into one preview, apply operation, and undo.
 
 ## Example
 
@@ -82,46 +85,51 @@ The cleanup deliberately preserves the existing control flow. Replacing an if/el
 
 ## Cases currently rejected
 
-The implemented detector does not yet migrate:
+The implemented detectors do not yet migrate:
 
-- public, protected, or package-visible constants or method signatures;
+- public or protected constants and method signatures;
 - parameters passed arbitrary integer expressions rather than recognised constants;
-- constants used in arithmetic, persistence, return values, method arguments, or unrelated comparisons;
+- constants used in arithmetic, persistence, return values, unrelated method arguments, or unrelated comparisons;
 - duplicate integer values used as aliases;
 - bit flags, which generally require a different model such as `EnumSet`;
-- state flows spanning multiple methods or compilation units;
+- inheritance, interfaces, overrides, method references, or state flows spanning several methods;
+- partial-project multi-file analysis;
 - existing nested types that conflict with the generated enum name.
 
 A rejected candidate is left unchanged.
 
-## Project-wide migration
+## Complete-project coordinated migration
 
-A complete migration of legacy APIs requires project-wide reference analysis and coordinated edits to declarations, callers, implementations, overrides, fields, locals, tests, serialization boundaries, and possibly external compatibility adapters.
+The coordinated planner currently recognises a deliberately narrow package-scoped state method and proven callers in other files. Before producing any edits it requires every source compilation unit in the Java project to be present in the cleanup target. This closed-world requirement prevents unselected callers or constant references from being missed.
 
-There are two stages:
+There are two ways to provide that scope:
 
-1. **Selected-scope multi-file cleanup without a JDT UI patch.** During `checkPreConditions`, analyse all compilation units already selected for cleanup and build a shared immutable plan. During `createFix`, emit only the planned edits for the current `CleanUpContext`. The existing cleanup refactoring collects all per-file changes atomically.
-2. **Automatic scope expansion with a small patched JDT UI bundle.** Before precondition checking, a patched `CleanUpRefactoring` asks participating cleanups for additional related compilation units and adds them to the normal target set. The existing parsing, fixpoint, overlap, preview, validation, apply, and undo pipeline remains in use.
+1. **Select the entire Java project explicitly.** Stock cleanup orchestration passes all selected source units to the shared planner.
+2. **Enable automatic project-wide scope expansion.** In a product containing the patched JDT UI scope-provider integration, enable the child option **Analyze all project source files for coordinated migrations**. The cleanup then requests every project source compilation unit before precondition checking.
 
-A dedicated LTK refactoring remains useful for interactive naming and compatibility choices, but it is not required merely to coordinate changes across already selected Java files.
+The project-wide option is disabled by default. Enabling only **Convert int constants to enum/switch** retains the user's initial selection and runs the local detector without scanning unrelated project files.
 
-The reusable planning infrastructure is tracked in issue #1206 and is intended for both this plugin and `sandbox_junit_cleanup`.
+The existing cleanup refactoring still owns parsing, fixpoint processing, overlap handling, preview, validation, apply, and undo. The Sandbox cleanup contributes scope discovery and an immutable semantic plan; it does not bypass the standard LTK transaction.
+
+A dedicated LTK refactoring remains useful for interactive naming and compatibility choices, but it is not required merely to coordinate already closed and fully selected Java source scope.
 
 ## Save actions
 
-The local transformation may remain available as a save action. Project-wide migration must be restricted to explicit cleanup runs because the save participant supplies only the saved compilation unit and should not silently edit other files.
+Local transformation may remain available as a save action. Project-wide scope expansion is initialized to `false` for save actions and also requires the main cleanup option, so saving one compilation unit cannot silently edit other files.
 
 ## Usage
 
 1. Open **Preferences → Java → Code Style → Clean Up**.
 2. Create or edit a cleanup profile.
-3. Enable **Convert int constants to enum/switch**.
-4. Run the cleanup on selected Java sources, a package, source folder, or project.
+3. Enable **Convert int constants to enum/switch** for local transformations in the selected cleanup scope.
+4. For the coordinated complete-project migration, additionally enable **Analyze all project source files for coordinated migrations**.
+5. Review the cleanup preview before applying changes.
 
 ## Requirements
 
 - Eclipse 2025-12 or later
 - Java 21 or later
+- The patched JDT UI scope-provider integration for automatic target expansion; otherwise select the complete Java project manually
 
 ## Technical documentation
 

--- a/sandbox_int_to_enum/src/org/sandbox/jdt/internal/corext/fix/IntToEnumCleanUpOptions.java
+++ b/sandbox_int_to_enum/src/org/sandbox/jdt/internal/corext/fix/IntToEnumCleanUpOptions.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.corext.fix;
+
+/** Additional options that control the scope of the Int-to-Enum cleanup. */
+public final class IntToEnumCleanUpOptions {
+
+	/**
+	 * Enables coordinated planning across every source compilation unit in the
+	 * selected Java project. The option is deliberately separate from the main
+	 * cleanup switch because project-wide analysis can change additional files and
+	 * is substantially more expensive than a local cleanup.
+	 */
+	public static final String PROJECT_WIDE= "cleanup.int_to_enum.project_wide"; //$NON-NLS-1$
+
+	private IntToEnumCleanUpOptions() {
+		// constants only
+	}
+}

--- a/sandbox_int_to_enum/src/org/sandbox/jdt/internal/ui/fix/IntToEnumCleanUpCore.java
+++ b/sandbox_int_to_enum/src/org/sandbox/jdt/internal/ui/fix/IntToEnumCleanUpCore.java
@@ -47,6 +47,7 @@ import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
 import org.sandbox.jdt.cleanup.multifile.AbstractPlannedMultiFileCleanUp;
 import org.sandbox.jdt.cleanup.multifile.JavaProjectCompilationUnits;
 import org.sandbox.jdt.cleanup.multifile.MultiFileCleanUpPlanResult;
+import org.sandbox.jdt.cleanup.multifile.SelectedCompilationUnitPlan;
 import org.sandbox.jdt.internal.corext.fix.IntToEnumFixCore;
 import org.sandbox.jdt.internal.corext.fix.multifile.IntEnumMigrationPlan;
 import org.sandbox.jdt.internal.corext.fix.multifile.IntEnumMultiFilePlanner;
@@ -77,6 +78,10 @@ public class IntToEnumCleanUpCore extends AbstractPlannedMultiFileCleanUp<IntEnu
 		}
 		if (monitor != null && monitor.isCanceled()) {
 			throw new OperationCanceledException();
+		}
+		if (!isEnabled(PROJECT_WIDE)) {
+			SelectedCompilationUnitPlan selectedScope= SelectedCompilationUnitPlan.of(project, compilationUnits);
+			return MultiFileCleanUpPlanResult.success(new IntEnumMigrationPlan(selectedScope, List.of()));
 		}
 		return IntEnumMultiFilePlanner.create(project, compilationUnits, monitor);
 	}

--- a/sandbox_int_to_enum/src/org/sandbox/jdt/internal/ui/fix/IntToEnumCleanUpCore.java
+++ b/sandbox_int_to_enum/src/org/sandbox/jdt/internal/ui/fix/IntToEnumCleanUpCore.java
@@ -13,9 +13,11 @@
  *******************************************************************************/
 package org.sandbox.jdt.internal.ui.fix;
 
+import static org.sandbox.jdt.internal.corext.fix.IntToEnumCleanUpOptions.PROJECT_WIDE;
 import static org.sandbox.jdt.internal.corext.fix2.MYCleanUpConstants.INT_TO_ENUM_CLEANUP;
 import static org.sandbox.jdt.internal.ui.fix.MultiFixMessages.IntToEnumCleanUpFix_refactor;
 import static org.sandbox.jdt.internal.ui.fix.MultiFixMessages.IntToEnumCleanUp_description;
+import static org.sandbox.jdt.internal.ui.fix.MultiFixMessages.IntToEnumCleanUp_project_wide_description;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -111,7 +113,7 @@ public class IntToEnumCleanUpCore extends AbstractPlannedMultiFileCleanUp<IntEnu
 	@Override
 	protected Collection<ICompilationUnit> discoverAdditionalCompilationUnits(IJavaProject project,
 			Collection<ICompilationUnit> currentScope, IProgressMonitor monitor) throws CoreException {
-		if (!isEnabled(INT_TO_ENUM_CLEANUP)) {
+		if (!isEnabled(INT_TO_ENUM_CLEANUP) || !isEnabled(PROJECT_WIDE)) {
 			return List.of();
 		}
 		if (monitor != null && monitor.isCanceled()) {
@@ -128,6 +130,9 @@ public class IntToEnumCleanUpCore extends AbstractPlannedMultiFileCleanUp<IntEnu
 					new Object[] { String.join(",", computeFixSet().stream() //$NON-NLS-1$
 							.map(IntToEnumFixCore::toString)
 							.collect(Collectors.toList())) }));
+			if (isEnabled(PROJECT_WIDE)) {
+				result.add(IntToEnumCleanUp_project_wide_description);
+			}
 		}
 		return result.toArray(new String[0]);
 	}

--- a/sandbox_int_to_enum/src/org/sandbox/jdt/internal/ui/fix/MultiFixMessages.java
+++ b/sandbox_int_to_enum/src/org/sandbox/jdt/internal/ui/fix/MultiFixMessages.java
@@ -23,6 +23,7 @@ public final class MultiFixMessages extends NLS {
 
 	public static String IntToEnumCleanUpFix_refactor;
 	public static String IntToEnumCleanUp_description;
+	public static String IntToEnumCleanUp_project_wide_description;
 
 	static {
 		NLS.initializeMessages(BUNDLE_NAME, MultiFixMessages.class);

--- a/sandbox_int_to_enum/src/org/sandbox/jdt/internal/ui/fix/MultiFixMessages.properties
+++ b/sandbox_int_to_enum/src/org/sandbox/jdt/internal/ui/fix/MultiFixMessages.properties
@@ -1,2 +1,3 @@
 IntToEnumCleanUpFix_refactor=Convert int constants to enum
 IntToEnumCleanUp_description=Converting int constants to enum: {0}
+IntToEnumCleanUp_project_wide_description=Coordinate Int-to-Enum migration across all project source files

--- a/sandbox_int_to_enum/src/org/sandbox/jdt/internal/ui/preferences/cleanup/CleanUpMessages.java
+++ b/sandbox_int_to_enum/src/org/sandbox/jdt/internal/ui/preferences/cleanup/CleanUpMessages.java
@@ -22,6 +22,7 @@ public final class CleanUpMessages extends NLS {
 	private static final String BUNDLE_NAME = "org.sandbox.jdt.internal.ui.preferences.cleanup.CleanUpMessages"; //$NON-NLS-1$
 
 	public static String IntToEnumTabPage_CheckboxName_IntToEnum;
+	public static String IntToEnumTabPage_CheckboxName_ProjectWide;
 	public static String IntToEnumTabPage_GroupName_IntToEnum;
 
 	static {

--- a/sandbox_int_to_enum/src/org/sandbox/jdt/internal/ui/preferences/cleanup/CleanUpMessages.properties
+++ b/sandbox_int_to_enum/src/org/sandbox/jdt/internal/ui/preferences/cleanup/CleanUpMessages.properties
@@ -1,2 +1,3 @@
 IntToEnumTabPage_CheckboxName_IntToEnum=Convert int constants to enum/switch
+IntToEnumTabPage_CheckboxName_ProjectWide=Analyze all project source files for coordinated migrations
 IntToEnumTabPage_GroupName_IntToEnum=Int to Enum Conversion

--- a/sandbox_int_to_enum/src/org/sandbox/jdt/internal/ui/preferences/cleanup/DefaultCleanUpOptionsInitializer.java
+++ b/sandbox_int_to_enum/src/org/sandbox/jdt/internal/ui/preferences/cleanup/DefaultCleanUpOptionsInitializer.java
@@ -15,6 +15,7 @@ package org.sandbox.jdt.internal.ui.preferences.cleanup;
 
 import org.eclipse.jdt.ui.cleanup.CleanUpOptions;
 import org.eclipse.jdt.ui.cleanup.ICleanUpOptionsInitializer;
+import org.sandbox.jdt.internal.corext.fix.IntToEnumCleanUpOptions;
 import org.sandbox.jdt.internal.corext.fix2.MYCleanUpConstants;
 
 /**
@@ -25,5 +26,6 @@ public class DefaultCleanUpOptionsInitializer implements ICleanUpOptionsInitiali
 	@Override
 	public void setDefaultOptions(CleanUpOptions options) {
 		options.setOption(MYCleanUpConstants.INT_TO_ENUM_CLEANUP, CleanUpOptions.FALSE);
+		options.setOption(IntToEnumCleanUpOptions.PROJECT_WIDE, CleanUpOptions.FALSE);
 	}
 }

--- a/sandbox_int_to_enum/src/org/sandbox/jdt/internal/ui/preferences/cleanup/SandboxCodeTabPage.java
+++ b/sandbox_int_to_enum/src/org/sandbox/jdt/internal/ui/preferences/cleanup/SandboxCodeTabPage.java
@@ -20,6 +20,7 @@ import org.eclipse.jdt.internal.ui.preferences.cleanup.AbstractCleanUpTabPage;
 import org.eclipse.jdt.ui.cleanup.CleanUpOptions;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
+import org.sandbox.jdt.internal.corext.fix.IntToEnumCleanUpOptions;
 import org.sandbox.jdt.internal.corext.fix2.MYCleanUpConstants;
 import org.sandbox.jdt.internal.ui.fix.IntToEnumCleanUp;
 
@@ -48,9 +49,19 @@ public class SandboxCodeTabPage extends AbstractCleanUpTabPage {
 	@Override
 	protected void doCreatePreferences(Composite composite, int numColumns) {
 		Group intToEnumGroup = createGroup(numColumns, composite, CleanUpMessages.IntToEnumTabPage_GroupName_IntToEnum);
-		createCheckboxPref(intToEnumGroup, numColumns, 
-				CleanUpMessages.IntToEnumTabPage_CheckboxName_IntToEnum, 
-				MYCleanUpConstants.INT_TO_ENUM_CLEANUP, 
+		CheckboxPreference intToEnum= createCheckboxPref(intToEnumGroup, numColumns,
+				CleanUpMessages.IntToEnumTabPage_CheckboxName_IntToEnum,
+				MYCleanUpConstants.INT_TO_ENUM_CLEANUP,
 				FALSE_TRUE);
+
+		intent(intToEnumGroup);
+		CheckboxPreference projectWide= createCheckboxPref(intToEnumGroup, numColumns - 1,
+				CleanUpMessages.IntToEnumTabPage_CheckboxName_ProjectWide,
+				IntToEnumCleanUpOptions.PROJECT_WIDE,
+				FALSE_TRUE);
+		registerSlavePreference(intToEnum, new CheckboxPreference[] { projectWide });
+
+		intent(intToEnumGroup);
+		registerPreference(intToEnum);
 	}
 }

--- a/sandbox_int_to_enum/src/org/sandbox/jdt/internal/ui/preferences/cleanup/SaveActionCleanUpOptionsInitializer.java
+++ b/sandbox_int_to_enum/src/org/sandbox/jdt/internal/ui/preferences/cleanup/SaveActionCleanUpOptionsInitializer.java
@@ -15,6 +15,7 @@ package org.sandbox.jdt.internal.ui.preferences.cleanup;
 
 import org.eclipse.jdt.ui.cleanup.CleanUpOptions;
 import org.eclipse.jdt.ui.cleanup.ICleanUpOptionsInitializer;
+import org.sandbox.jdt.internal.corext.fix.IntToEnumCleanUpOptions;
 import org.sandbox.jdt.internal.corext.fix2.MYCleanUpConstants;
 
 /**
@@ -25,5 +26,6 @@ public class SaveActionCleanUpOptionsInitializer implements ICleanUpOptionsIniti
 	@Override
 	public void setDefaultOptions(CleanUpOptions options) {
 		options.setOption(MYCleanUpConstants.INT_TO_ENUM_CLEANUP, CleanUpOptions.FALSE);
+		options.setOption(IntToEnumCleanUpOptions.PROJECT_WIDE, CleanUpOptions.FALSE);
 	}
 }

--- a/sandbox_int_to_enum_test/src/org/eclipse/jdt/ui/tests/quickfix/Java22/IntToEnumScopeExpansionTest.java
+++ b/sandbox_int_to_enum_test/src/org/eclipse/jdt/ui/tests/quickfix/Java22/IntToEnumScopeExpansionTest.java
@@ -65,6 +65,10 @@ public class IntToEnumScopeExpansionTest {
 					private static final int STATUS_PENDING = 0;
 					private static final int STATUS_APPROVED = 1;
 
+					void run() {
+						process(STATUS_PENDING);
+					}
+
 					private void process(int status) {
 						if (status == STATUS_PENDING) {
 							System.out.println("pending");
@@ -84,6 +88,10 @@ public class IntToEnumScopeExpansionTest {
 						public class Selected {
 							private enum Status {
 								PENDING, APPROVED
+							}
+
+							void run() {
+								process(Status.PENDING);
 							}
 
 							private void process(Status status) {

--- a/sandbox_int_to_enum_test/src/org/eclipse/jdt/ui/tests/quickfix/Java22/IntToEnumScopeExpansionTest.java
+++ b/sandbox_int_to_enum_test/src/org/eclipse/jdt/ui/tests/quickfix/Java22/IntToEnumScopeExpansionTest.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.quickfix.Java22;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.ui.cleanup.CleanUpOptions;
+
+import org.sandbox.jdt.internal.corext.fix.IntToEnumCleanUpOptions;
+import org.sandbox.jdt.internal.corext.fix2.MYCleanUpConstants;
+import org.sandbox.jdt.internal.ui.fix.IntToEnumCleanUpCore;
+import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
+import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava22;
+
+/** Tests that project-wide Int-to-Enum analysis requires explicit opt-in. */
+public class IntToEnumScopeExpansionTest {
+
+	@RegisterExtension
+	AbstractEclipseJava context= new EclipseJava22();
+
+	@Test
+	public void localOptionDoesNotExpandScope() throws CoreException {
+		IPackageFragment pack= context.getSourceFolder().createPackageFragment("test", true, null); //$NON-NLS-1$
+		ICompilationUnit selected= createUnit(pack, "Selected.java"); //$NON-NLS-1$
+		createUnit(pack, "Unrelated.java"); //$NON-NLS-1$
+		IntToEnumCleanUpCore cleanup= new IntToEnumCleanUpCore(Map.of(
+				MYCleanUpConstants.INT_TO_ENUM_CLEANUP, CleanUpOptions.TRUE));
+
+		Collection<ICompilationUnit> expanded= cleanup.expandCleanUpScope(selected.getJavaProject(),
+				List.of(selected), null);
+
+		assertTrue(expanded.isEmpty(), "A local Int-to-Enum cleanup must retain the user's target scope");
+	}
+
+	@Test
+	public void projectWideOptionExpandsToAllProjectSources() throws CoreException {
+		IPackageFragment pack= context.getSourceFolder().createPackageFragment("test", true, null); //$NON-NLS-1$
+		ICompilationUnit selected= createUnit(pack, "Selected.java"); //$NON-NLS-1$
+		ICompilationUnit related= createUnit(pack, "Related.java"); //$NON-NLS-1$
+		ICompilationUnit unrelated= createUnit(pack, "Unrelated.java"); //$NON-NLS-1$
+		IntToEnumCleanUpCore cleanup= new IntToEnumCleanUpCore(Map.of(
+				MYCleanUpConstants.INT_TO_ENUM_CLEANUP, CleanUpOptions.TRUE,
+				IntToEnumCleanUpOptions.PROJECT_WIDE, CleanUpOptions.TRUE));
+
+		Collection<ICompilationUnit> expanded= cleanup.expandCleanUpScope(selected.getJavaProject(),
+				List.of(selected), null);
+		Set<String> expandedHandles= expanded.stream().map(ICompilationUnit::getHandleIdentifier)
+				.collect(Collectors.toSet());
+
+		assertEquals(Set.of(selected.getHandleIdentifier(), related.getHandleIdentifier(),
+				unrelated.getHandleIdentifier()), expandedHandles,
+				"The explicit project-wide option must include every project source unit");
+	}
+
+	private static ICompilationUnit createUnit(IPackageFragment pack, String name) throws CoreException {
+		String source= "package test;%n%npublic class %s {%n}%n" //$NON-NLS-1$
+				.formatted(name.substring(0, name.length() - ".java".length())); //$NON-NLS-1$
+		return pack.createCompilationUnit(name, source, false, null);
+	}
+}

--- a/sandbox_int_to_enum_test/src/org/eclipse/jdt/ui/tests/quickfix/Java22/IntToEnumScopeExpansionTest.java
+++ b/sandbox_int_to_enum_test/src/org/eclipse/jdt/ui/tests/quickfix/Java22/IntToEnumScopeExpansionTest.java
@@ -55,6 +55,49 @@ public class IntToEnumScopeExpansionTest {
 	}
 
 	@Test
+	public void localCleanupStillRunsWithoutProjectPlanner() throws CoreException {
+		IPackageFragment pack= context.getSourceFolder().createPackageFragment("test", true, null); //$NON-NLS-1$
+		ICompilationUnit selected= pack.createCompilationUnit("Selected.java", //$NON-NLS-1$
+				"""
+				package test;
+
+				public class Selected {
+					private static final int STATUS_PENDING = 0;
+					private static final int STATUS_APPROVED = 1;
+
+					private void process(int status) {
+						if (status == STATUS_PENDING) {
+							System.out.println("pending");
+						} else if (status == STATUS_APPROVED) {
+							System.out.println("approved");
+						}
+					}
+				}
+				""", false, null);
+		createUnit(pack, "Unrelated.java"); //$NON-NLS-1$
+		context.enable(MYCleanUpConstants.INT_TO_ENUM_CLEANUP);
+
+		context.assertRefactoringResultAsExpectedNormalizingWhitespace(new ICompilationUnit[] { selected },
+				new String[] { """
+						package test;
+
+						public class Selected {
+							private enum Status {
+								PENDING, APPROVED
+							}
+
+							private void process(Status status) {
+								if (status == Status.PENDING) {
+									System.out.println("pending");
+								} else if (status == Status.APPROVED) {
+									System.out.println("approved");
+								}
+							}
+						}
+						""" }, null);
+	}
+
+	@Test
 	public void projectWideOptionExpandsToAllProjectSources() throws CoreException {
 		IPackageFragment pack= context.getSourceFolder().createPackageFragment("test", true, null); //$NON-NLS-1$
 		ICompilationUnit selected= createUnit(pack, "Selected.java"); //$NON-NLS-1$

--- a/sandbox_int_to_enum_test/src/org/eclipse/jdt/ui/tests/quickfix/Java22/MultiFileIntToEnumCleanUpTest.java
+++ b/sandbox_int_to_enum_test/src/org/eclipse/jdt/ui/tests/quickfix/Java22/MultiFileIntToEnumCleanUpTest.java
@@ -18,6 +18,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IPackageFragment;
 
+import org.sandbox.jdt.internal.corext.fix.IntToEnumCleanUpOptions;
 import org.sandbox.jdt.internal.corext.fix2.MYCleanUpConstants;
 import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
 import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava22;
@@ -60,6 +61,7 @@ public class MultiFileIntToEnumCleanUpTest {
 				""", false, null);
 
 		context.enable(MYCleanUpConstants.INT_TO_ENUM_CLEANUP);
+		context.enable(IntToEnumCleanUpOptions.PROJECT_WIDE);
 
 		context.assertRefactoringResultAsExpectedNormalizingWhitespace(new ICompilationUnit[] { processor, client },
 				new String[] {
@@ -127,6 +129,7 @@ public class MultiFileIntToEnumCleanUpTest {
 				""", false, null);
 
 		context.enable(MYCleanUpConstants.INT_TO_ENUM_CLEANUP);
+		context.enable(IntToEnumCleanUpOptions.PROJECT_WIDE);
 
 		context.assertRefactoringHasNoChange(new ICompilationUnit[] { processor, client });
 	}


### PR DESCRIPTION
## Summary

Separates local Int-to-Enum cleanup behavior from automatic full-project scope expansion and prevents the full-project planner from running for local-only profiles.

## Behavior

- enabling `INT_TO_ENUM_CLEANUP` alone retains the user's selected compilation units;
- local runs create only a lightweight selected-scope plan, so they do not enumerate every project source file;
- a new disabled-by-default child option, **Analyze all project source files for coordinated migrations**, explicitly requests every project source unit and activates the coordinated planner;
- save actions keep project-wide expansion disabled;
- cleanup step descriptions disclose when project-wide coordination is active.

The current coordinated Int-to-Enum planner deliberately requires the complete project source scope before it proposes cross-file edits. Without the new option, the local detector still runs in the user's selected units; in stock JDT UI, users can provide the coordinated planner's closed scope by selecting the complete Java project manually and enabling the project-wide option in the profile.

## Tests

- local Int-to-Enum option returns no additional compilation units;
- local transformation still runs on the selected unit when unrelated project sources exist;
- project-wide opt-in expands to selected, related, and unrelated project source units;
- existing package-scoped multi-file migration tests enable the project-wide option explicitly.

## Documentation

- explains the distinction between local detection and complete-project coordinated migration;
- documents the disabled-by-default child option, save-action boundary, patched-JDT requirement, and manual full-project-selection alternative.

Fixes #1228.