### PR TITLE
Verify and harden atomic multi-file cleanup lifecycle

### DIFF
--- a/sandbox_common/src/org/sandbox/jdt/cleanup/multifile/AbstractPlannedMultiFileCleanUp.java
+++ b/sandbox_common/src/org/sandbox/jdt/cleanup/multifile/AbstractPlannedMultiFileCleanUp.java
@@ -108,8 +108,17 @@ public abstract class AbstractPlannedMultiFileCleanUp<P> extends AbstractCleanUp
 		if (unit == null) {
 			return null;
 		}
-		P plan= plansByProject.get(unit.getJavaProject());
-		return plan == null ? null : createFixForPlan(plan, context);
+		IJavaProject project= unit.getJavaProject();
+		P plan= plansByProject.get(project);
+		if (plan == null) {
+			return null;
+		}
+		try {
+			return createFixForPlan(plan, context);
+		} catch (CoreException | RuntimeException e) {
+			plansByProject.remove(project);
+			throw e;
+		}
 	}
 
 	@Override

--- a/sandbox_common_test/src/org/sandbox/jdt/cleanup/multifile/AbstractPlannedMultiFileCleanUpTest.java
+++ b/sandbox_common_test/src/org/sandbox/jdt/cleanup/multifile/AbstractPlannedMultiFileCleanUpTest.java
@@ -12,8 +12,10 @@ package org.sandbox.jdt.cleanup.multifile;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.lang.reflect.Proxy;
 import java.util.ArrayList;
@@ -25,6 +27,8 @@ import org.junit.jupiter.api.Test;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.Status;
 
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 
@@ -43,10 +47,21 @@ class AbstractPlannedMultiFileCleanUpTest {
 		private final List<ICompilationUnit> fixedUnits= new ArrayList<>();
 		private ICompilationUnit[] plannedUnits;
 		private RefactoringStatus planningStatus= new RefactoringStatus();
+		private CoreException planningCoreFailure;
+		private RuntimeException planningRuntimeFailure;
+		private IJavaProject failingFixProject;
+		private CoreException fixFailure;
+		private CoreException postConditionFailure;
 
 		@Override
 		protected MultiFileCleanUpPlanResult<TestPlan> createPlan(IJavaProject project,
-				ICompilationUnit[] compilationUnits, IProgressMonitor monitor) {
+				ICompilationUnit[] compilationUnits, IProgressMonitor monitor) throws CoreException {
+			if (planningCoreFailure != null) {
+				throw planningCoreFailure;
+			}
+			if (planningRuntimeFailure != null) {
+				throw planningRuntimeFailure;
+			}
 			plannedUnits= compilationUnits;
 			if (planningStatus.hasFatalError()) {
 				return new MultiFileCleanUpPlanResult<>(null, planningStatus);
@@ -55,10 +70,21 @@ class AbstractPlannedMultiFileCleanUpTest {
 		}
 
 		@Override
-		protected ICleanUpFix createFixForPlan(TestPlan plan, CleanUpContext context) {
+		protected ICleanUpFix createFixForPlan(TestPlan plan, CleanUpContext context) throws CoreException {
 			assertSame(plan.project(), context.getCompilationUnit().getJavaProject());
+			if (plan.project() == failingFixProject && fixFailure != null) {
+				throw fixFailure;
+			}
 			fixedUnits.add(context.getCompilationUnit());
 			return null;
+		}
+
+		@Override
+		protected RefactoringStatus checkPlanPostConditions(IProgressMonitor monitor) throws CoreException {
+			if (postConditionFailure != null) {
+				throw postConditionFailure;
+			}
+			return new RefactoringStatus();
 		}
 
 		TestPlan retainedPlan(IJavaProject project) {
@@ -101,6 +127,91 @@ class AbstractPlannedMultiFileCleanUpTest {
 		assertEquals(RefactoringStatus.FATAL, status.getSeverity());
 		assertNull(cleanUp.retainedPlan(project));
 		assertNull(cleanUp.createFix(new CleanUpContext(unit, null)));
+	}
+
+	@Test
+	void clearsPreviousPlanWhenPlanningThrowsCoreException() throws CoreException {
+		IJavaProject project= javaProject();
+		ICompilationUnit unit= compilationUnit(project, "Changed.java"); //$NON-NLS-1$
+		TestCleanUp cleanUp= new TestCleanUp();
+		cleanUp.checkPreConditions(project, new ICompilationUnit[] { unit }, new NullProgressMonitor());
+		assertNotNull(cleanUp.retainedPlan(project));
+		cleanUp.planningCoreFailure= new CoreException(Status.error("Planning failed")); //$NON-NLS-1$
+
+		assertThrows(CoreException.class, () -> cleanUp.checkPreConditions(project,
+				new ICompilationUnit[] { unit }, new NullProgressMonitor()));
+
+		assertNull(cleanUp.retainedPlan(project));
+	}
+
+	@Test
+	void clearsPreviousPlanWhenPlanningIsCancelled() throws CoreException {
+		IJavaProject project= javaProject();
+		ICompilationUnit unit= compilationUnit(project, "Cancelled.java"); //$NON-NLS-1$
+		TestCleanUp cleanUp= new TestCleanUp();
+		cleanUp.checkPreConditions(project, new ICompilationUnit[] { unit }, new NullProgressMonitor());
+		assertNotNull(cleanUp.retainedPlan(project));
+		cleanUp.planningRuntimeFailure= new OperationCanceledException();
+
+		assertThrows(OperationCanceledException.class, () -> cleanUp.checkPreConditions(project,
+				new ICompilationUnit[] { unit }, new NullProgressMonitor()));
+
+		assertNull(cleanUp.retainedPlan(project));
+	}
+
+	@Test
+	void fixResolutionFailureClearsOnlyTheAffectedProjectPlan() throws CoreException {
+		IJavaProject firstProject= javaProject();
+		IJavaProject secondProject= javaProject();
+		ICompilationUnit first= compilationUnit(firstProject, "First.java"); //$NON-NLS-1$
+		ICompilationUnit second= compilationUnit(secondProject, "Second.java"); //$NON-NLS-1$
+		TestCleanUp cleanUp= new TestCleanUp();
+		cleanUp.checkPreConditions(firstProject, new ICompilationUnit[] { first }, new NullProgressMonitor());
+		cleanUp.checkPreConditions(secondProject, new ICompilationUnit[] { second }, new NullProgressMonitor());
+		cleanUp.failingFixProject= firstProject;
+		cleanUp.fixFailure= new CoreException(Status.error("Planned binding is stale")); //$NON-NLS-1$
+
+		assertThrows(CoreException.class, () -> cleanUp.createFix(new CleanUpContext(first, null)));
+
+		assertNull(cleanUp.retainedPlan(firstProject));
+		assertNotNull(cleanUp.retainedPlan(secondProject));
+		cleanUp.createFix(new CleanUpContext(second, null));
+		assertEquals(List.of(second), cleanUp.fixedUnits);
+	}
+
+	@Test
+	void postConditionExceptionClearsPlansForEveryProject() throws CoreException {
+		IJavaProject firstProject= javaProject();
+		IJavaProject secondProject= javaProject();
+		ICompilationUnit first= compilationUnit(firstProject, "First.java"); //$NON-NLS-1$
+		ICompilationUnit second= compilationUnit(secondProject, "Second.java"); //$NON-NLS-1$
+		TestCleanUp cleanUp= new TestCleanUp();
+		cleanUp.checkPreConditions(firstProject, new ICompilationUnit[] { first }, new NullProgressMonitor());
+		cleanUp.checkPreConditions(secondProject, new ICompilationUnit[] { second }, new NullProgressMonitor());
+		cleanUp.postConditionFailure= new CoreException(Status.error("Postcondition failed")); //$NON-NLS-1$
+
+		assertThrows(CoreException.class, () -> cleanUp.checkPostConditions(new NullProgressMonitor()));
+
+		assertNull(cleanUp.retainedPlan(firstProject));
+		assertNull(cleanUp.retainedPlan(secondProject));
+	}
+
+	@Test
+	void keepsPlansAndFixesIsolatedByJavaProject() throws CoreException {
+		IJavaProject firstProject= javaProject();
+		IJavaProject secondProject= javaProject();
+		ICompilationUnit first= compilationUnit(firstProject, "SameName.java"); //$NON-NLS-1$
+		ICompilationUnit second= compilationUnit(secondProject, "SameName.java"); //$NON-NLS-1$
+		TestCleanUp cleanUp= new TestCleanUp();
+
+		cleanUp.checkPreConditions(firstProject, new ICompilationUnit[] { first }, new NullProgressMonitor());
+		cleanUp.checkPreConditions(secondProject, new ICompilationUnit[] { second }, new NullProgressMonitor());
+
+		assertEquals(List.of(first), cleanUp.retainedPlan(firstProject).units());
+		assertEquals(List.of(second), cleanUp.retainedPlan(secondProject).units());
+		cleanUp.createFix(new CleanUpContext(second, null));
+		cleanUp.createFix(new CleanUpContext(first, null));
+		assertEquals(List.of(second, first), cleanUp.fixedUnits);
 	}
 
 	@Test

--- a/sandbox_int_to_enum_test/src/org/eclipse/jdt/ui/tests/quickfix/Java22/MultiFileIntToEnumCleanUpTest.java
+++ b/sandbox_int_to_enum_test/src/org/eclipse/jdt/ui/tests/quickfix/Java22/MultiFileIntToEnumCleanUpTest.java
@@ -22,6 +22,7 @@ import org.sandbox.jdt.internal.corext.fix.IntToEnumCleanUpOptions;
 import org.sandbox.jdt.internal.corext.fix2.MYCleanUpConstants;
 import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
 import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava22;
+import org.sandbox.jdt.ui.tests.quickfix.rules.MultiFileCleanUpLifecycleAssertions;
 
 /** Integration test for a package-scoped state API and a caller in another file. */
 public class MultiFileIntToEnumCleanUpTest {
@@ -63,7 +64,8 @@ public class MultiFileIntToEnumCleanUpTest {
 		context.enable(MYCleanUpConstants.INT_TO_ENUM_CLEANUP);
 		context.enable(IntToEnumCleanUpOptions.PROJECT_WIDE);
 
-		context.assertRefactoringResultAsExpectedNormalizingWhitespace(new ICompilationUnit[] { processor, client },
+		MultiFileCleanUpLifecycleAssertions.assertApplyCompileAndUndo(
+				new ICompilationUnit[] { processor, client },
 				new String[] {
 						"""
 						package test;
@@ -90,7 +92,7 @@ public class MultiFileIntToEnumCleanUpTest {
 								processor.process(test.OrderProcessor.Status.PENDING);
 							}
 						}
-						""" }, null);
+						""" });
 	}
 
 	@Test

--- a/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/MultiFileExternalResourceLifecycleTest.java
+++ b/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/MultiFileExternalResourceLifecycleTest.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.quickfix.Java8;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.junit.JUnitCore;
+
+import org.sandbox.jdt.internal.corext.fix2.MYCleanUpConstants;
+import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
+import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava17;
+import org.sandbox.jdt.ui.tests.quickfix.rules.MultiFileCleanUpLifecycleAssertions;
+
+/** Lifecycle QA for the coordinated JUnit ExternalResource migration. */
+public class MultiFileExternalResourceLifecycleTest {
+
+	@RegisterExtension
+	AbstractEclipseJava context= new EclipseJava17();
+
+	private IPackageFragmentRoot root;
+
+	@BeforeEach
+	public void setup() throws CoreException {
+		root= context.createClasspathForJUnit(JUnitCore.JUNIT4_CONTAINER_PATH);
+		AbstractEclipseJava.addToClasspath(context.getJavaProject(),
+				JavaCore.newContainerEntry(JUnitCore.JUNIT5_CONTAINER_PATH));
+	}
+
+	@Test
+	public void appliesCompilesAndUndoesNamedExternalResourceMigration() throws CoreException {
+		IPackageFragment pack= root.createPackageFragment("test", true, null); //$NON-NLS-1$
+		ICompilationUnit resource= pack.createCompilationUnit("SharedResource.java", //$NON-NLS-1$
+				"""
+				package test;
+				import org.junit.rules.ExternalResource;
+
+				public class SharedResource extends ExternalResource {
+					@Override
+					protected void before() throws Throwable {
+						System.setProperty("resource", "started");
+					}
+
+					@Override
+					protected void after() {
+						System.clearProperty("resource");
+					}
+				}
+				""", false, null);
+		ICompilationUnit test= pack.createCompilationUnit("MyTest.java", //$NON-NLS-1$
+				"""
+				package test;
+				import org.junit.Rule;
+
+				public class MyTest {
+					@Rule
+					public SharedResource resource = new SharedResource();
+				}
+				""", false, null);
+
+		context.enable(MYCleanUpConstants.JUNIT_CLEANUP);
+		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_4_RULEEXTERNALRESOURCE);
+
+		MultiFileCleanUpLifecycleAssertions.assertApplyCompileAndUndo(
+				new ICompilationUnit[] { resource, test },
+				new String[] {
+						"""
+						package test;
+						import org.junit.jupiter.api.extension.AfterEachCallback;
+						import org.junit.jupiter.api.extension.BeforeEachCallback;
+						import org.junit.jupiter.api.extension.ExtensionContext;
+
+						public class SharedResource implements BeforeEachCallback, AfterEachCallback {
+							@Override
+							public void beforeEach(ExtensionContext context) {
+								System.setProperty("resource", "started");
+							}
+
+							@Override
+							public void afterEach(ExtensionContext context) {
+								System.clearProperty("resource");
+							}
+						}
+						""",
+						"""
+						package test;
+						import org.junit.jupiter.api.extension.RegisterExtension;
+
+						public class MyTest {
+							@RegisterExtension
+							public SharedResource resource = new SharedResource();
+						}
+						""" });
+	}
+}

--- a/sandbox_test_commons/src/org/sandbox/jdt/ui/tests/quickfix/rules/MultiFileCleanUpLifecycleAssertions.java
+++ b/sandbox_test_commons/src/org/sandbox/jdt/ui/tests/quickfix/rules/MultiFileCleanUpLifecycleAssertions.java
@@ -181,10 +181,24 @@ public final class MultiFileCleanUpLifecycleAssertions {
 
 	private static String normalizeWhitespace(String source) {
 		return Arrays.stream(normalizeLineEndings(source).split("\n", -1)) //$NON-NLS-1$
-				.map(line -> line.stripTrailing().replaceFirst("^\\t+", match -> "    ".repeat(match.group().length()))) //$NON-NLS-1$ //$NON-NLS-2$
+				.map(MultiFileCleanUpLifecycleAssertions::normalizeIndentation)
+				.map(String::stripTrailing)
 				.collect(Collectors.joining("\n")) //$NON-NLS-1$
 				.replaceAll("\n{3,}", "\n\n") //$NON-NLS-1$ //$NON-NLS-2$
 				.strip();
+	}
+
+	private static String normalizeIndentation(String line) {
+		int endOfIndent= 0;
+		while (endOfIndent < line.length()
+				&& (line.charAt(endOfIndent) == ' ' || line.charAt(endOfIndent) == '\t')) {
+			endOfIndent++;
+		}
+		if (endOfIndent == 0) {
+			return line;
+		}
+		String leading= line.substring(0, endOfIndent).replace("\t", "    "); //$NON-NLS-1$ //$NON-NLS-2$
+		return leading + line.substring(endOfIndent);
 	}
 
 	private static String normalizeLineEndings(String source) {

--- a/sandbox_test_commons/src/org/sandbox/jdt/ui/tests/quickfix/rules/MultiFileCleanUpLifecycleAssertions.java
+++ b/sandbox_test_commons/src/org/sandbox/jdt/ui/tests/quickfix/rules/MultiFileCleanUpLifecycleAssertions.java
@@ -1,0 +1,161 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.ui.tests.quickfix.rules;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+
+import org.eclipse.ltk.core.refactoring.Change;
+import org.eclipse.ltk.core.refactoring.CheckConditionsOperation;
+import org.eclipse.ltk.core.refactoring.CreateChangeOperation;
+import org.eclipse.ltk.core.refactoring.IUndoManager;
+import org.eclipse.ltk.core.refactoring.PerformChangeOperation;
+import org.eclipse.ltk.core.refactoring.RefactoringCore;
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.compiler.IProblem;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
+import org.eclipse.jdt.internal.corext.fix.CleanUpRefactoring;
+import org.eclipse.jdt.internal.ui.JavaPlugin;
+import org.eclipse.jdt.ui.cleanup.ICleanUp;
+
+/**
+ * Assertions for the complete lifecycle of one coordinated multi-file cleanup.
+ *
+ * <p>The helper executes one {@link CleanUpRefactoring}, verifies all affected
+ * sources and their Java error sets after apply, performs the returned undo
+ * change, and finally proves that source and semantic state returned to the
+ * original baseline.</p>
+ */
+public final class MultiFileCleanUpLifecycleAssertions {
+
+	private record ProblemSignature(int id, String message) {
+	}
+
+	private MultiFileCleanUpLifecycleAssertions() {
+		// assertions only
+	}
+
+	/**
+	 * Applies the configured cleanup profile atomically and verifies compilation and
+	 * undo for the complete source set.
+	 *
+	 * @param compilationUnits all units participating in the coordinated cleanup
+	 * @param expectedAfterApply expected source contents after the common change
+	 * @return the final-condition status of the cleanup refactoring
+	 * @throws CoreException if Eclipse cannot create or execute either change
+	 */
+	public static RefactoringStatus assertApplyCompileAndUndo(ICompilationUnit[] compilationUnits,
+			String[] expectedAfterApply) throws CoreException {
+		String[] originals= contents(compilationUnits);
+		Map<String, Map<ProblemSignature, Long>> baselineProblems= errorCounts(compilationUnits);
+
+		CleanUpRefactoring refactoring= new CleanUpRefactoring();
+		refactoring.setUseOptionsFromProfile(true);
+		for (ICompilationUnit unit : compilationUnits) {
+			refactoring.addCompilationUnit(unit);
+		}
+		for (ICleanUp cleanup : JavaPlugin.getDefault().getCleanUpRegistry().createCleanUps()) {
+			refactoring.addCleanUp(cleanup);
+		}
+
+		IUndoManager undoManager= RefactoringCore.getUndoManager();
+		undoManager.flush();
+		CreateChangeOperation create= new CreateChangeOperation(
+				new CheckConditionsOperation(refactoring, CheckConditionsOperation.ALL_CONDITIONS),
+				RefactoringStatus.FATAL);
+		PerformChangeOperation apply= new PerformChangeOperation(create);
+		apply.setUndoManager(undoManager, refactoring.getName());
+		IWorkspace workspace= ResourcesPlugin.getWorkspace();
+		workspace.run(apply, new NullProgressMonitor());
+
+		RefactoringStatus status= create.getConditionCheckingStatus();
+		assertFalse(status.hasFatalError(), () -> "Cleanup final conditions failed: " + status); //$NON-NLS-1$
+		assertTrue(apply.changeExecuted(), "The coordinated cleanup change was not executed"); //$NON-NLS-1$
+		Change undo= apply.getUndoChange();
+		assertNotNull(undo, "The coordinated cleanup did not create an undo change"); //$NON-NLS-1$
+
+		AbstractEclipseJava.assertEqualStringsIgnoreOrderAndWhitespace(contents(compilationUnits), expectedAfterApply);
+		assertNoNewErrors(compilationUnits, baselineProblems, "after apply"); //$NON-NLS-1$
+
+		PerformChangeOperation performUndo= new PerformChangeOperation(undo);
+		workspace.run(performUndo, new NullProgressMonitor());
+		assertTrue(performUndo.changeExecuted(), "The coordinated cleanup undo change was not executed"); //$NON-NLS-1$
+		AbstractEclipseJava.assertEqualStringsIgnoreOrder(contents(compilationUnits), originals);
+		assertEquals(baselineProblems, errorCounts(compilationUnits),
+				"Undo must restore the original Java error set"); //$NON-NLS-1$
+		return status;
+	}
+
+	private static String[] contents(ICompilationUnit[] units) throws CoreException {
+		String[] result= new String[units.length];
+		for (int i= 0; i < units.length; i++) {
+			result[i]= units[i].getBuffer().getContents();
+		}
+		return result;
+	}
+
+	private static void assertNoNewErrors(ICompilationUnit[] units,
+			Map<String, Map<ProblemSignature, Long>> baseline, String phase) {
+		Map<String, Map<ProblemSignature, Long>> current= errorCounts(units);
+		StringBuilder newErrors= new StringBuilder();
+		for (Map.Entry<String, Map<ProblemSignature, Long>> unitEntry : current.entrySet()) {
+			Map<ProblemSignature, Long> previous= baseline.getOrDefault(unitEntry.getKey(), Map.of());
+			for (Map.Entry<ProblemSignature, Long> problemEntry : unitEntry.getValue().entrySet()) {
+				long added= problemEntry.getValue() - previous.getOrDefault(problemEntry.getKey(), 0L);
+				if (added > 0) {
+					newErrors.append(unitEntry.getKey()).append(": ") //$NON-NLS-1$
+							.append(problemEntry.getKey().message()).append(" [id=") //$NON-NLS-1$
+							.append(problemEntry.getKey().id()).append("] x").append(added).append('\n'); //$NON-NLS-1$
+				}
+			}
+		}
+		if (!newErrors.isEmpty()) {
+			fail("New Java errors " + phase + ":\n" + newErrors); //$NON-NLS-1$ //$NON-NLS-2$
+		}
+	}
+
+	private static Map<String, Map<ProblemSignature, Long>> errorCounts(ICompilationUnit[] units) {
+		Map<String, Map<ProblemSignature, Long>> result= new LinkedHashMap<>();
+		for (ICompilationUnit unit : units) {
+			ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
+			parser.setSource(unit);
+			parser.setProject(unit.getJavaProject());
+			parser.setResolveBindings(true);
+			parser.setBindingsRecovery(IASTSharedValues.SHARED_BINDING_RECOVERY);
+			parser.setStatementsRecovery(IASTSharedValues.SHARED_AST_STATEMENT_RECOVERY);
+			CompilationUnit root= (CompilationUnit) parser.createAST(null);
+			Map<ProblemSignature, Long> problems= Arrays.stream(root.getProblems())
+					.filter(problem -> !problem.isWarning() && !problem.isInfo())
+					.map(problem -> new ProblemSignature(problem.getID(), problem.getMessage()))
+					.collect(Collectors.groupingBy(Function.identity(), LinkedHashMap::new, Collectors.counting()));
+			result.put(unit.getPrimary().getHandleIdentifier(), problems);
+		}
+		return result;
+	}
+}

--- a/sandbox_test_commons/src/org/sandbox/jdt/ui/tests/quickfix/rules/MultiFileCleanUpLifecycleAssertions.java
+++ b/sandbox_test_commons/src/org/sandbox/jdt/ui/tests/quickfix/rules/MultiFileCleanUpLifecycleAssertions.java
@@ -36,7 +36,6 @@ import org.eclipse.ltk.core.refactoring.RefactoringCore;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 
 import org.eclipse.jdt.core.ICompilationUnit;
-import org.eclipse.jdt.core.compiler.IProblem;
 import org.eclipse.jdt.core.dom.ASTParser;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
@@ -47,10 +46,10 @@ import org.eclipse.jdt.ui.cleanup.ICleanUp;
 /**
  * Assertions for the complete lifecycle of one coordinated multi-file cleanup.
  *
- * <p>The helper executes one {@link CleanUpRefactoring}, verifies all affected
- * sources and their Java error sets after apply, performs the returned undo
+ * <p>The helper executes one {@link CleanUpRefactoring}, verifies every affected
+ * compilation unit and its Java error set after apply, performs the returned undo
  * change, and finally proves that source and semantic state returned to the
- * original baseline.</p>
+ * original per-file baseline.</p>
  */
 public final class MultiFileCleanUpLifecycleAssertions {
 
@@ -66,12 +65,15 @@ public final class MultiFileCleanUpLifecycleAssertions {
 	 * undo for the complete source set.
 	 *
 	 * @param compilationUnits all units participating in the coordinated cleanup
-	 * @param expectedAfterApply expected source contents after the common change
+	 * @param expectedAfterApply expected source contents after the common change, in
+	 *            the same order as {@code compilationUnits}
 	 * @return the final-condition status of the cleanup refactoring
 	 * @throws CoreException if Eclipse cannot create or execute either change
 	 */
 	public static RefactoringStatus assertApplyCompileAndUndo(ICompilationUnit[] compilationUnits,
 			String[] expectedAfterApply) throws CoreException {
+		assertEquals(compilationUnits.length, expectedAfterApply.length,
+				"Each compilation unit needs one expected post-apply source"); //$NON-NLS-1$
 		String[] originals= contents(compilationUnits);
 		Map<String, Map<ProblemSignature, Long>> baselineProblems= errorCounts(compilationUnits);
 
@@ -100,16 +102,34 @@ public final class MultiFileCleanUpLifecycleAssertions {
 		Change undo= apply.getUndoChange();
 		assertNotNull(undo, "The coordinated cleanup did not create an undo change"); //$NON-NLS-1$
 
-		AbstractEclipseJava.assertEqualStringsIgnoreOrderAndWhitespace(contents(compilationUnits), expectedAfterApply);
+		assertPostApplyContents(compilationUnits, expectedAfterApply);
 		assertNoNewErrors(compilationUnits, baselineProblems, "after apply"); //$NON-NLS-1$
 
 		PerformChangeOperation performUndo= new PerformChangeOperation(undo);
 		workspace.run(performUndo, new NullProgressMonitor());
 		assertTrue(performUndo.changeExecuted(), "The coordinated cleanup undo change was not executed"); //$NON-NLS-1$
-		AbstractEclipseJava.assertEqualStringsIgnoreOrder(contents(compilationUnits), originals);
+		assertRestoredContents(compilationUnits, originals);
 		assertEquals(baselineProblems, errorCounts(compilationUnits),
 				"Undo must restore the original Java error set"); //$NON-NLS-1$
 		return status;
+	}
+
+	private static void assertPostApplyContents(ICompilationUnit[] units, String[] expected) throws CoreException {
+		String[] actual= contents(units);
+		for (int i= 0; i < units.length; i++) {
+			String unitName= units[i].getElementName();
+			assertEquals(normalizeWhitespace(expected[i]), normalizeWhitespace(actual[i]),
+					() -> unitName + " has unexpected content after the coordinated cleanup"); //$NON-NLS-1$
+		}
+	}
+
+	private static void assertRestoredContents(ICompilationUnit[] units, String[] originals) throws CoreException {
+		String[] actual= contents(units);
+		for (int i= 0; i < units.length; i++) {
+			String unitName= units[i].getElementName();
+			assertEquals(normalizeLineEndings(originals[i]), normalizeLineEndings(actual[i]),
+					() -> unitName + " was not restored exactly by undo"); //$NON-NLS-1$
+		}
 	}
 
 	private static String[] contents(ICompilationUnit[] units) throws CoreException {
@@ -157,5 +177,17 @@ public final class MultiFileCleanUpLifecycleAssertions {
 			result.put(unit.getPrimary().getHandleIdentifier(), problems);
 		}
 		return result;
+	}
+
+	private static String normalizeWhitespace(String source) {
+		return Arrays.stream(normalizeLineEndings(source).split("\n", -1)) //$NON-NLS-1$
+				.map(line -> line.stripTrailing().replaceFirst("^\\t+", match -> "    ".repeat(match.group().length()))) //$NON-NLS-1$ //$NON-NLS-2$
+				.collect(Collectors.joining("\n")) //$NON-NLS-1$
+				.replaceAll("\n{3,}", "\n\n") //$NON-NLS-1$ //$NON-NLS-2$
+				.strip();
+	}
+
+	private static String normalizeLineEndings(String source) {
+		return source.replace("\r\n", "\n").replace("\r", "\n"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 	}
 }


### PR DESCRIPTION
## Summary

Adds executable lifecycle assertions for coordinated multi-file cleanups, applies them to both current cross-file consumers, and closes a retained-plan leak after fix-resolution failures.

## End-to-end lifecycle coverage

- creates one `CleanUpRefactoring` for the complete compilation-unit set;
- checks all final conditions and executes one common change;
- verifies the expected result against the corresponding compilation unit, not as an unordered source set;
- records Java error multisets before execution and rejects newly introduced errors after apply;
- executes the actual returned undo `Change`;
- verifies exact per-file source restoration modulo platform line endings;
- verifies that undo restores the original Java error multiset.

## Consumer coverage

### Int-to-Enum

`MultiFileIntToEnumCleanUpTest#migratesPackageScopedStateMethodAndExternalCaller` now proves that the generated nested enum, changed method signature, and external caller compile together and that both files are restored by one undo operation.

### JUnit ExternalResource

`MultiFileExternalResourceLifecycleTest` supplies JUnit 4 and JUnit 5 simultaneously to the temporary project. It proves that the migrated callback interfaces, `ExtensionContext` methods, `@RegisterExtension` field, and shared resource type compile together before the original two files are restored by one undo operation.

## Planner-state hardening

`AbstractPlannedMultiFileCleanUp#createFix` now removes the affected project plan when fix re-resolution throws `CoreException` or a runtime exception. A stale plan can therefore not be reused later in the same cleanup instance.

The shared tests cover:

- successful planning, per-file fix creation, and postcondition cleanup;
- fatal planning status;
- planning `CoreException`;
- planning cancellation;
- fix-resolution failure without deleting another project's plan;
- postcondition failure clearing all retained plans;
- independent plans and fixes for two projects with identically named source files.

## Remaining scope

This implements the atomic apply/undo, semantic-compilation, multi-project isolation, and retained-plan failure-state slices of #1213 and #1222. Stale edits caused by an earlier cleanup, save-action isolation, and patched-JDT scope-provider validation remain separate follow-up slices.

Refs #1213
Refs #1222