### PR TITLE
Gate coordinated cleanup expansion by selected candidates

### DIFF
--- a/sandbox_int_to_enum/src/org/sandbox/jdt/internal/corext/fix/multifile/IntEnumScopeCandidateDetector.java
+++ b/sandbox_int_to_enum/src/org/sandbox/jdt/internal/corext/fix/multifile/IntEnumScopeCandidateDetector.java
@@ -1,0 +1,146 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.corext.fix.multifile;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.dom.ASTRequestor;
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.FieldDeclaration;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.Modifier;
+import org.eclipse.jdt.core.dom.PrimitiveType;
+import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
+import org.eclipse.jdt.core.dom.Type;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
+
+/** Lightweight pre-scan used before requesting complete-project Int-to-Enum scope. */
+public final class IntEnumScopeCandidateDetector {
+
+	private IntEnumScopeCandidateDetector() {
+		// utility class
+	}
+
+	/**
+	 * Returns whether the current selection contains the structural prerequisites of
+	 * the coordinated package-scoped migration.
+	 * <p>
+	 * This is deliberately a conservative gate rather than the semantic planner. A
+	 * positive result may still be rejected after complete-project analysis; a
+	 * negative result proves that the selected units contain no owner declaration
+	 * that the current coordinated planner could migrate.
+	 * </p>
+	 *
+	 * @param project Java project owning the current cleanup scope
+	 * @param currentScope compilation units currently selected by the user or an
+	 *            earlier scope-expansion iteration
+	 * @param monitor progress monitor, may be {@code null}
+	 * @return {@code true} when complete-project fallback analysis may be required
+	 */
+	public static boolean containsCandidate(IJavaProject project, Collection<ICompilationUnit> currentScope,
+			IProgressMonitor monitor) {
+		if (currentScope == null || currentScope.isEmpty()) {
+			return false;
+		}
+		checkCanceled(monitor);
+		Set<ICompilationUnit> units= new LinkedHashSet<>();
+		for (ICompilationUnit unit : currentScope) {
+			if (unit != null && unit.exists() && project.equals(unit.getJavaProject())) {
+				units.add(unit.getPrimary());
+			}
+		}
+		if (units.isEmpty()) {
+			return false;
+		}
+
+		AtomicBoolean candidate= new AtomicBoolean();
+		ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
+		parser.setProject(project);
+		parser.setResolveBindings(false);
+		parser.setStatementsRecovery(IASTSharedValues.SHARED_AST_STATEMENT_RECOVERY);
+		parser.createASTs(units.toArray(ICompilationUnit[]::new), new String[0], new ASTRequestor() {
+			@Override
+			public void acceptAST(ICompilationUnit source, CompilationUnit ast) {
+				if (candidate.get()) {
+					return;
+				}
+				ast.accept(new ASTVisitor() {
+					@Override
+					public boolean visit(TypeDeclaration type) {
+						if (!(type.getParent() instanceof CompilationUnit) || type.isInterface()
+								|| type.getSuperclassType() != null || !type.superInterfaceTypes().isEmpty()) {
+							return false;
+						}
+						if (countPackagePrivateIntConstants(type) >= 2 && hasPackagePrivateIntStateMethod(type)) {
+							candidate.set(true);
+						}
+						return false;
+					}
+				});
+			}
+		}, monitor);
+		checkCanceled(monitor);
+		return candidate.get();
+	}
+
+	private static int countPackagePrivateIntConstants(TypeDeclaration type) {
+		int count= 0;
+		for (FieldDeclaration field : type.getFields()) {
+			int modifiers= field.getModifiers();
+			if (isPackagePrivate(modifiers) && Modifier.isStatic(modifiers) && Modifier.isFinal(modifiers)
+					&& isPlainInt(field.getType())) {
+				count+= field.fragments().size();
+			}
+		}
+		return count;
+	}
+
+	private static boolean hasPackagePrivateIntStateMethod(TypeDeclaration type) {
+		for (MethodDeclaration method : type.getMethods()) {
+			if (method.isConstructor() || method.getBody() == null || !isPackagePrivate(method.getModifiers())) {
+				continue;
+			}
+			for (Object parameterObject : method.parameters()) {
+				SingleVariableDeclaration parameter= (SingleVariableDeclaration) parameterObject;
+				if (parameter.getExtraDimensions() == 0 && !parameter.isVarargs() && isPlainInt(parameter.getType())) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	private static boolean isPlainInt(Type type) {
+		return type instanceof PrimitiveType primitive
+				&& primitive.getPrimitiveTypeCode() == PrimitiveType.INT;
+	}
+
+	private static boolean isPackagePrivate(int modifiers) {
+		return !Modifier.isPublic(modifiers) && !Modifier.isProtected(modifiers) && !Modifier.isPrivate(modifiers);
+	}
+
+	private static void checkCanceled(IProgressMonitor monitor) {
+		if (monitor != null && monitor.isCanceled()) {
+			throw new OperationCanceledException();
+		}
+	}
+}

--- a/sandbox_int_to_enum/src/org/sandbox/jdt/internal/ui/fix/IntToEnumCleanUpCore.java
+++ b/sandbox_int_to_enum/src/org/sandbox/jdt/internal/ui/fix/IntToEnumCleanUpCore.java
@@ -136,7 +136,7 @@ public class IntToEnumCleanUpCore extends AbstractPlannedMultiFileCleanUp<IntEnu
 		List<String> result= new ArrayList<>();
 		if (isEnabled(INT_TO_ENUM_CLEANUP)) {
 			result.add(Messages.format(IntToEnumCleanUp_description,
-					new Object[] { String.join(",", computeFixSet().stream()) //$NON-NLS-1$
+					new Object[] { String.join(",", computeFixSet().stream() //$NON-NLS-1$
 							.map(IntToEnumFixCore::toString)
 							.collect(Collectors.toList())) }));
 			if (isEnabled(PROJECT_WIDE)) {

--- a/sandbox_int_to_enum/src/org/sandbox/jdt/internal/ui/fix/IntToEnumCleanUpCore.java
+++ b/sandbox_int_to_enum/src/org/sandbox/jdt/internal/ui/fix/IntToEnumCleanUpCore.java
@@ -51,6 +51,7 @@ import org.sandbox.jdt.cleanup.multifile.SelectedCompilationUnitPlan;
 import org.sandbox.jdt.internal.corext.fix.IntToEnumFixCore;
 import org.sandbox.jdt.internal.corext.fix.multifile.IntEnumMigrationPlan;
 import org.sandbox.jdt.internal.corext.fix.multifile.IntEnumMultiFilePlanner;
+import org.sandbox.jdt.internal.corext.fix.multifile.IntEnumScopeCandidateDetector;
 
 /** Core cleanup implementation that converts integer constants to enums. */
 public class IntToEnumCleanUpCore extends AbstractPlannedMultiFileCleanUp<IntEnumMigrationPlan> {
@@ -124,6 +125,9 @@ public class IntToEnumCleanUpCore extends AbstractPlannedMultiFileCleanUp<IntEnu
 		if (monitor != null && monitor.isCanceled()) {
 			throw new OperationCanceledException();
 		}
+		if (!IntEnumScopeCandidateDetector.containsCandidate(project, currentScope, monitor)) {
+			return List.of();
+		}
 		return JavaProjectCompilationUnits.collect(project);
 	}
 
@@ -132,7 +136,7 @@ public class IntToEnumCleanUpCore extends AbstractPlannedMultiFileCleanUp<IntEnu
 		List<String> result= new ArrayList<>();
 		if (isEnabled(INT_TO_ENUM_CLEANUP)) {
 			result.add(Messages.format(IntToEnumCleanUp_description,
-					new Object[] { String.join(",", computeFixSet().stream() //$NON-NLS-1$
+					new Object[] { String.join(",", computeFixSet().stream()) //$NON-NLS-1$
 							.map(IntToEnumFixCore::toString)
 							.collect(Collectors.toList())) }));
 			if (isEnabled(PROJECT_WIDE)) {

--- a/sandbox_int_to_enum/src/org/sandbox/jdt/internal/ui/fix/IntToEnumCleanUpCore.java
+++ b/sandbox_int_to_enum/src/org/sandbox/jdt/internal/ui/fix/IntToEnumCleanUpCore.java
@@ -22,6 +22,7 @@ import static org.sandbox.jdt.internal.ui.fix.MultiFixMessages.IntToEnumCleanUp_
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -55,6 +56,9 @@ import org.sandbox.jdt.internal.corext.fix.multifile.IntEnumScopeCandidateDetect
 
 /** Core cleanup implementation that converts integer constants to enums. */
 public class IntToEnumCleanUpCore extends AbstractPlannedMultiFileCleanUp<IntEnumMigrationPlan> {
+
+	private final Map<IJavaProject, Set<String>> pendingExpandedScopes= new HashMap<>();
+
 	public IntToEnumCleanUpCore(final Map<String, String> options) {
 		super(options);
 	}
@@ -125,10 +129,22 @@ public class IntToEnumCleanUpCore extends AbstractPlannedMultiFileCleanUp<IntEnu
 		if (monitor != null && monitor.isCanceled()) {
 			throw new OperationCanceledException();
 		}
+
+		Set<String> currentHandles= handles(currentScope);
+		Set<String> pendingScope= pendingExpandedScopes.remove(project);
+		if (pendingScope != null && currentHandles.containsAll(pendingScope)) {
+			return List.of();
+		}
 		if (!IntEnumScopeCandidateDetector.containsCandidate(project, currentScope, monitor)) {
 			return List.of();
 		}
-		return JavaProjectCompilationUnits.collect(project);
+
+		List<ICompilationUnit> projectUnits= JavaProjectCompilationUnits.collect(project);
+		Set<String> projectHandles= handles(projectUnits);
+		if (!currentHandles.containsAll(projectHandles)) {
+			pendingExpandedScopes.put(project, projectHandles);
+		}
+		return projectUnits;
 	}
 
 	@Override
@@ -160,5 +176,16 @@ public class IntToEnumCleanUpCore extends AbstractPlannedMultiFileCleanUp<IntEnu
 			fixSet= EnumSet.allOf(IntToEnumFixCore.class);
 		}
 		return fixSet;
+	}
+
+	private static Set<String> handles(Collection<ICompilationUnit> units) {
+		if (units == null || units.isEmpty()) {
+			return Set.of();
+		}
+		return units.stream()
+				.filter(java.util.Objects::nonNull)
+				.map(ICompilationUnit::getPrimary)
+				.map(ICompilationUnit::getHandleIdentifier)
+				.collect(Collectors.toSet());
 	}
 }

--- a/sandbox_int_to_enum_test/src/org/eclipse/jdt/ui/tests/quickfix/Java22/IntToEnumCandidateGateFixedPointTest.java
+++ b/sandbox_int_to_enum_test/src/org/eclipse/jdt/ui/tests/quickfix/Java22/IntToEnumCandidateGateFixedPointTest.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.quickfix.Java22;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.ui.cleanup.CleanUpOptions;
+
+import org.sandbox.jdt.internal.corext.fix.IntToEnumCleanUpOptions;
+import org.sandbox.jdt.internal.corext.fix2.MYCleanUpConstants;
+import org.sandbox.jdt.internal.ui.fix.IntToEnumCleanUpCore;
+import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
+import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava22;
+
+/** Verifies fixed-point state of candidate-gated Int-to-Enum expansion. */
+public class IntToEnumCandidateGateFixedPointTest {
+
+	@RegisterExtension
+	AbstractEclipseJava context= new EclipseJava22();
+
+	@Test
+	public void fallbackIsReturnedOnceAndDoesNotLeakIntoLaterScope() throws CoreException {
+		IPackageFragment pack= context.getSourceFolder().createPackageFragment("test", true, null); //$NON-NLS-1$
+		ICompilationUnit candidate= pack.createCompilationUnit("Candidate.java", //$NON-NLS-1$
+				"""
+				package test;
+				public class Candidate {
+					static final int STATE_ONE = 1;
+					static final int STATE_TWO = 2;
+					void consume(int state) {
+					}
+				}
+				""", false, null);
+		ICompilationUnit unrelated= pack.createCompilationUnit("Unrelated.java", //$NON-NLS-1$
+				"package test; public class Unrelated {}", false, null); //$NON-NLS-1$
+		IntToEnumCleanUpCore cleanup= new IntToEnumCleanUpCore(Map.of(
+				MYCleanUpConstants.INT_TO_ENUM_CLEANUP, CleanUpOptions.TRUE,
+				IntToEnumCleanUpOptions.PROJECT_WIDE, CleanUpOptions.TRUE));
+
+		Collection<ICompilationUnit> first= cleanup.expandCleanUpScope(candidate.getJavaProject(),
+				List.of(candidate), null);
+		assertEquals(2, first.size());
+		assertTrue(first.contains(unrelated));
+
+		Collection<ICompilationUnit> fixedPoint= cleanup.expandCleanUpScope(candidate.getJavaProject(), first, null);
+		assertTrue(fixedPoint.isEmpty(), "The complete-project fallback must be emitted only once");
+
+		Collection<ICompilationUnit> laterUnrelatedScope= cleanup.expandCleanUpScope(candidate.getJavaProject(),
+				List.of(unrelated), null);
+		assertTrue(laterUnrelatedScope.isEmpty(), "A completed fallback must not leak into a later candidate-free scope");
+	}
+}

--- a/sandbox_int_to_enum_test/src/org/eclipse/jdt/ui/tests/quickfix/Java22/IntToEnumScopeExpansionTest.java
+++ b/sandbox_int_to_enum_test/src/org/eclipse/jdt/ui/tests/quickfix/Java22/IntToEnumScopeExpansionTest.java
@@ -34,7 +34,7 @@ import org.sandbox.jdt.internal.ui.fix.IntToEnumCleanUpCore;
 import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
 import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava22;
 
-/** Tests that project-wide Int-to-Enum analysis requires explicit opt-in. */
+/** Tests candidate-gated project-wide Int-to-Enum analysis. */
 public class IntToEnumScopeExpansionTest {
 
 	@RegisterExtension
@@ -106,23 +106,56 @@ public class IntToEnumScopeExpansionTest {
 	}
 
 	@Test
-	public void projectWideOptionExpandsToAllProjectSources() throws CoreException {
+	public void projectWideOptionWithoutCandidateDoesNotExpandScope() throws CoreException {
 		IPackageFragment pack= context.getSourceFolder().createPackageFragment("test", true, null); //$NON-NLS-1$
 		ICompilationUnit selected= createUnit(pack, "Selected.java"); //$NON-NLS-1$
-		ICompilationUnit related= createUnit(pack, "Related.java"); //$NON-NLS-1$
-		ICompilationUnit unrelated= createUnit(pack, "Unrelated.java"); //$NON-NLS-1$
-		IntToEnumCleanUpCore cleanup= new IntToEnumCleanUpCore(Map.of(
-				MYCleanUpConstants.INT_TO_ENUM_CLEANUP, CleanUpOptions.TRUE,
-				IntToEnumCleanUpOptions.PROJECT_WIDE, CleanUpOptions.TRUE));
+		createUnit(pack, "Unrelated.java"); //$NON-NLS-1$
+		IntToEnumCleanUpCore cleanup= projectWideCleanup();
 
 		Collection<ICompilationUnit> expanded= cleanup.expandCleanUpScope(selected.getJavaProject(),
 				List.of(selected), null);
+
+		assertTrue(expanded.isEmpty(),
+				"An explicit project-wide option must not scan the project without a selected candidate owner");
+	}
+
+	@Test
+	public void selectedCandidateUsesConservativeProjectFallback() throws CoreException {
+		IPackageFragment pack= context.getSourceFolder().createPackageFragment("test", true, null); //$NON-NLS-1$
+		ICompilationUnit selected= pack.createCompilationUnit("Selected.java", //$NON-NLS-1$
+				"""
+				package test;
+
+				public class Selected {
+					static final int STATUS_PENDING = 0;
+					static final int STATUS_APPROVED = 1;
+
+					void process(int status) {
+						if (status == STATUS_PENDING) {
+							System.out.println("pending");
+						} else if (status == STATUS_APPROVED) {
+							System.out.println("approved");
+						}
+					}
+				}
+				""", false, null);
+		ICompilationUnit related= createUnit(pack, "Related.java"); //$NON-NLS-1$
+		ICompilationUnit unrelated= createUnit(pack, "Unrelated.java"); //$NON-NLS-1$
+
+		Collection<ICompilationUnit> expanded= projectWideCleanup().expandCleanUpScope(
+				selected.getJavaProject(), List.of(selected), null);
 		Set<String> expandedHandles= expanded.stream().map(ICompilationUnit::getHandleIdentifier)
 				.collect(Collectors.toSet());
 
 		assertEquals(Set.of(selected.getHandleIdentifier(), related.getHandleIdentifier(),
 				unrelated.getHandleIdentifier()), expandedHandles,
-				"The explicit project-wide option must include every project source unit");
+				"A selected coordinated candidate must retain the conservative complete-project fallback");
+	}
+
+	private static IntToEnumCleanUpCore projectWideCleanup() {
+		return new IntToEnumCleanUpCore(Map.of(
+				MYCleanUpConstants.INT_TO_ENUM_CLEANUP, CleanUpOptions.TRUE,
+				IntToEnumCleanUpOptions.PROJECT_WIDE, CleanUpOptions.TRUE));
 	}
 
 	private static ICompilationUnit createUnit(IPackageFragment pack, String name) throws CoreException {

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnitScopeCandidateDetector.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnitScopeCandidateDetector.java
@@ -1,0 +1,132 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.corext.fix.multifile;
+
+import static org.sandbox.jdt.internal.corext.fix.helper.lib.JUnitConstants.ORG_JUNIT_CLASS_RULE;
+import static org.sandbox.jdt.internal.corext.fix.helper.lib.JUnitConstants.ORG_JUNIT_RULE;
+import static org.sandbox.jdt.internal.corext.fix.helper.lib.JUnitConstants.ORG_JUNIT_RULES_EXTERNAL_RESOURCE;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.ASTRequestor;
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.Annotation;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.FieldDeclaration;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
+import org.eclipse.jdt.internal.corext.refactoring.util.RefactoringASTParser;
+
+/** Lightweight pre-scan used before requesting complete-project JUnit scope. */
+public final class JUnitScopeCandidateDetector {
+
+	private JUnitScopeCandidateDetector() {
+		// utility class
+	}
+
+	/**
+	 * Returns whether the current selection contains either side of the coordinated
+	 * named {@code ExternalResource} migration: a resource declaration or a
+	 * {@code @Rule}/{@code @ClassRule} field.
+	 * <p>
+	 * A positive result only enables the existing conservative complete-project
+	 * fallback. The semantic planner remains responsible for proving that a closed,
+	 * lifecycle-compatible migration exists.
+	 * </p>
+	 *
+	 * @param project Java project owning the cleanup scope
+	 * @param currentScope currently selected compilation units
+	 * @param monitor progress monitor, may be {@code null}
+	 * @return {@code true} when coordinated fallback analysis may be required
+	 */
+	public static boolean containsCandidate(IJavaProject project, Collection<ICompilationUnit> currentScope,
+			IProgressMonitor monitor) {
+		if (currentScope == null || currentScope.isEmpty()) {
+			return false;
+		}
+		checkCanceled(monitor);
+		Set<ICompilationUnit> units= new LinkedHashSet<>();
+		for (ICompilationUnit unit : currentScope) {
+			if (unit != null && unit.exists() && project.equals(unit.getJavaProject())) {
+				units.add(unit.getPrimary());
+			}
+		}
+		if (units.isEmpty()) {
+			return false;
+		}
+
+		AtomicBoolean candidate= new AtomicBoolean();
+		ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
+		parser.setProject(project);
+		parser.setResolveBindings(true);
+		parser.setBindingsRecovery(IASTSharedValues.SHARED_BINDING_RECOVERY);
+		parser.setStatementsRecovery(IASTSharedValues.SHARED_AST_STATEMENT_RECOVERY);
+		parser.setCompilerOptions(RefactoringASTParser.getCompilerOptions(project));
+		parser.createASTs(units.toArray(ICompilationUnit[]::new), new String[0], new ASTRequestor() {
+			@Override
+			public void acceptAST(ICompilationUnit source, CompilationUnit ast) {
+				if (candidate.get()) {
+					return;
+				}
+				ast.accept(new ASTVisitor() {
+					@Override
+					public boolean visit(TypeDeclaration node) {
+						ITypeBinding binding= node.resolveBinding();
+						if (binding != null && binding.getSuperclass() != null
+								&& ORG_JUNIT_RULES_EXTERNAL_RESOURCE.equals(
+										binding.getSuperclass().getErasure().getQualifiedName())) {
+							candidate.set(true);
+							return false;
+						}
+						return !candidate.get();
+					}
+
+					@Override
+					public boolean visit(FieldDeclaration node) {
+						for (Object modifier : node.modifiers()) {
+							if (!(modifier instanceof Annotation annotation)) {
+								continue;
+							}
+							ITypeBinding binding= annotation.resolveTypeBinding();
+							if (binding == null) {
+								continue;
+							}
+							String qualifiedName= binding.getQualifiedName();
+							if (ORG_JUNIT_RULE.equals(qualifiedName) || ORG_JUNIT_CLASS_RULE.equals(qualifiedName)) {
+								candidate.set(true);
+								return false;
+							}
+						}
+						return !candidate.get();
+					}
+				});
+			}
+		}, monitor);
+		checkCanceled(monitor);
+		return candidate.get();
+	}
+
+	private static void checkCanceled(IProgressMonitor monitor) {
+		if (monitor != null && monitor.isCanceled()) {
+			throw new OperationCanceledException();
+		}
+	}
+}

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/ui/fix/JUnitCleanUpCore.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/ui/fix/JUnitCleanUpCore.java
@@ -21,6 +21,7 @@ import static org.sandbox.jdt.internal.ui.fix.MultiFixMessages.JUnitCleanUp_desc
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -54,6 +55,9 @@ import org.sandbox.jdt.internal.corext.fix2.MYCleanUpConstants;
 
 /** Core cleanup implementation for JUnit 3/4 to Jupiter migration. */
 public class JUnitCleanUpCore extends AbstractPlannedMultiFileCleanUp<JUnitMigrationPlan> {
+
+	private final Map<IJavaProject, Set<String>> pendingExpandedScopes= new HashMap<>();
+
 	public JUnitCleanUpCore(final Map<String, String> options) {
 		super(options);
 	}
@@ -117,10 +121,22 @@ public class JUnitCleanUpCore extends AbstractPlannedMultiFileCleanUp<JUnitMigra
 		if (monitor != null && monitor.isCanceled()) {
 			throw new OperationCanceledException();
 		}
+
+		Set<String> currentHandles= handles(currentScope);
+		Set<String> pendingScope= pendingExpandedScopes.remove(project);
+		if (pendingScope != null && currentHandles.containsAll(pendingScope)) {
+			return List.of();
+		}
 		if (!JUnitScopeCandidateDetector.containsCandidate(project, currentScope, monitor)) {
 			return List.of();
 		}
-		return JavaProjectCompilationUnits.collect(project);
+
+		List<ICompilationUnit> projectUnits= JavaProjectCompilationUnits.collect(project);
+		Set<String> projectHandles= handles(projectUnits);
+		if (!currentHandles.containsAll(projectHandles)) {
+			pendingExpandedScopes.put(project, projectHandles);
+		}
+		return projectUnits;
 	}
 
 	@Override
@@ -202,5 +218,16 @@ public class JUnitCleanUpCore extends AbstractPlannedMultiFileCleanUp<JUnitMigra
 
 	private EnumSet<JUnitCleanUpFixCore> allOfJunit3() {
 		return EnumSet.of(JUnitCleanUpFixCore.TEST3);
+	}
+
+	private static Set<String> handles(Collection<ICompilationUnit> units) {
+		if (units == null || units.isEmpty()) {
+			return Set.of();
+		}
+		return units.stream()
+				.filter(java.util.Objects::nonNull)
+				.map(ICompilationUnit::getPrimary)
+				.map(ICompilationUnit::getHandleIdentifier)
+				.collect(Collectors.toSet());
 	}
 }

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/ui/fix/JUnitCleanUpCore.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/ui/fix/JUnitCleanUpCore.java
@@ -49,6 +49,7 @@ import org.sandbox.jdt.cleanup.multifile.MultiFileCleanUpPlanResult;
 import org.sandbox.jdt.internal.corext.fix.JUnitCleanUpFixCore;
 import org.sandbox.jdt.internal.corext.fix.multifile.JUnitMigrationPlan;
 import org.sandbox.jdt.internal.corext.fix.multifile.JUnitMultiFilePlanner;
+import org.sandbox.jdt.internal.corext.fix.multifile.JUnitScopeCandidateDetector;
 import org.sandbox.jdt.internal.corext.fix2.MYCleanUpConstants;
 
 /** Core cleanup implementation for JUnit 3/4 to Jupiter migration. */
@@ -115,6 +116,9 @@ public class JUnitCleanUpCore extends AbstractPlannedMultiFileCleanUp<JUnitMigra
 		}
 		if (monitor != null && monitor.isCanceled()) {
 			throw new OperationCanceledException();
+		}
+		if (!JUnitScopeCandidateDetector.containsCandidate(project, currentScope, monitor)) {
+			return List.of();
 		}
 		return JavaProjectCompilationUnits.collect(project);
 	}

--- a/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/JUnitCandidateGateFixedPointTest.java
+++ b/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/JUnitCandidateGateFixedPointTest.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.quickfix.Java8;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.junit.JUnitCore;
+import org.eclipse.jdt.ui.cleanup.CleanUpOptions;
+
+import org.sandbox.jdt.internal.corext.fix2.MYCleanUpConstants;
+import org.sandbox.jdt.internal.ui.fix.JUnitCleanUpCore;
+import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
+import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava17;
+
+/** Verifies fixed-point state of candidate-gated JUnit expansion. */
+public class JUnitCandidateGateFixedPointTest {
+
+	@RegisterExtension
+	AbstractEclipseJava context= new EclipseJava17();
+
+	private IPackageFragmentRoot root;
+
+	@BeforeEach
+	public void setup() throws CoreException {
+		root= context.createClasspathForJUnit(JUnitCore.JUNIT4_CONTAINER_PATH);
+	}
+
+	@Test
+	public void fallbackIsReturnedOnceAndDoesNotLeakIntoLaterScope() throws CoreException {
+		IPackageFragment pack= root.createPackageFragment("test", true, null); //$NON-NLS-1$
+		ICompilationUnit candidate= pack.createCompilationUnit("SharedResource.java", //$NON-NLS-1$
+				"""
+				package test;
+				import org.junit.rules.ExternalResource;
+				public class SharedResource extends ExternalResource {
+				}
+				""", false, null);
+		ICompilationUnit unrelated= pack.createCompilationUnit("UnrelatedTest.java", //$NON-NLS-1$
+				"package test; public class UnrelatedTest {}", false, null); //$NON-NLS-1$
+		JUnitCleanUpCore cleanup= new JUnitCleanUpCore(Map.of(
+				MYCleanUpConstants.JUNIT_CLEANUP, CleanUpOptions.TRUE,
+				MYCleanUpConstants.JUNIT_CLEANUP_4_RULEEXTERNALRESOURCE, CleanUpOptions.TRUE));
+
+		Collection<ICompilationUnit> first= cleanup.expandCleanUpScope(candidate.getJavaProject(),
+				List.of(candidate), null);
+		assertEquals(2, first.size());
+		assertTrue(first.contains(unrelated));
+
+		Collection<ICompilationUnit> fixedPoint= cleanup.expandCleanUpScope(candidate.getJavaProject(), first, null);
+		assertTrue(fixedPoint.isEmpty(), "The complete-project fallback must be emitted only once");
+
+		Collection<ICompilationUnit> laterUnrelatedScope= cleanup.expandCleanUpScope(candidate.getJavaProject(),
+				List.of(unrelated), null);
+		assertTrue(laterUnrelatedScope.isEmpty(), "A completed fallback must not leak into a later candidate-free scope");
+	}
+}

--- a/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/JUnitScopeExpansionTest.java
+++ b/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/JUnitScopeExpansionTest.java
@@ -36,7 +36,7 @@ import org.sandbox.jdt.internal.ui.fix.JUnitCleanUpCore;
 import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
 import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava17;
 
-/** Tests that only coordinated JUnit options expand the cleanup target scope. */
+/** Tests candidate-gated scope expansion for coordinated JUnit migration. */
 public class JUnitScopeExpansionTest {
 
 	@RegisterExtension
@@ -65,23 +65,50 @@ public class JUnitScopeExpansionTest {
 	}
 
 	@Test
-	public void externalResourceRuleOptionStillExpandsToAllProjectSources() throws CoreException {
+	public void externalResourceOptionWithoutCandidateDoesNotExpandScope() throws CoreException {
 		IPackageFragment pack= root.createPackageFragment("test", true, null); //$NON-NLS-1$
 		ICompilationUnit selected= createUnit(pack, "SelectedTest.java"); //$NON-NLS-1$
-		ICompilationUnit related= createUnit(pack, "SharedResource.java"); //$NON-NLS-1$
-		ICompilationUnit unrelated= createUnit(pack, "UnrelatedTest.java"); //$NON-NLS-1$
-		JUnitCleanUpCore cleanup= new JUnitCleanUpCore(Map.of(
-				MYCleanUpConstants.JUNIT_CLEANUP, CleanUpOptions.TRUE,
-				MYCleanUpConstants.JUNIT_CLEANUP_4_RULEEXTERNALRESOURCE, CleanUpOptions.TRUE));
+		createUnit(pack, "UnrelatedTest.java"); //$NON-NLS-1$
 
-		Collection<ICompilationUnit> expanded= cleanup.expandCleanUpScope(selected.getJavaProject(),
-				List.of(selected), null);
+		Collection<ICompilationUnit> expanded= externalResourceCleanup().expandCleanUpScope(
+				selected.getJavaProject(), List.of(selected), null);
+
+		assertTrue(expanded.isEmpty(),
+				"The coordinated option must not scan the project without a resource or rule candidate in scope");
+	}
+
+	@Test
+	public void selectedExternalResourceUsesConservativeProjectFallback() throws CoreException {
+		IPackageFragment pack= root.createPackageFragment("test", true, null); //$NON-NLS-1$
+		ICompilationUnit selected= pack.createCompilationUnit("SharedResource.java", //$NON-NLS-1$
+				"""
+				package test;
+
+				import org.junit.rules.ExternalResource;
+
+				public class SharedResource extends ExternalResource {
+					@Override
+					protected void before() {
+					}
+				}
+				""", false, null);
+		ICompilationUnit related= createUnit(pack, "SelectedTest.java"); //$NON-NLS-1$
+		ICompilationUnit unrelated= createUnit(pack, "UnrelatedTest.java"); //$NON-NLS-1$
+
+		Collection<ICompilationUnit> expanded= externalResourceCleanup().expandCleanUpScope(
+				selected.getJavaProject(), List.of(selected), null);
 		Set<String> expandedHandles= expanded.stream().map(ICompilationUnit::getHandleIdentifier)
 				.collect(Collectors.toSet());
 
 		assertEquals(Set.of(selected.getHandleIdentifier(), related.getHandleIdentifier(),
 				unrelated.getHandleIdentifier()), expandedHandles,
-				"The coordinated rule migration must still receive every project source unit");
+				"A selected resource candidate must retain the conservative complete-project fallback");
+	}
+
+	private static JUnitCleanUpCore externalResourceCleanup() {
+		return new JUnitCleanUpCore(Map.of(
+				MYCleanUpConstants.JUNIT_CLEANUP, CleanUpOptions.TRUE,
+				MYCleanUpConstants.JUNIT_CLEANUP_4_RULEEXTERNALRESOURCE, CleanUpOptions.TRUE));
 	}
 
 	private static ICompilationUnit createUnit(IPackageFragment pack, String name) throws CoreException {


### PR DESCRIPTION
## Summary

Introduces a conservative candidate gate before the existing complete-project fallback for coordinated Int-to-Enum and JUnit `ExternalResource` cleanup analysis.

## Problem

Even after explicit option gating, enabling a coordinated cleanup caused every project source unit to be requested whenever the relevant option was active. A selected file containing only local transformations or no coordinated declaration therefore paid the complete-project expansion cost.

## Implementation

### Int-to-Enum

`IntEnumScopeCandidateDetector` performs a lightweight AST pre-scan of the current selection. It recognizes the structural owner prerequisites of the existing coordinated planner:

- a top-level class compatible with the planner's closed-scope restrictions;
- at least two package-private `static final int` constants;
- a package-private method with a plain `int` parameter.

Only a positive result enables the existing `JavaProjectCompilationUnits.collect(project)` fallback. The full planner still performs all binding, reference, caller, completeness, naming and safety validation.

### JUnit

`JUnitScopeCandidateDetector` resolves bindings only in the current selection and recognizes either side of the currently implemented coordinated migration:

- a type directly extending JUnit 4 `ExternalResource`;
- a field annotated with `@Rule` or `@ClassRule`.

Again, a positive result merely enables the unchanged complete-project fallback and semantic planner.

### Fixed-point lifecycle

Both cleanup instances retain only the expected handle set between the initial fallback and the immediately following fixed-point invocation. Once the complete scope is observed, the marker is removed and expansion returns empty. A later candidate-free scope is unaffected by prior state.

## Safety boundary

This PR deliberately does **not** claim the final minimal JDT SearchEngine closure from #1212:

- false-positive structural candidates may still request the full project;
- detected candidates continue to use the fully conservative complete-project planner;
- no candidate is migrated on an incomplete scope;
- cancellation and invalid-scope handling remain in the established lifecycle.

## Tests

The scope-expansion suites verify:

- local options retaining the original scope;
- coordinated options with no candidate returning no additional units;
- a selected coordinated owner activating the conservative project fallback, including unrelated units;
- the fallback being emitted once and then reaching a fixed point;
- fixed-point state not leaking into a later candidate-free scope.

## Follow-up

The remaining part of #1212 is binding-derived JDT SearchEngine discovery of the minimal closed owner/reference/caller set plus explicit fallback diagnostics and performance benchmarks.

Refs #1212
