### PR TITLE
Use the reactor Tycho version in CodeQL builds

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -72,17 +72,13 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
+        # By default, queries listed here will override any specified queries in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
 
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
-
-
-    # Build explicitly with Maven to ensure consistent Tycho version usage
-    # (Autobuild may download different Tycho versions causing injection errors)
+    # Build with the versions declared by the reactor. Hard-coding Tycho here can
+    # make CodeQL validate a different build than the normal Maven workflow.
     - name: Build with Maven
-      run: mvn -B -Dtycho.version=5.0.1 -DskipTests clean package
+      run: mvn -B -DskipTests clean package
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Summary

Removes the stale `-Dtycho.version=5.0.1` override from the CodeQL Maven build.

The root reactor already defines and validates the supported Tycho baseline. Hard-coding another version in CodeQL caused security analysis to compile a different build than the normal Java CI workflow and can produce dependency-injection/build failures that are unrelated to the pull request under analysis.

## Change

CodeQL now runs:

```text
mvn -B -DskipTests clean package
```

and therefore consumes the same Tycho version and dependency management as the repository POM.

## Validation

- CodeQL must complete its Maven build and analysis;
- normal Java CI remains unchanged;
- no product or test source is modified.
