### PR TITLE
Serialize and document multi-file cleanup lifecycle

### DIFF
--- a/docs/multi-file-cleanup-lifecycle-ownership.md
+++ b/docs/multi-file-cleanup-lifecycle-ownership.md
@@ -1,0 +1,45 @@
+# Multi-file cleanup lifecycle ownership
+
+## Contract
+
+`AbstractPlannedMultiFileCleanUp` is stateful for the duration of one explicit cleanup run. It retains one immutable semantic plan per `IJavaProject` between `checkPreConditions(...)`, the per-file `createFix(...)` calls, and `checkPostConditions(...)`.
+
+The supported ownership model is:
+
+- one cleanup instance may serve more than one Java project in the same run;
+- lifecycle calls on one instance are serialized;
+- after `checkPostConditions(...)` completes, the instance contains no retained plan and may be reused;
+- a fatal planning result, cancellation, fix-resolution failure, or postcondition failure removes the affected retained state as documented by the lifecycle tests.
+
+This matches the current Eclipse JDT cleanup orchestrator, which invokes one registered cleanup instance sequentially while it builds a common preview and change tree.
+
+## Defensive concurrency boundary
+
+Alternative callers, including future headless batching code, must not assume that project plans can be created or resolved concurrently on the same instance. The base class protects every entry point that can access retained plan state with a private lifecycle lock:
+
+- `checkPreConditions(...)`;
+- `createFix(...)`;
+- `checkPostConditions(...)`;
+- `expandCleanUpScope(...)`;
+- protected plan access used by tests and specialised subclasses.
+
+The lock is deliberately private. The implementation does not synchronize on the publicly reachable cleanup instance or on the cleanup class, so external code cannot accidentally participate in the monitor protocol.
+
+Overridable planning, scope-discovery, fix-resolution, and postcondition hooks execute while the lifecycle lock is held. Implementations must remain synchronous and must not wait for another thread to invoke a lifecycle method on the same cleanup instance.
+
+## Parallel execution
+
+Parallel project processing requires one cleanup instance per independently executing run. Sharing one instance across worker threads is safe only in the limited sense that the base class serializes access; it does not provide parallel planning throughput.
+
+This distinction is intentional:
+
+- mutable run state remains simple and auditable;
+- plans for different projects cannot race or leak into each other;
+- existing JDT UI behavior is preserved;
+- a future parallel orchestrator has an explicit factory/ownership requirement instead of relying on incidental thread safety.
+
+## Verification
+
+`AbstractPlannedMultiFileCleanUpTest` starts planning for two projects from separate executor threads, blocks the first plan inside the overridable hook, and verifies that the second hook cannot enter until the first lifecycle call is released. The test also verifies that both project plans remain independently available afterward.
+
+Related issue: #1220.

--- a/sandbox_common/src/org/sandbox/jdt/cleanup/multifile/AbstractPlannedMultiFileCleanUp.java
+++ b/sandbox_common/src/org/sandbox/jdt/cleanup/multifile/AbstractPlannedMultiFileCleanUp.java
@@ -41,6 +41,19 @@ import org.sandbox.jdt.cleanup.multifile.api.IMultiFileCleanUpScopeProvider;
  * for every target. The ordinary cleanup refactoring already combines all local
  * changes into one preview, apply operation, and undo.</p>
  *
+ * <p>The JDT cleanup orchestrator invokes one cleanup instance sequentially.
+ * Alternative callers must not assume that project plans can be built or
+ * resolved concurrently on the same instance. All lifecycle entry points that
+ * can access retained plan state are therefore serialized on a private lock.
+ * The lock is deliberately not the publicly reachable cleanup instance or class
+ * monitor. An instance may be reused after {@link #checkPostConditions(IProgressMonitor)}
+ * has completed and cleared all retained state.</p>
+ *
+ * <p>Overridable planning, scope-discovery, fix-resolution, and postcondition
+ * hooks execute while that private lifecycle lock is held. Implementations must
+ * therefore remain synchronous and must not wait for another thread to call a
+ * lifecycle method on the same cleanup instance.</p>
+ *
  * <p>Plans must not retain AST nodes from the planning parser. Previous cleanups
  * may change working copies before this cleanup receives its current AST. Store
  * Java model handles, binding keys, signatures, and semantic edit descriptions,
@@ -50,6 +63,8 @@ import org.sandbox.jdt.cleanup.multifile.api.IMultiFileCleanUpScopeProvider;
  */
 public abstract class AbstractPlannedMultiFileCleanUp<P> extends AbstractCleanUp
 		implements IMultiFileCleanUpScopeProvider {
+
+	private final Object lifecycleLock= new Object();
 
 	private final Map<IJavaProject, P> plansByProject= new HashMap<>();
 
@@ -88,45 +103,51 @@ public abstract class AbstractPlannedMultiFileCleanUp<P> extends AbstractCleanUp
 	@Override
 	public final RefactoringStatus checkPreConditions(IJavaProject project, ICompilationUnit[] compilationUnits,
 			IProgressMonitor monitor) throws CoreException {
-		plansByProject.remove(project);
-		MultiFileCleanUpPlanResult<P> result;
-		try {
-			result= createPlan(project, compilationUnits.clone(), monitor);
-		} catch (CoreException | RuntimeException e) {
+		synchronized (lifecycleLock) {
 			plansByProject.remove(project);
-			throw e;
+			MultiFileCleanUpPlanResult<P> result;
+			try {
+				result= createPlan(project, compilationUnits.clone(), monitor);
+			} catch (CoreException | RuntimeException e) {
+				plansByProject.remove(project);
+				throw e;
+			}
+			if (!result.status().hasFatalError() && result.plan() != null) {
+				plansByProject.put(project, result.plan());
+			}
+			return result.status();
 		}
-		if (!result.status().hasFatalError() && result.plan() != null) {
-			plansByProject.put(project, result.plan());
-		}
-		return result.status();
 	}
 
 	@Override
 	public final ICleanUpFix createFix(CleanUpContext context) throws CoreException {
-		ICompilationUnit unit= context.getCompilationUnit();
-		if (unit == null) {
-			return null;
-		}
-		IJavaProject project= unit.getJavaProject();
-		P plan= plansByProject.get(project);
-		if (plan == null) {
-			return null;
-		}
-		try {
-			return createFixForPlan(plan, context);
-		} catch (CoreException | RuntimeException e) {
-			plansByProject.remove(project);
-			throw e;
+		synchronized (lifecycleLock) {
+			ICompilationUnit unit= context.getCompilationUnit();
+			if (unit == null) {
+				return null;
+			}
+			IJavaProject project= unit.getJavaProject();
+			P plan= plansByProject.get(project);
+			if (plan == null) {
+				return null;
+			}
+			try {
+				return createFixForPlan(plan, context);
+			} catch (CoreException | RuntimeException e) {
+				plansByProject.remove(project);
+				throw e;
+			}
 		}
 	}
 
 	@Override
 	public final RefactoringStatus checkPostConditions(IProgressMonitor monitor) throws CoreException {
-		try {
-			return checkPlanPostConditions(monitor);
-		} finally {
-			plansByProject.clear();
+		synchronized (lifecycleLock) {
+			try {
+				return checkPlanPostConditions(monitor);
+			} finally {
+				plansByProject.clear();
+			}
 		}
 	}
 
@@ -144,9 +165,11 @@ public abstract class AbstractPlannedMultiFileCleanUp<P> extends AbstractCleanUp
 	@Override
 	public final Collection<ICompilationUnit> expandCleanUpScope(IJavaProject project,
 			Collection<ICompilationUnit> currentScope, IProgressMonitor monitor) throws CoreException {
-		Collection<ICompilationUnit> result= discoverAdditionalCompilationUnits(project,
-				Collections.unmodifiableCollection(currentScope), monitor);
-		return result == null ? Collections.emptyList() : result;
+		synchronized (lifecycleLock) {
+			Collection<ICompilationUnit> result= discoverAdditionalCompilationUnits(project,
+					Collections.unmodifiableCollection(currentScope), monitor);
+			return result == null ? Collections.emptyList() : result;
+		}
 	}
 
 	/**
@@ -171,6 +194,8 @@ public abstract class AbstractPlannedMultiFileCleanUp<P> extends AbstractCleanUp
 	 * @return plan or {@code null}
 	 */
 	protected final P getPlan(IJavaProject project) {
-		return plansByProject.get(project);
+		synchronized (lifecycleLock) {
+			return plansByProject.get(project);
+		}
 	}
 }

--- a/sandbox_common_test/src/org/sandbox/jdt/cleanup/multifile/AbstractPlannedMultiFileCleanUpTest.java
+++ b/sandbox_common_test/src/org/sandbox/jdt/cleanup/multifile/AbstractPlannedMultiFileCleanUpTest.java
@@ -16,11 +16,18 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 
@@ -45,6 +52,9 @@ class AbstractPlannedMultiFileCleanUpTest {
 
 	private static final class TestCleanUp extends AbstractPlannedMultiFileCleanUp<TestPlan> {
 		private final List<ICompilationUnit> fixedUnits= new ArrayList<>();
+		private final AtomicInteger planningCalls= new AtomicInteger();
+		private final AtomicInteger activePlanningCalls= new AtomicInteger();
+		private final AtomicInteger maximumConcurrentPlanningCalls= new AtomicInteger();
 		private ICompilationUnit[] plannedUnits;
 		private RefactoringStatus planningStatus= new RefactoringStatus();
 		private CoreException planningCoreFailure;
@@ -52,21 +62,38 @@ class AbstractPlannedMultiFileCleanUpTest {
 		private IJavaProject failingFixProject;
 		private CoreException fixFailure;
 		private CoreException postConditionFailure;
+		private CountDownLatch firstPlanningEntered;
+		private CountDownLatch releaseFirstPlanning;
+		private CountDownLatch secondPlanningEntered;
 
 		@Override
 		protected MultiFileCleanUpPlanResult<TestPlan> createPlan(IJavaProject project,
 				ICompilationUnit[] compilationUnits, IProgressMonitor monitor) throws CoreException {
-			if (planningCoreFailure != null) {
-				throw planningCoreFailure;
+			int call= planningCalls.incrementAndGet();
+			int activeCalls= activePlanningCalls.incrementAndGet();
+			maximumConcurrentPlanningCalls.accumulateAndGet(activeCalls, Math::max);
+			try {
+				if (call == 1 && firstPlanningEntered != null) {
+					firstPlanningEntered.countDown();
+					await(releaseFirstPlanning);
+				}
+				if (call == 2 && secondPlanningEntered != null) {
+					secondPlanningEntered.countDown();
+				}
+				if (planningCoreFailure != null) {
+					throw planningCoreFailure;
+				}
+				if (planningRuntimeFailure != null) {
+					throw planningRuntimeFailure;
+				}
+				plannedUnits= compilationUnits;
+				if (planningStatus.hasFatalError()) {
+					return new MultiFileCleanUpPlanResult<>(null, planningStatus);
+				}
+				return new MultiFileCleanUpPlanResult<>(new TestPlan(project, List.of(compilationUnits)), planningStatus);
+			} finally {
+				activePlanningCalls.decrementAndGet();
 			}
-			if (planningRuntimeFailure != null) {
-				throw planningRuntimeFailure;
-			}
-			plannedUnits= compilationUnits;
-			if (planningStatus.hasFatalError()) {
-				return new MultiFileCleanUpPlanResult<>(null, planningStatus);
-			}
-			return new MultiFileCleanUpPlanResult<>(new TestPlan(project, List.of(compilationUnits)), planningStatus);
 		}
 
 		@Override
@@ -215,6 +242,41 @@ class AbstractPlannedMultiFileCleanUpTest {
 	}
 
 	@Test
+	void serializesLifecycleCallsAcrossThreads() throws Exception {
+		IJavaProject firstProject= javaProject();
+		IJavaProject secondProject= javaProject();
+		ICompilationUnit first= compilationUnit(firstProject, "First.java"); //$NON-NLS-1$
+		ICompilationUnit second= compilationUnit(secondProject, "Second.java"); //$NON-NLS-1$
+		TestCleanUp cleanUp= new TestCleanUp();
+		cleanUp.firstPlanningEntered= new CountDownLatch(1);
+		cleanUp.releaseFirstPlanning= new CountDownLatch(1);
+		cleanUp.secondPlanningEntered= new CountDownLatch(1);
+		ExecutorService executor= Executors.newFixedThreadPool(2);
+		try {
+			Future<RefactoringStatus> firstPlanning= executor.submit(() -> cleanUp.checkPreConditions(firstProject,
+					new ICompilationUnit[] { first }, new NullProgressMonitor()));
+			assertTrue(cleanUp.firstPlanningEntered.await(5, TimeUnit.SECONDS));
+
+			Future<RefactoringStatus> secondPlanning= executor.submit(() -> cleanUp.checkPreConditions(secondProject,
+					new ICompilationUnit[] { second }, new NullProgressMonitor()));
+			assertFalse(cleanUp.secondPlanningEntered.await(250, TimeUnit.MILLISECONDS),
+					"Second planning must wait for the first lifecycle call"); //$NON-NLS-1$
+
+			cleanUp.releaseFirstPlanning.countDown();
+			assertFalse(firstPlanning.get(5, TimeUnit.SECONDS).hasError());
+			assertFalse(secondPlanning.get(5, TimeUnit.SECONDS).hasError());
+			assertTrue(cleanUp.secondPlanningEntered.await(5, TimeUnit.SECONDS));
+			assertEquals(1, cleanUp.maximumConcurrentPlanningCalls.get());
+			assertEquals(List.of(first), cleanUp.retainedPlan(firstProject).units());
+			assertEquals(List.of(second), cleanUp.retainedPlan(secondProject).units());
+		} finally {
+			cleanUp.releaseFirstPlanning.countDown();
+			executor.shutdownNow();
+			assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+		}
+	}
+
+	@Test
 	void defaultScopeExpansionIsEmpty() throws CoreException {
 		IJavaProject project= javaProject();
 		ICompilationUnit unit= compilationUnit(project, "Only.java"); //$NON-NLS-1$
@@ -224,6 +286,17 @@ class AbstractPlannedMultiFileCleanUpTest {
 				new NullProgressMonitor());
 
 		assertEquals(List.of(), List.copyOf(expanded));
+	}
+
+	private static void await(CountDownLatch latch) {
+		try {
+			if (!latch.await(5, TimeUnit.SECONDS)) {
+				throw new AssertionError("Timed out waiting for lifecycle test latch"); //$NON-NLS-1$
+			}
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new OperationCanceledException();
+		}
 	}
 
 	private static IJavaProject javaProject() {

--- a/sandbox_common_test/src/org/sandbox/jdt/cleanup/multifile/AbstractPlannedMultiFileCleanUpTest.java
+++ b/sandbox_common_test/src/org/sandbox/jdt/cleanup/multifile/AbstractPlannedMultiFileCleanUpTest.java
@@ -251,15 +251,20 @@ class AbstractPlannedMultiFileCleanUpTest {
 		cleanUp.firstPlanningEntered= new CountDownLatch(1);
 		cleanUp.releaseFirstPlanning= new CountDownLatch(1);
 		cleanUp.secondPlanningEntered= new CountDownLatch(1);
+		CountDownLatch secondWorkerStarted= new CountDownLatch(1);
 		ExecutorService executor= Executors.newFixedThreadPool(2);
 		try {
 			Future<RefactoringStatus> firstPlanning= executor.submit(() -> cleanUp.checkPreConditions(firstProject,
 					new ICompilationUnit[] { first }, new NullProgressMonitor()));
 			assertTrue(cleanUp.firstPlanningEntered.await(5, TimeUnit.SECONDS));
 
-			Future<RefactoringStatus> secondPlanning= executor.submit(() -> cleanUp.checkPreConditions(secondProject,
-					new ICompilationUnit[] { second }, new NullProgressMonitor()));
-			assertFalse(cleanUp.secondPlanningEntered.await(250, TimeUnit.MILLISECONDS),
+			Future<RefactoringStatus> secondPlanning= executor.submit(() -> {
+				secondWorkerStarted.countDown();
+				return cleanUp.checkPreConditions(secondProject,
+						new ICompilationUnit[] { second }, new NullProgressMonitor());
+			});
+			assertTrue(secondWorkerStarted.await(5, TimeUnit.SECONDS));
+			assertFalse(cleanUp.secondPlanningEntered.await(1, TimeUnit.SECONDS),
 					"Second planning must wait for the first lifecycle call"); //$NON-NLS-1$
 
 			cleanUp.releaseFirstPlanning.countDown();


### PR DESCRIPTION
## Summary

Defines and enforces the ownership/concurrency contract for stateful planned multi-file cleanup instances.

## Changes

- document that the current JDT cleanup orchestrator invokes one cleanup instance sequentially;
- protect retained project plans with a private lifecycle lock rather than a public instance/class monitor;
- serialize preconditions, scope discovery, per-file fix resolution, postconditions and protected plan access;
- document instance reuse after postconditions and the hook restriction against waiting for another lifecycle call on the same instance;
- add a dedicated lifecycle-ownership document for UI and future headless callers;
- add a two-thread regression test proving that planning hooks cannot overlap and project plans remain isolated afterward.

## Design boundary

The base class provides defensive correctness when an alternative caller shares an instance across threads, but it intentionally does not promise parallel planning throughput. Parallel workers must create one cleanup instance per independent run.

Closes #1220.