### PR TITLE
Publish exact post-merge build provenance

### DIFF
--- a/.github/pages/index.html
+++ b/.github/pages/index.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Sandbox Eclipse JDT cleanup project dashboard">
+  <title>Sandbox — Eclipse JDT Cleanups & Tools</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --background: #f5f7fa;
+      --surface: #ffffff;
+      --text: #172033;
+      --muted: #5f6b7a;
+      --primary: #1769aa;
+      --border: #dbe2ea;
+      --shadow: 0 8px 24px rgba(23, 32, 51, 0.08);
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --background: #111722;
+        --surface: #1a2332;
+        --text: #eef3f8;
+        --muted: #b5c0cd;
+        --primary: #76b9ed;
+        --border: #344155;
+        --shadow: none;
+      }
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.6;
+      color: var(--text);
+      background: var(--background);
+    }
+    header {
+      padding: 4rem 1.5rem 3rem;
+      text-align: center;
+      color: white;
+      background: linear-gradient(135deg, #182848, #1769aa);
+    }
+    header h1 { margin: 0; font-size: clamp(2rem, 5vw, 3.4rem); }
+    header p { margin: .75rem auto 1.5rem; max-width: 760px; font-size: 1.1rem; }
+    .badges { display: flex; flex-wrap: wrap; justify-content: center; gap: .5rem; }
+    .badges img { height: 20px; }
+    main { max-width: 1180px; margin: 0 auto; padding: 2.5rem 1.5rem 4rem; }
+    section { margin-bottom: 2.8rem; }
+    h2 { margin: 0 0 1.2rem; font-size: 1.65rem; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1.1rem; }
+    .card {
+      display: flex;
+      flex-direction: column;
+      min-height: 190px;
+      padding: 1.35rem;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      background: var(--surface);
+      box-shadow: var(--shadow);
+    }
+    .card h3 { margin: 0 0 .5rem; font-size: 1.18rem; }
+    .card p { margin: 0 0 1rem; color: var(--muted); }
+    .card a { margin-top: auto; color: var(--primary); font-weight: 650; text-decoration: none; }
+    .card a:hover, .card a:focus-visible { text-decoration: underline; }
+    code {
+      display: block;
+      padding: .65rem;
+      overflow-wrap: anywhere;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: var(--background);
+      font-size: .86rem;
+    }
+    footer { padding: 2rem 1rem; text-align: center; color: var(--muted); border-top: 1px solid var(--border); }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Sandbox</h1>
+    <p>Experimental Eclipse JDT cleanups, coordinated refactorings, developer tooling, and reproducible product builds.</p>
+    <div class="badges" aria-label="Build status">
+      <a href="https://github.com/carstenartur/sandbox/actions/workflows/maven.yml"><img src="https://github.com/carstenartur/sandbox/actions/workflows/maven.yml/badge.svg?branch=main" alt="Java CI status"></a>
+      <a href="https://github.com/carstenartur/sandbox/actions/workflows/codeql.yml"><img src="https://github.com/carstenartur/sandbox/actions/workflows/codeql.yml/badge.svg?branch=main" alt="CodeQL status"></a>
+      <a href="https://github.com/carstenartur/sandbox/actions/workflows/test-report.yml"><img src="https://github.com/carstenartur/sandbox/actions/workflows/test-report.yml/badge.svg?branch=main" alt="Test report status"></a>
+      <a href="https://github.com/carstenartur/sandbox/actions/workflows/deploy-snapshot.yml"><img src="https://github.com/carstenartur/sandbox/actions/workflows/deploy-snapshot.yml/badge.svg?branch=main" alt="Snapshot deployment status"></a>
+    </div>
+  </header>
+
+  <main>
+    <section>
+      <h2>Quality and provenance</h2>
+      <div class="grid">
+        <article class="card">
+          <h3>Build provenance</h3>
+          <p>Exact main commit, workflow runs, toolchain versions, test inventory, target-definition hashes, and distribution digests.</p>
+          <a href="provenance/">Open provenance dashboard →</a>
+        </article>
+        <article class="card">
+          <h3>Test results</h3>
+          <p>HTML reports for all Maven/Tycho test modules, including failures and module totals.</p>
+          <a href="tests/">Open test reports →</a>
+        </article>
+        <article class="card">
+          <h3>Code coverage</h3>
+          <p>JaCoCo coverage reports for the maintained core and Eclipse plugin modules.</p>
+          <a href="coverage/">Open coverage reports →</a>
+        </article>
+        <article class="card">
+          <h3>Performance</h3>
+          <p>JMH benchmark history for performance-sensitive transformation and analysis components.</p>
+          <a href="dev/bench/">Open benchmark charts →</a>
+        </article>
+      </div>
+    </section>
+
+    <section>
+      <h2>Distribution</h2>
+      <div class="grid">
+        <article class="card">
+          <h3>Versioned releases</h3>
+          <p>Stable, immutable p2 repositories published for tagged releases.</p>
+          <code>https://carstenartur.github.io/sandbox/releases/</code>
+          <a href="releases/">Browse releases →</a>
+        </article>
+        <article class="card">
+          <h3>Latest snapshot</h3>
+          <p>Development update site built from the exact successful Java CI commit recorded in its manifest.</p>
+          <code>https://carstenartur.github.io/sandbox/snapshots/latest/</code>
+          <a href="snapshots/latest/">Browse snapshot →</a>
+        </article>
+        <article class="card">
+          <h3>Snapshot manifest</h3>
+          <p>Machine-readable commit, source CI run, Maven/Tycho/Java versions, and p2 repository digest.</p>
+          <a href="snapshots/latest/build-manifest.json">View snapshot manifest →</a>
+        </article>
+      </div>
+    </section>
+
+    <section>
+      <h2>Project resources</h2>
+      <div class="grid">
+        <article class="card"><h3>Source code</h3><p>Repository, architecture, implementation, and contribution history.</p><a href="https://github.com/carstenartur/sandbox">Open repository →</a></article>
+        <article class="card"><h3>Issues</h3><p>Tracked defects, implementation plans, and release-quality work.</p><a href="https://github.com/carstenartur/sandbox/issues">Open issues →</a></article>
+        <article class="card"><h3>Eclipse Marketplace</h3><p>Install the published Sandbox features through Eclipse Marketplace.</p><a href="https://marketplace.eclipse.org/content/sandbox">Open listing →</a></article>
+      </div>
+    </section>
+  </main>
+
+  <footer>Sandbox Project · Eclipse Public License 2.0 · © 2024–present Carsten Hammer and contributors</footer>
+</body>
+</html>

--- a/.github/scripts/collect_commit_workflows.py
+++ b/.github/scripts/collect_commit_workflows.py
@@ -60,7 +60,7 @@ def select_expected_runs(
             and run.get("event") == "push"
         ]
         candidates.sort(
-            key=lambda run: (run.get("run_attempt", 0), run.get("run_number", 0)),
+            key=lambda run: (run.get("run_number", 0), run.get("run_attempt", 0)),
             reverse=True,
         )
         if not candidates:

--- a/.github/scripts/collect_commit_workflows.py
+++ b/.github/scripts/collect_commit_workflows.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Collect the exact completed validation workflow runs for one commit."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+EXPECTED_WORKFLOWS = (
+    "Java CI with Maven",
+    "Core Module Build",
+    "CodeQL",
+    "Codacy Security Scan",
+    "Test Report",
+)
+
+
+def fetch_runs(repository: str, commit_sha: str, token: str) -> list[dict[str, Any]]:
+    url = (
+        f"https://api.github.com/repos/{repository}/actions/runs"
+        f"?head_sha={quote(commit_sha)}&per_page=100"
+    )
+    request = Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "sandbox-build-provenance",
+        },
+    )
+    try:
+        with urlopen(request, timeout=30) as response:
+            payload = json.load(response)
+    except (HTTPError, URLError) as error:
+        raise RuntimeError(f"Could not query GitHub workflow runs: {error}") from error
+    return payload.get("workflow_runs", [])
+
+
+def select_expected_runs(
+    runs: list[dict[str, Any]], commit_sha: str
+) -> tuple[list[dict[str, Any]], list[str], list[str]]:
+    selected: list[dict[str, Any]] = []
+    missing: list[str] = []
+    incomplete: list[str] = []
+
+    for name in EXPECTED_WORKFLOWS:
+        candidates = [
+            run
+            for run in runs
+            if run.get("name") == name
+            and run.get("head_sha") == commit_sha
+            and run.get("event") == "push"
+        ]
+        candidates.sort(
+            key=lambda run: (run.get("run_attempt", 0), run.get("run_number", 0)),
+            reverse=True,
+        )
+        if not candidates:
+            missing.append(name)
+            continue
+        run = candidates[0]
+        normalized = {
+            "id": run.get("id"),
+            "name": run.get("name"),
+            "event": run.get("event"),
+            "head_sha": run.get("head_sha"),
+            "status": run.get("status"),
+            "conclusion": run.get("conclusion"),
+            "run_number": run.get("run_number"),
+            "run_attempt": run.get("run_attempt"),
+            "created_at": run.get("created_at"),
+            "updated_at": run.get("updated_at"),
+            "html_url": run.get("html_url"),
+        }
+        selected.append(normalized)
+        if run.get("status") != "completed":
+            incomplete.append(name)
+
+    selected.sort(key=lambda run: EXPECTED_WORKFLOWS.index(run["name"]))
+    return selected, missing, incomplete
+
+
+def collect(
+    repository: str,
+    commit_sha: str,
+    token: str,
+    timeout_seconds: int,
+    interval_seconds: int,
+) -> list[dict[str, Any]]:
+    deadline = time.monotonic() + timeout_seconds
+    last_missing: list[str] = []
+    last_incomplete: list[str] = []
+    while True:
+        runs = fetch_runs(repository, commit_sha, token)
+        selected, missing, incomplete = select_expected_runs(runs, commit_sha)
+        if not missing and not incomplete:
+            failures = [
+                run
+                for run in selected
+                if run.get("conclusion") not in {"success", "neutral", "skipped"}
+            ]
+            if failures:
+                summary = ", ".join(
+                    f"{run['name']}={run.get('conclusion')}" for run in failures
+                )
+                raise RuntimeError(f"Validation workflow failed for {commit_sha}: {summary}")
+            return selected
+
+        last_missing = missing
+        last_incomplete = incomplete
+        if time.monotonic() >= deadline:
+            raise TimeoutError(
+                "Timed out waiting for commit workflows. "
+                f"Missing: {last_missing or 'none'}; "
+                f"incomplete: {last_incomplete or 'none'}"
+            )
+        print(
+            "Waiting for commit workflows; "
+            f"missing={missing or 'none'}, incomplete={incomplete or 'none'}",
+            flush=True,
+        )
+        time.sleep(interval_seconds)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY"))
+    parser.add_argument("--commit", required=True)
+    parser.add_argument("--output", type=Path, default=Path("related-workflow-runs.json"))
+    parser.add_argument("--timeout-seconds", type=int, default=3600)
+    parser.add_argument("--interval-seconds", type=int, default=30)
+    args = parser.parse_args()
+
+    token = os.environ.get("GITHUB_TOKEN")
+    if not args.repository:
+        raise SystemExit("--repository or GITHUB_REPOSITORY is required")
+    if not token:
+        raise SystemExit("GITHUB_TOKEN is required")
+
+    selected = collect(
+        args.repository,
+        args.commit,
+        token,
+        args.timeout_seconds,
+        args.interval_seconds,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(selected, indent=2) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/collect_commit_workflows.py
+++ b/.github/scripts/collect_commit_workflows.py
@@ -103,9 +103,7 @@ def collect(
         selected, missing, incomplete = select_expected_runs(runs, commit_sha)
         if not missing and not incomplete:
             failures = [
-                run
-                for run in selected
-                if run.get("conclusion") not in {"success", "neutral", "skipped"}
+                run for run in selected if run.get("conclusion") != "success"
             ]
             if failures:
                 summary = ", ".join(

--- a/.github/scripts/generate_build_manifest.py
+++ b/.github/scripts/generate_build_manifest.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Generate machine-readable build provenance for one repository commit."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import re
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+import xml.etree.ElementTree as ET
+
+MAVEN_NAMESPACE = {"m": "http://maven.apache.org/POM/4.0.0"}
+DISTRIBUTION_SUFFIXES = (".zip", ".tar.gz", ".tgz", ".dmg", ".exe")
+P2_METADATA_NAMES = {
+    "artifacts.jar",
+    "artifacts.xml",
+    "content.jar",
+    "content.xml",
+    "p2.index",
+}
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def tree_digest(root: Path) -> dict[str, Any]:
+    files = sorted(path for path in root.rglob("*") if path.is_file())
+    digest = hashlib.sha256()
+    total_bytes = 0
+    for path in files:
+        relative = path.relative_to(root).as_posix()
+        file_digest = sha256_file(path)
+        size = path.stat().st_size
+        total_bytes += size
+        digest.update(relative.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(file_digest.encode("ascii"))
+        digest.update(b"\n")
+    return {
+        "path": root.as_posix(),
+        "file_count": len(files),
+        "total_bytes": total_bytes,
+        "sha256_tree": digest.hexdigest(),
+    }
+
+
+def parse_pom(repo_root: Path) -> dict[str, Any]:
+    pom = repo_root / "pom.xml"
+    root = ET.parse(pom).getroot()
+    properties = root.find("m:properties", MAVEN_NAMESPACE)
+
+    def property_value(name: str) -> str | None:
+        if properties is None:
+            return None
+        element = properties.find(f"m:{name}", MAVEN_NAMESPACE)
+        return element.text.strip() if element is not None and element.text else None
+
+    version = root.findtext("m:version", default="", namespaces=MAVEN_NAMESPACE).strip()
+    repository_urls = [
+        element.text.strip()
+        for element in root.findall("m:repositories/m:repository/m:url", MAVEN_NAMESPACE)
+        if element.text
+    ]
+    release = None
+    for url in repository_urls:
+        match = re.search(r"/releases/([^/]+)/?", url)
+        if match:
+            release = match.group(1)
+            break
+
+    return {
+        "project_version": version,
+        "java_version": property_value("java-version"),
+        "java_execution_environment": property_value("java-execenv"),
+        "tycho_version": property_value("tycho-version"),
+        "spotbugs_maven_plugin_version": property_value("spotbugs-version"),
+        "eclipse_release": release,
+        "p2_repositories": repository_urls,
+    }
+
+
+def target_definitions(repo_root: Path) -> list[dict[str, Any]]:
+    target_dir = repo_root / "sandbox_target"
+    if not target_dir.is_dir():
+        return []
+    return [
+        {
+            "path": path.relative_to(repo_root).as_posix(),
+            "size_bytes": path.stat().st_size,
+            "sha256": sha256_file(path),
+        }
+        for path in sorted(target_dir.glob("*.target"))
+    ]
+
+
+def load_test_inventory(repo_root: Path) -> dict[str, Any] | None:
+    path = repo_root / "test-report.json"
+    if not path.is_file():
+        return None
+    with path.open(encoding="utf-8") as stream:
+        report = json.load(stream)
+    return report.get("summary")
+
+
+def executed_test_totals(repo_root: Path) -> dict[str, int]:
+    totals = {"tests": 0, "failures": 0, "errors": 0, "skipped": 0, "report_files": 0}
+    for path in sorted(repo_root.glob("**/target/surefire-reports/TEST-*.xml")):
+        try:
+            root = ET.parse(path).getroot()
+        except ET.ParseError:
+            continue
+        suites: Iterable[ET.Element]
+        if root.tag.rsplit("}", 1)[-1] == "testsuite":
+            suites = (root,)
+        else:
+            suites = [child for child in root if child.tag.rsplit("}", 1)[-1] == "testsuite"]
+        totals["report_files"] += 1
+        for suite in suites:
+            for key in ("tests", "failures", "errors", "skipped"):
+                try:
+                    totals[key] += int(suite.attrib.get(key, "0"))
+                except ValueError:
+                    pass
+    return totals
+
+
+def distribution_artifacts(repo_root: Path) -> dict[str, Any]:
+    product_roots = [repo_root / "sandbox_product" / "target" / "products"]
+    product_files: list[dict[str, Any]] = []
+    for root in product_roots:
+        if not root.is_dir():
+            continue
+        for path in sorted(candidate for candidate in root.rglob("*") if candidate.is_file()):
+            lower_name = path.name.lower()
+            if not lower_name.endswith(DISTRIBUTION_SUFFIXES):
+                continue
+            product_files.append({
+                "path": path.relative_to(repo_root).as_posix(),
+                "size_bytes": path.stat().st_size,
+                "sha256": sha256_file(path),
+            })
+
+    update_site_root = repo_root / "sandbox_updatesite" / "target" / "repository"
+    update_site = None
+    if update_site_root.is_dir():
+        update_site = tree_digest(update_site_root)
+        update_site["path"] = update_site_root.relative_to(repo_root).as_posix()
+        update_site["metadata"] = [
+            {
+                "path": path.relative_to(repo_root).as_posix(),
+                "size_bytes": path.stat().st_size,
+                "sha256": sha256_file(path),
+            }
+            for path in sorted(update_site_root.rglob("*"))
+            if path.is_file() and path.name in P2_METADATA_NAMES
+        ]
+
+    return {
+        "products": product_files,
+        "product_status": "built" if product_files else "not_built_in_this_run",
+        "update_site": update_site,
+        "update_site_status": "built" if update_site else "not_built_in_this_run",
+    }
+
+
+def command_version(command: list[str]) -> str | None:
+    try:
+        result = subprocess.run(command, check=True, capture_output=True, text=True)
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    output = result.stdout.strip() or result.stderr.strip()
+    return output.splitlines()[0] if output else None
+
+
+def load_related_workflows(path: Path | None) -> list[dict[str, Any]]:
+    if path is None or not path.is_file():
+        return []
+    with path.open(encoding="utf-8") as stream:
+        value = json.load(stream)
+    if not isinstance(value, list):
+        raise ValueError("Related workflow data must be a JSON array")
+    return value
+
+
+def build_manifest(repo_root: Path, related_workflows: Path | None) -> dict[str, Any]:
+    repository = os.environ.get("GITHUB_REPOSITORY", "local/sandbox")
+    commit_sha = os.environ.get("GITHUB_SHA") or command_version(["git", "rev-parse", "HEAD"])
+    run_id = os.environ.get("GITHUB_RUN_ID")
+    server_url = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
+    workflow_run_url = (
+        f"{server_url}/{repository}/actions/runs/{run_id}" if run_id else None
+    )
+
+    manifest = {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "repository": repository,
+        "commit_sha": commit_sha,
+        "commit_url": f"{server_url}/{repository}/commit/{commit_sha}" if commit_sha else None,
+        "ref": os.environ.get("GITHUB_REF"),
+        "event_name": os.environ.get("GITHUB_EVENT_NAME"),
+        "provenance_workflow": {
+            "name": os.environ.get("GITHUB_WORKFLOW"),
+            "run_id": run_id,
+            "run_number": os.environ.get("GITHUB_RUN_NUMBER"),
+            "run_attempt": os.environ.get("GITHUB_RUN_ATTEMPT"),
+            "run_url": workflow_run_url,
+            "source_java_ci_run_id": os.environ.get("SOURCE_JAVA_CI_RUN_ID"),
+            "source_java_ci_run_url": os.environ.get("SOURCE_JAVA_CI_RUN_URL"),
+        },
+        "toolchain": {
+            **parse_pom(repo_root),
+            "runtime_python": platform.python_version(),
+            "runtime_java": command_version(["java", "-version"]),
+            "runtime_maven": command_version(["mvn", "--version"]),
+            "target_definitions": target_definitions(repo_root),
+        },
+        "tests": {
+            "inventory": load_test_inventory(repo_root),
+            "executed": executed_test_totals(repo_root),
+        },
+        "artifacts": distribution_artifacts(repo_root),
+        "related_workflows": load_related_workflows(related_workflows),
+        "patched_jdt_ui": {
+            "commit": os.environ.get("PATCHED_JDT_UI_COMMIT"),
+            "version": os.environ.get("PATCHED_JDT_UI_VERSION"),
+        },
+    }
+    return manifest
+
+
+def render_html(manifest: dict[str, Any]) -> str:
+    commit_sha = manifest.get("commit_sha") or "unknown"
+    commit_url = manifest.get("commit_url") or "#"
+    workflows = manifest.get("related_workflows", [])
+    rows = "\n".join(
+        "<tr><td>{name}</td><td>{conclusion}</td><td><a href=\"{url}\">run {run_id}</a></td></tr>".format(
+            name=workflow.get("name", "unknown"),
+            conclusion=workflow.get("conclusion") or workflow.get("status", "unknown"),
+            url=workflow.get("html_url", "#"),
+            run_id=workflow.get("id", "?"),
+        )
+        for workflow in workflows
+    )
+    inventory = manifest.get("tests", {}).get("inventory") or {}
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sandbox build provenance</title>
+  <style>
+    body {{ font-family: system-ui, sans-serif; max-width: 1100px; margin: 0 auto; padding: 2rem; }}
+    code {{ background: #f3f3f3; padding: .15rem .3rem; }}
+    table {{ border-collapse: collapse; width: 100%; }}
+    th, td {{ border: 1px solid #ddd; padding: .6rem; text-align: left; }}
+    th {{ background: #f3f3f3; }}
+  </style>
+</head>
+<body>
+  <h1>Sandbox build provenance</h1>
+  <p>Commit: <a href="{commit_url}"><code>{commit_sha}</code></a></p>
+  <p>Static test inventory: {inventory.get('total_tests', 'N/A')} tests,
+     {inventory.get('disabled_tests', 'N/A')} disabled.</p>
+  <p><a href="latest.json">Machine-readable manifest</a></p>
+  <h2>Validated workflow runs</h2>
+  <table>
+    <thead><tr><th>Workflow</th><th>Conclusion</th><th>Run</th></tr></thead>
+    <tbody>{rows}</tbody>
+  </table>
+</body>
+</html>
+"""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository-root", type=Path, default=Path.cwd())
+    parser.add_argument("--related-workflows", type=Path)
+    parser.add_argument("--output", type=Path, default=Path("build-manifest.json"))
+    parser.add_argument("--html-output", type=Path)
+    args = parser.parse_args()
+
+    repo_root = args.repository_root.resolve()
+    manifest = build_manifest(repo_root, args.related_workflows)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    if args.html_output:
+        args.html_output.parent.mkdir(parents=True, exist_ok=True)
+        args.html_output.write_text(render_html(manifest), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/generate_build_manifest.py
+++ b/.github/scripts/generate_build_manifest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+from html import escape
 import json
 import os
 import platform
@@ -115,7 +116,11 @@ def load_test_inventory(repo_root: Path) -> dict[str, Any] | None:
 
 def executed_test_totals(repo_root: Path) -> dict[str, int]:
     totals = {"tests": 0, "failures": 0, "errors": 0, "skipped": 0, "report_files": 0}
-    for path in sorted(repo_root.glob("**/target/surefire-reports/TEST-*.xml")):
+    combined_reports = sorted(repo_root.glob("**/combined-tests.xml"))
+    report_paths = combined_reports or sorted(
+        repo_root.glob("**/target/surefire-reports/TEST-*.xml")
+    )
+    for path in report_paths:
         try:
             root = ET.parse(path).getroot()
         except ET.ParseError:
@@ -136,14 +141,14 @@ def executed_test_totals(repo_root: Path) -> dict[str, int]:
 
 
 def distribution_artifacts(repo_root: Path) -> dict[str, Any]:
-    product_roots = [repo_root / "sandbox_product" / "target" / "products"]
+    product_root = repo_root / "sandbox_product" / "target" / "products"
+    product_tree = None
     product_files: list[dict[str, Any]] = []
-    for root in product_roots:
-        if not root.is_dir():
-            continue
-        for path in sorted(candidate for candidate in root.rglob("*") if candidate.is_file()):
-            lower_name = path.name.lower()
-            if not lower_name.endswith(DISTRIBUTION_SUFFIXES):
+    if product_root.is_dir():
+        product_tree = tree_digest(product_root)
+        product_tree["path"] = product_root.relative_to(repo_root).as_posix()
+        for path in sorted(candidate for candidate in product_root.rglob("*") if candidate.is_file()):
+            if not path.name.lower().endswith(DISTRIBUTION_SUFFIXES):
                 continue
             product_files.append({
                 "path": path.relative_to(repo_root).as_posix(),
@@ -168,7 +173,8 @@ def distribution_artifacts(repo_root: Path) -> dict[str, Any]:
 
     return {
         "products": product_files,
-        "product_status": "built" if product_files else "not_built_in_this_run",
+        "product_tree": product_tree,
+        "product_status": "built" if product_tree else "not_built_in_this_run",
         "update_site": update_site,
         "update_site_status": "built" if update_site else "not_built_in_this_run",
     }
@@ -202,7 +208,7 @@ def build_manifest(repo_root: Path, related_workflows: Path | None) -> dict[str,
         f"{server_url}/{repository}/actions/runs/{run_id}" if run_id else None
     )
 
-    manifest = {
+    return {
         "schema_version": 1,
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "repository": repository,
@@ -237,19 +243,18 @@ def build_manifest(repo_root: Path, related_workflows: Path | None) -> dict[str,
             "version": os.environ.get("PATCHED_JDT_UI_VERSION"),
         },
     }
-    return manifest
 
 
 def render_html(manifest: dict[str, Any]) -> str:
-    commit_sha = manifest.get("commit_sha") or "unknown"
-    commit_url = manifest.get("commit_url") or "#"
+    commit_sha = escape(str(manifest.get("commit_sha") or "unknown"))
+    commit_url = escape(str(manifest.get("commit_url") or "#"), quote=True)
     workflows = manifest.get("related_workflows", [])
     rows = "\n".join(
         "<tr><td>{name}</td><td>{conclusion}</td><td><a href=\"{url}\">run {run_id}</a></td></tr>".format(
-            name=workflow.get("name", "unknown"),
-            conclusion=workflow.get("conclusion") or workflow.get("status", "unknown"),
-            url=workflow.get("html_url", "#"),
-            run_id=workflow.get("id", "?"),
+            name=escape(str(workflow.get("name", "unknown"))),
+            conclusion=escape(str(workflow.get("conclusion") or workflow.get("status", "unknown"))),
+            url=escape(str(workflow.get("html_url", "#")), quote=True),
+            run_id=escape(str(workflow.get("id", "?"))),
         )
         for workflow in workflows
     )

--- a/.github/scripts/generate_build_manifest.py
+++ b/.github/scripts/generate_build_manifest.py
@@ -199,9 +199,18 @@ def load_related_workflows(path: Path | None) -> list[dict[str, Any]]:
     return value
 
 
-def build_manifest(repo_root: Path, related_workflows: Path | None) -> dict[str, Any]:
+def build_manifest(
+    repo_root: Path,
+    related_workflows: Path | None,
+    commit_sha: str | None = None,
+    source_ref: str | None = None,
+) -> dict[str, Any]:
     repository = os.environ.get("GITHUB_REPOSITORY", "local/sandbox")
-    commit_sha = os.environ.get("GITHUB_SHA") or command_version(["git", "rev-parse", "HEAD"])
+    resolved_commit_sha = (
+        commit_sha
+        or os.environ.get("GITHUB_SHA")
+        or command_version(["git", "rev-parse", "HEAD"])
+    )
     run_id = os.environ.get("GITHUB_RUN_ID")
     server_url = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
     workflow_run_url = (
@@ -212,9 +221,13 @@ def build_manifest(repo_root: Path, related_workflows: Path | None) -> dict[str,
         "schema_version": 1,
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "repository": repository,
-        "commit_sha": commit_sha,
-        "commit_url": f"{server_url}/{repository}/commit/{commit_sha}" if commit_sha else None,
-        "ref": os.environ.get("GITHUB_REF"),
+        "commit_sha": resolved_commit_sha,
+        "commit_url": (
+            f"{server_url}/{repository}/commit/{resolved_commit_sha}"
+            if resolved_commit_sha
+            else None
+        ),
+        "ref": source_ref or os.environ.get("GITHUB_REF"),
         "event_name": os.environ.get("GITHUB_EVENT_NAME"),
         "provenance_workflow": {
             "name": os.environ.get("GITHUB_WORKFLOW"),
@@ -252,7 +265,9 @@ def render_html(manifest: dict[str, Any]) -> str:
     rows = "\n".join(
         "<tr><td>{name}</td><td>{conclusion}</td><td><a href=\"{url}\">run {run_id}</a></td></tr>".format(
             name=escape(str(workflow.get("name", "unknown"))),
-            conclusion=escape(str(workflow.get("conclusion") or workflow.get("status", "unknown"))),
+            conclusion=escape(
+                str(workflow.get("conclusion") or workflow.get("status", "unknown"))
+            ),
             url=escape(str(workflow.get("html_url", "#")), quote=True),
             run_id=escape(str(workflow.get("id", "?"))),
         )
@@ -293,12 +308,19 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--repository-root", type=Path, default=Path.cwd())
     parser.add_argument("--related-workflows", type=Path)
+    parser.add_argument("--commit-sha")
+    parser.add_argument("--source-ref")
     parser.add_argument("--output", type=Path, default=Path("build-manifest.json"))
     parser.add_argument("--html-output", type=Path)
     args = parser.parse_args()
 
     repo_root = args.repository_root.resolve()
-    manifest = build_manifest(repo_root, args.related_workflows)
+    manifest = build_manifest(
+        repo_root,
+        args.related_workflows,
+        commit_sha=args.commit_sha,
+        source_ref=args.source_ref,
+    )
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
     if args.html_output:

--- a/.github/scripts/test_build_provenance.py
+++ b/.github/scripts/test_build_provenance.py
@@ -173,6 +173,18 @@ class WorkflowSelectionTest(unittest.TestCase):
                 "run_attempt": 2,
             }
         )
+        runs.append(
+            {
+                "id": 102,
+                "name": "Java CI with Maven",
+                "head_sha": commit,
+                "event": "push",
+                "status": "completed",
+                "conclusion": "failure",
+                "run_number": 9,
+                "run_attempt": 5,
+            }
+        )
 
         selected, missing, incomplete = workflow_module.select_expected_runs(runs, commit)
 

--- a/.github/scripts/test_build_provenance.py
+++ b/.github/scripts/test_build_provenance.py
@@ -132,23 +132,26 @@ class BuildManifestTest(unittest.TestCase):
 
 class WorkflowSelectionTest(unittest.TestCase):
 
+    @staticmethod
+    def successful_runs(commit: str) -> list[dict[str, object]]:
+        return [
+            {
+                "id": index + 1,
+                "name": name,
+                "head_sha": commit,
+                "event": "push",
+                "status": "completed",
+                "conclusion": "success",
+                "run_number": 10,
+                "run_attempt": 1,
+                "html_url": f"https://example/{name}",
+            }
+            for index, name in enumerate(workflow_module.EXPECTED_WORKFLOWS)
+        ]
+
     def test_selects_latest_push_run_for_exact_commit(self):
         commit = "abc123"
-        runs = []
-        for name in workflow_module.EXPECTED_WORKFLOWS:
-            runs.append(
-                {
-                    "id": len(runs) + 1,
-                    "name": name,
-                    "head_sha": commit,
-                    "event": "push",
-                    "status": "completed",
-                    "conclusion": "success",
-                    "run_number": 10,
-                    "run_attempt": 1,
-                    "html_url": f"https://example/{name}",
-                }
-            )
+        runs = self.successful_runs(commit)
         runs.append(
             {
                 "id": 100,
@@ -212,6 +215,15 @@ class WorkflowSelectionTest(unittest.TestCase):
         self.assertEqual(1, len(selected))
         self.assertIn("Core Module Build", missing)
         self.assertEqual(["Java CI with Maven"], incomplete)
+
+    def test_collect_rejects_skipped_required_workflow(self):
+        commit = "abc123"
+        runs = self.successful_runs(commit)
+        runs[2]["conclusion"] = "skipped"
+
+        with patch.object(workflow_module, "fetch_runs", return_value=runs):
+            with self.assertRaisesRegex(RuntimeError, "CodeQL=skipped"):
+                workflow_module.collect("carstenartur/sandbox", commit, "token", 1, 0)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_build_provenance.py
+++ b/.github/scripts/test_build_provenance.py
@@ -90,7 +90,7 @@ class BuildManifestTest(unittest.TestCase):
 
             environment = {
                 "GITHUB_REPOSITORY": "carstenartur/sandbox",
-                "GITHUB_SHA": "abc123",
+                "GITHUB_SHA": "workflow-context-sha",
                 "GITHUB_SERVER_URL": "https://github.com",
                 "GITHUB_RUN_ID": "99",
                 "GITHUB_WORKFLOW": "Post-merge Build Provenance",
@@ -98,15 +98,22 @@ class BuildManifestTest(unittest.TestCase):
             with patch.dict(os.environ, environment, clear=False), patch.object(
                 manifest_module, "command_version", return_value="tool version"
             ):
-                manifest = manifest_module.build_manifest(root, workflow_file)
+                manifest = manifest_module.build_manifest(
+                    root,
+                    workflow_file,
+                    commit_sha="validated-main-sha",
+                    source_ref="refs/heads/main",
+                )
 
-            self.assertEqual("abc123", manifest["commit_sha"])
+            self.assertEqual("validated-main-sha", manifest["commit_sha"])
+            self.assertEqual("refs/heads/main", manifest["ref"])
             self.assertEqual("5.0.3", manifest["toolchain"]["tycho_version"])
             self.assertEqual("2025-12", manifest["toolchain"]["eclipse_release"])
             self.assertEqual(10, manifest["tests"]["inventory"]["total_tests"])
             self.assertEqual(3, manifest["tests"]["executed"]["tests"])
             self.assertEqual(1, manifest["tests"]["executed"]["failures"])
             self.assertEqual("built", manifest["artifacts"]["product_status"])
+            self.assertEqual(1, manifest["artifacts"]["product_tree"]["file_count"])
             self.assertEqual("built", manifest["artifacts"]["update_site_status"])
             self.assertEqual(2, manifest["artifacts"]["update_site"]["file_count"])
             self.assertEqual(1, len(manifest["toolchain"]["target_definitions"]))

--- a/.github/scripts/test_build_provenance.py
+++ b/.github/scripts/test_build_provenance.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Unit tests for the build provenance scripts."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPT_DIR = Path(__file__).parent
+
+
+def load_module(name: str, filename: str):
+    specification = importlib.util.spec_from_file_location(name, SCRIPT_DIR / filename)
+    if specification is None or specification.loader is None:
+        raise RuntimeError(f"Could not load {filename}")
+    module = importlib.util.module_from_spec(specification)
+    specification.loader.exec_module(module)
+    return module
+
+
+manifest_module = load_module("generate_build_manifest", "generate_build_manifest.py")
+workflow_module = load_module("collect_commit_workflows", "collect_commit_workflows.py")
+
+
+class BuildManifestTest(unittest.TestCase):
+
+    def test_manifest_contains_versions_tests_targets_and_distribution_digests(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            (root / "pom.xml").write_text(
+                """<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.sandbox</groupId>
+  <artifactId>central</artifactId>
+  <version>1.3.2-SNAPSHOT</version>
+  <properties>
+    <tycho-version>5.0.3</tycho-version>
+    <java-version>21</java-version>
+    <java-execenv>JavaSE-21</java-execenv>
+    <spotbugs-version>4.10.3.0</spotbugs-version>
+  </properties>
+  <repositories>
+    <repository><url>https://download.eclipse.org/releases/2025-12/</url></repository>
+  </repositories>
+</project>
+""",
+                encoding="utf-8",
+            )
+            target_dir = root / "sandbox_target"
+            target_dir.mkdir()
+            (target_dir / "sandbox.target").write_text("target", encoding="utf-8")
+            (root / "test-report.json").write_text(
+                json.dumps(
+                    {
+                        "summary": {
+                            "total_modules": 2,
+                            "total_tests": 10,
+                            "enabled_tests": 9,
+                            "disabled_tests": 1,
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            reports = root / "module" / "target" / "surefire-reports"
+            reports.mkdir(parents=True)
+            (reports / "TEST-example.xml").write_text(
+                '<testsuite tests="3" failures="1" errors="0" skipped="1"/>',
+                encoding="utf-8",
+            )
+            products = root / "sandbox_product" / "target" / "products"
+            products.mkdir(parents=True)
+            (products / "sandbox.zip").write_bytes(b"product")
+            update_site = root / "sandbox_updatesite" / "target" / "repository"
+            update_site.mkdir(parents=True)
+            (update_site / "content.jar").write_bytes(b"content")
+            (update_site / "plugins").mkdir()
+            (update_site / "plugins" / "bundle.jar").write_bytes(b"bundle")
+            workflow_file = root / "related.json"
+            workflow_file.write_text(
+                json.dumps([{"id": 7, "name": "Java CI with Maven", "conclusion": "success"}]),
+                encoding="utf-8",
+            )
+
+            environment = {
+                "GITHUB_REPOSITORY": "carstenartur/sandbox",
+                "GITHUB_SHA": "abc123",
+                "GITHUB_SERVER_URL": "https://github.com",
+                "GITHUB_RUN_ID": "99",
+                "GITHUB_WORKFLOW": "Post-merge Build Provenance",
+            }
+            with patch.dict(os.environ, environment, clear=False), patch.object(
+                manifest_module, "command_version", return_value="tool version"
+            ):
+                manifest = manifest_module.build_manifest(root, workflow_file)
+
+            self.assertEqual("abc123", manifest["commit_sha"])
+            self.assertEqual("5.0.3", manifest["toolchain"]["tycho_version"])
+            self.assertEqual("2025-12", manifest["toolchain"]["eclipse_release"])
+            self.assertEqual(10, manifest["tests"]["inventory"]["total_tests"])
+            self.assertEqual(3, manifest["tests"]["executed"]["tests"])
+            self.assertEqual(1, manifest["tests"]["executed"]["failures"])
+            self.assertEqual("built", manifest["artifacts"]["product_status"])
+            self.assertEqual("built", manifest["artifacts"]["update_site_status"])
+            self.assertEqual(2, manifest["artifacts"]["update_site"]["file_count"])
+            self.assertEqual(1, len(manifest["toolchain"]["target_definitions"]))
+            self.assertEqual(7, manifest["related_workflows"][0]["id"])
+
+    def test_tree_digest_is_path_order_independent(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            (root / "b.txt").write_text("b", encoding="utf-8")
+            (root / "a.txt").write_text("a", encoding="utf-8")
+            first = manifest_module.tree_digest(root)
+            second = manifest_module.tree_digest(root)
+            self.assertEqual(first["sha256_tree"], second["sha256_tree"])
+            self.assertEqual(2, first["file_count"])
+
+
+class WorkflowSelectionTest(unittest.TestCase):
+
+    def test_selects_latest_push_run_for_exact_commit(self):
+        commit = "abc123"
+        runs = []
+        for name in workflow_module.EXPECTED_WORKFLOWS:
+            runs.append(
+                {
+                    "id": len(runs) + 1,
+                    "name": name,
+                    "head_sha": commit,
+                    "event": "push",
+                    "status": "completed",
+                    "conclusion": "success",
+                    "run_number": 10,
+                    "run_attempt": 1,
+                    "html_url": f"https://example/{name}",
+                }
+            )
+        runs.append(
+            {
+                "id": 100,
+                "name": "Java CI with Maven",
+                "head_sha": commit,
+                "event": "pull_request",
+                "status": "completed",
+                "conclusion": "failure",
+                "run_number": 99,
+                "run_attempt": 1,
+            }
+        )
+        runs.append(
+            {
+                "id": 101,
+                "name": "Java CI with Maven",
+                "head_sha": commit,
+                "event": "push",
+                "status": "completed",
+                "conclusion": "success",
+                "run_number": 10,
+                "run_attempt": 2,
+            }
+        )
+
+        selected, missing, incomplete = workflow_module.select_expected_runs(runs, commit)
+
+        self.assertEqual([], missing)
+        self.assertEqual([], incomplete)
+        self.assertEqual(101, selected[0]["id"])
+        self.assertEqual(list(workflow_module.EXPECTED_WORKFLOWS), [run["name"] for run in selected])
+
+    def test_reports_missing_and_incomplete_workflows(self):
+        selected, missing, incomplete = workflow_module.select_expected_runs(
+            [
+                {
+                    "id": 1,
+                    "name": "Java CI with Maven",
+                    "head_sha": "abc123",
+                    "event": "push",
+                    "status": "in_progress",
+                    "conclusion": None,
+                    "run_number": 1,
+                    "run_attempt": 1,
+                }
+            ],
+            "abc123",
+        )
+        self.assertEqual(1, len(selected))
+        self.assertIn("Core Module Build", missing)
+        self.assertEqual(["Java CI with Maven"], incomplete)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/core-module-build.yml
+++ b/.github/workflows/core-module-build.yml
@@ -20,25 +20,20 @@ concurrency:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        
+
       - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
           java-version: '21'
-          distribution: 'temurin'
+          distribution: temurin
           cache: maven
-          
-      - name: Build and Test Functional Converter Core
-        working-directory: sandbox-functional-converter-core
-        run: mvn clean verify
-        
-      - name: Build and Test Common Core
-        working-directory: sandbox_common_core
-        run: mvn clean verify
 
-      - name: Build and Test Mining Core and CLI
-        run: mvn -pl sandbox_mining_core,sandbox_mining_cli -am clean verify
+      - name: Build and test all core modules in one reactor
+        run: >-
+          mvn clean verify
+          -pl sandbox-functional-converter-core,sandbox_common_core,sandbox_mining_core,sandbox_mining_cli
+          -am

--- a/.github/workflows/core-module-build.yml
+++ b/.github/workflows/core-module-build.yml
@@ -2,12 +2,7 @@ name: Core Module Build
 
 on:
   push:
-    paths:
-      - 'sandbox-functional-converter-core/**'
-      - 'sandbox_common_core/**'
-      - 'sandbox_mining_cli/**'
-      - 'sandbox_mining_core/**'
-      - '.github/workflows/core-module-build.yml'
+    branches: [ main ]
   pull_request:
     paths:
       - 'sandbox-functional-converter-core/**'
@@ -15,6 +10,8 @@ on:
       - 'sandbox_mining_cli/**'
       - 'sandbox_mining_core/**'
       - '.github/workflows/core-module-build.yml'
+      - '.github/workflows/post-merge-provenance.yml'
+      - '.github/scripts/collect_commit_workflows.py'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -43,27 +40,5 @@ jobs:
         working-directory: sandbox_common_core
         run: mvn clean verify
 
-      - name: Build and Test Mining CLI
-        run: |
-          mvn install -N -q
-          mvn install -pl sandbox_common_core -DskipTests -q
-          mvn clean verify -pl sandbox_mining_cli
-
-      - name: Build and Test Mining Core
-        run: |
-          set -o pipefail
-          mvn install -N -q
-          mvn install -pl sandbox_common_core -DskipTests -q
-          mvn clean verify -pl sandbox_mining_core 2>&1 | tee mining-core-build.log
-        
-      - name: Upload Test Results
-        uses: actions/upload-artifact@v7
-        if: always()
-        with:
-          name: test-results
-          path: |
-            sandbox-functional-converter-core/target/surefire-reports/
-            sandbox_common_core/target/surefire-reports/
-            sandbox_mining_cli/target/surefire-reports/
-            sandbox_mining_core/target/surefire-reports/
-            mining-core-build.log
+      - name: Build and Test Mining Core and CLI
+        run: mvn -pl sandbox_mining_core,sandbox_mining_cli -am clean verify

--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -23,6 +23,7 @@ jobs:
     timeout-minutes: 75
     env:
       VALIDATED_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+      VALIDATED_REF: ${{ github.event_name == 'workflow_run' && format('refs/heads/{0}', github.event.workflow_run.head_branch) || github.ref }}
       SOURCE_JAVA_CI_RUN_ID: ${{ github.event.workflow_run.id }}
       SOURCE_JAVA_CI_RUN_URL: ${{ github.event.workflow_run.html_url }}
 
@@ -59,7 +60,7 @@ jobs:
           python3 .github/scripts/generate_test_report.py > /tmp/test-report-generation.log
           python3 .github/scripts/generate_build_manifest.py \
             --commit-sha "$VALIDATED_SHA" \
-            --source-ref refs/heads/main \
+            --source-ref "$VALIDATED_REF" \
             --output build-manifest.json
           python3 -m json.tool build-manifest.json > /dev/null
 

--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -55,12 +55,11 @@ jobs:
         run: mvn -Pproduct,repo -T 1C --batch-mode clean verify -DskipTests
 
       - name: Generate snapshot build manifest
-        env:
-          GITHUB_SHA: ${{ env.VALIDATED_SHA }}
-          GITHUB_REF: refs/heads/main
         run: |
           python3 .github/scripts/generate_test_report.py > /tmp/test-report-generation.log
           python3 .github/scripts/generate_build_manifest.py \
+            --commit-sha "$VALIDATED_SHA" \
+            --source-ref refs/heads/main \
             --output build-manifest.json
           python3 -m json.tool build-manifest.json > /dev/null
 

--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -5,25 +5,25 @@ on:
     workflows: [ 'Java CI with Maven' ]
     types: [ completed ]
     branches: [ main ]
-  workflow_dispatch:
 
 permissions:
   contents: write
 
 concurrency:
-  group: deploy-snapshot-${{ github.event.workflow_run.head_sha || github.sha }}
+  group: deploy-snapshot-${{ github.event.workflow_run.head_sha }}
   cancel-in-progress: false
 
 jobs:
   build-and-deploy:
     if: >-
-      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main' &&
       github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 75
     env:
-      VALIDATED_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
-      VALIDATED_REF: ${{ github.event_name == 'workflow_run' && format('refs/heads/{0}', github.event.workflow_run.head_branch) || github.ref }}
+      VALIDATED_SHA: ${{ github.event.workflow_run.head_sha }}
+      VALIDATED_REF: refs/heads/main
       SOURCE_JAVA_CI_RUN_ID: ${{ github.event.workflow_run.id }}
       SOURCE_JAVA_CI_RUN_URL: ${{ github.event.workflow_run.html_url }}
 
@@ -129,9 +129,7 @@ jobs:
             echo '### Deployed resources'
             echo
             echo "- [Validated commit](https://github.com/${GITHUB_REPOSITORY}/commit/${VALIDATED_SHA})"
-            if [ -n "$SOURCE_JAVA_CI_RUN_URL" ]; then
-              echo "- [Source Java CI run](${SOURCE_JAVA_CI_RUN_URL})"
-            fi
+            echo "- [Source Java CI run](${SOURCE_JAVA_CI_RUN_URL})"
             echo '- [Project dashboard](https://carstenartur.github.io/sandbox/)'
             echo '- [Latest snapshot update site](https://carstenartur.github.io/sandbox/snapshots/latest/)'
             echo '- [Snapshot build manifest](https://carstenartur.github.io/sandbox/snapshots/latest/build-manifest.json)'

--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -2,460 +2,137 @@ name: Deploy Snapshot to GitHub Pages
 
 on:
   workflow_run:
-    workflows: ["Java CI with Maven"]
-    types:
-      - completed
-    branches: [main]
+    workflows: [ 'Java CI with Maven' ]
+    types: [ completed ]
+    branches: [ main ]
   workflow_dispatch:
 
 permissions:
-  contents: write  # Required: push to gh-pages branch for snapshot deployment
+  contents: write
+
+concurrency:
+  group: deploy-snapshot-${{ github.event.workflow_run.head_sha || github.sha }}
+  cancel-in-progress: false
 
 jobs:
   build-and-deploy:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
-    # Only run if maven workflow succeeded (for workflow_run trigger)
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
-    
+    timeout-minutes: 75
+    env:
+      VALIDATED_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+      SOURCE_JAVA_CI_RUN_ID: ${{ github.event.workflow_run.id }}
+      SOURCE_JAVA_CI_RUN_URL: ${{ github.event.workflow_run.html_url }}
+
     steps:
-    - uses: actions/checkout@v6
-      with:
-        fetch-depth: 0  # Required for jgit timestamp provider
+      - name: Checkout the validated commit
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.VALIDATED_SHA }}
+          fetch-depth: 0
 
-    - name: Set up JDK 21
-      uses: actions/setup-java@v5
-      with:
-        java-version: '21'
-        distribution: 'temurin'
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: temurin
 
-    - name: Cache Maven dependencies
-      uses: actions/cache@v5
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml', 'sandbox_target/*.target') }}
-        restore-keys: ${{ runner.os }}-maven-
+      - name: Cache Maven dependencies
+        uses: actions/cache@v5
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml', 'sandbox_target/*.target') }}
+          restore-keys: ${{ runner.os }}-maven-
 
-    - name: Build Update Site
-      run: mvn -Pproduct,repo -T 1C clean verify -DskipTests
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1
+        with:
+          maven-version: 3.9.14
 
-    - name: Prepare snapshot directory
-      run: |
-        mkdir -p gh-pages-content/snapshots/latest
-        cp -r sandbox_updatesite/target/repository/* gh-pages-content/snapshots/latest/
+      - name: Build product and update site
+        run: mvn -Pproduct,repo -T 1C --batch-mode clean verify -DskipTests
 
-    - name: Create or update composite metadata
-      run: |
-        cd gh-pages-content/snapshots
-        
-        # Use current timestamp as fallback for manual triggers
-        TIMESTAMP="${{ github.event.head_commit.timestamp }}"
-        if [ -z "$TIMESTAMP" ]; then
-          TIMESTAMP="$(date +%s)000"
-        fi
-        
-        # Create compositeContent.xml
-        cat > compositeContent.xml << EOF
-        <?xml version='1.0' encoding='UTF-8'?>
-        <?compositeMetadataRepository version='1.0.0'?>
-        <repository name='Sandbox Snapshots'
-                    type='org.eclipse.equinox.internal.p2.metadata.repository.CompositeMetadataRepository'
-                    version='1.0.0'>
-          <properties size='1'>
-            <property name='p2.timestamp' value='$TIMESTAMP'/>
-          </properties>
-          <children size='1'>
-            <child location='latest'/>
-          </children>
-        </repository>
-        EOF
-        
-        # Create compositeArtifacts.xml
-        cat > compositeArtifacts.xml << EOF
-        <?xml version='1.0' encoding='UTF-8'?>
-        <?compositeArtifactRepository version='1.0.0'?>
-        <repository name='Sandbox Snapshots'
-                    type='org.eclipse.equinox.internal.p2.artifact.repository.CompositeArtifactRepository'
-                    version='1.0.0'>
-          <properties size='1'>
-            <property name='p2.timestamp' value='$TIMESTAMP'/>
-          </properties>
-          <children size='1'>
-            <child location='latest'/>
-          </children>
-        </repository>
-        EOF
+      - name: Generate snapshot build manifest
+        env:
+          GITHUB_SHA: ${{ env.VALIDATED_SHA }}
+          GITHUB_REF: refs/heads/main
+        run: |
+          python3 .github/scripts/generate_test_report.py > /tmp/test-report-generation.log
+          python3 .github/scripts/generate_build_manifest.py \
+            --output build-manifest.json
+          python3 -m json.tool build-manifest.json > /dev/null
 
-    - name: Create modern dashboard index.html
-      run: |
-        cat > gh-pages-content/index.html << 'EOF'
-        <!DOCTYPE html>
-        <html lang="en">
-        <head>
-            <meta charset="UTF-8">
-            <meta name="viewport" content="width=device-width, initial-scale=1.0">
-            <title>Sandbox - Eclipse JDT Cleanups & Tools Dashboard</title>
-            <style>
-                :root {
-                    --primary: #3498db;
-                    --primary-dark: #2c3e50;
-                    --secondary: #2ecc71;
-                    --warning: #f39c12;
-                    --danger: #e74c3c;
-                    --light-bg: #f8f9fa;
-                    --card-shadow: 0 2px 8px rgba(0,0,0,0.1);
-                    --card-hover-shadow: 0 4px 16px rgba(0,0,0,0.15);
-                }
-                
-                * {
-                    margin: 0;
-                    padding: 0;
-                    box-sizing: border-box;
-                }
-                
-                body {
-                    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-                    line-height: 1.6;
-                    color: #333;
-                    background: var(--light-bg);
-                }
-                
-                .hero {
-                    background: linear-gradient(135deg, var(--primary-dark) 0%, var(--primary) 100%);
-                    color: white;
-                    padding: 3rem 2rem;
-                    text-align: center;
-                }
-                
-                .hero h1 {
-                    font-size: 2.5rem;
-                    margin-bottom: 0.5rem;
-                }
-                
-                .hero p {
-                    font-size: 1.2rem;
-                    opacity: 0.9;
-                }
-                
-                .badges {
-                    display: flex;
-                    flex-wrap: wrap;
-                    justify-content: center;
-                    gap: 0.5rem;
-                    margin-top: 1.5rem;
-                }
-                
-                .badges img {
-                    height: 20px;
-                }
-                
-                .container {
-                    max-width: 1200px;
-                    margin: 0 auto;
-                    padding: 2rem;
-                }
-                
-                .section {
-                    margin-bottom: 3rem;
-                }
-                
-                .section h2 {
-                    color: var(--primary-dark);
-                    font-size: 1.8rem;
-                    margin-bottom: 1.5rem;
-                    border-bottom: 3px solid var(--primary);
-                    padding-bottom: 0.5rem;
-                }
-                
-                .card-grid {
-                    display: grid;
-                    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-                    gap: 1.5rem;
-                }
-                
-                .card {
-                    background: white;
-                    border-radius: 8px;
-                    padding: 1.5rem;
-                    box-shadow: var(--card-shadow);
-                    transition: all 0.3s ease;
-                }
-                
-                .card:hover {
-                    transform: translateY(-4px);
-                    box-shadow: var(--card-hover-shadow);
-                }
-                
-                .card h3 {
-                    color: var(--primary-dark);
-                    font-size: 1.3rem;
-                    margin-bottom: 0.5rem;
-                }
-                
-                .card p {
-                    color: #666;
-                    margin-bottom: 1rem;
-                }
-                
-                .card a {
-                    color: var(--primary);
-                    text-decoration: none;
-                    font-weight: 500;
-                }
-                
-                .card a:hover {
-                    text-decoration: underline;
-                }
-                
-                .url-display {
-                    background: var(--light-bg);
-                    padding: 0.75rem;
-                    border-radius: 4px;
-                    font-family: 'Courier New', monospace;
-                    font-size: 0.9rem;
-                    word-break: break-all;
-                    margin-top: 0.5rem;
-                    border-left: 4px solid var(--primary);
-                }
-                
-                .badge-label {
-                    display: inline-block;
-                    padding: 0.25rem 0.75rem;
-                    border-radius: 12px;
-                    font-size: 0.85rem;
-                    font-weight: 500;
-                    margin-top: 0.5rem;
-                }
-                
-                .label-stable {
-                    background: var(--secondary);
-                    color: white;
-                }
-                
-                .label-dev {
-                    background: var(--warning);
-                    color: white;
-                }
-                
-                .install-steps {
-                    background: white;
-                    border-radius: 8px;
-                    padding: 2rem;
-                    box-shadow: var(--card-shadow);
-                }
-                
-                .install-steps ol {
-                    margin-left: 1.5rem;
-                }
-                
-                .install-steps li {
-                    margin-bottom: 0.75rem;
-                }
-                
-                footer {
-                    background: var(--primary-dark);
-                    color: white;
-                    padding: 2rem;
-                    text-align: center;
-                    margin-top: 3rem;
-                }
-                
-                footer a {
-                    color: var(--primary);
-                    text-decoration: none;
-                }
-                
-                footer a:hover {
-                    text-decoration: underline;
-                }
-                
-                @media (max-width: 640px) {
-                    .hero h1 {
-                        font-size: 1.8rem;
-                    }
-                    
-                    .card-grid {
-                        grid-template-columns: 1fr;
-                    }
-                }
-            </style>
-        </head>
-        <body>
-            <div class="hero">
-                <h1>🛠️ Sandbox</h1>
-                <p>Eclipse JDT Cleanups & Automated Code Modernization</p>
-                
-                <div class="badges">
-                    <a href="https://github.com/carstenartur/sandbox/actions/workflows/maven.yml">
-                        <img src="https://github.com/carstenartur/sandbox/actions/workflows/maven.yml/badge.svg" alt="Maven CI">
-                    </a>
-                    <a href="https://github.com/carstenartur/sandbox/actions/workflows/codeql.yml">
-                        <img src="https://github.com/carstenartur/sandbox/actions/workflows/codeql.yml/badge.svg" alt="CodeQL">
-                    </a>
-                    <a href="https://github.com/carstenartur/sandbox/actions/workflows/coverage.yml">
-                        <img src="https://github.com/carstenartur/sandbox/actions/workflows/coverage.yml/badge.svg" alt="Coverage">
-                    </a>
-                    <a href="https://github.com/carstenartur/sandbox/actions/workflows/test-report.yml">
-                        <img src="https://github.com/carstenartur/sandbox/actions/workflows/test-report.yml/badge.svg" alt="Tests">
-                    </a>
-                    <a href="https://github.com/carstenartur/sandbox/actions/workflows/benchmark.yml">
-                        <img src="https://github.com/carstenartur/sandbox/actions/workflows/benchmark.yml/badge.svg" alt="Benchmarks">
-                    </a>
-                    <a href="https://github.com/carstenartur/sandbox/actions/workflows/deploy-snapshot.yml">
-                        <img src="https://github.com/carstenartur/sandbox/actions/workflows/deploy-snapshot.yml/badge.svg" alt="Snapshot Deploy">
-                    </a>
-                    <a href="https://marketplace.eclipse.org/content/sandbox">
-                        <img src="https://img.shields.io/badge/Eclipse%20Marketplace-Sandbox-blue" alt="Eclipse Marketplace">
-                    </a>
-                </div>
-            </div>
-            
-            <div class="container">
-                <section class="section">
-                    <h2>📊 Quality & Reports</h2>
-                    <div class="card-grid">
-                        <div class="card">
-                            <h3>🧪 Test Results</h3>
-                            <p>JUnit test reports for all modules with detailed pass/fail statistics.</p>
-                            <p style="margin: 10px 0;">
-                                <a href="https://github.com/carstenartur/sandbox/actions/workflows/test-report.yml">
-                                    <img src="https://github.com/carstenartur/sandbox/actions/workflows/test-report.yml/badge.svg" alt="Test Report Status" style="height: 20px;">
-                                </a>
-                            </p>
-                            <a href="tests/">View Test Reports →</a>
-                        </div>
-                        
-                        <div class="card">
-                            <h3>📈 Code Coverage</h3>
-                            <p>JaCoCo coverage reports showing test coverage across the entire codebase.</p>
-                            <p style="margin: 10px 0;">
-                                <a href="https://github.com/carstenartur/sandbox/actions/workflows/coverage.yml">
-                                    <img src="https://github.com/carstenartur/sandbox/actions/workflows/coverage.yml/badge.svg" alt="Coverage Status" style="height: 20px;">
-                                </a>
-                            </p>
-                            <a href="coverage/">View Coverage Report →</a>
-                        </div>
-                        
-                        <div class="card">
-                            <h3>⚡ Performance Benchmarks</h3>
-                            <p>JMH benchmark results tracking performance over time.</p>
-                            <p style="margin: 10px 0;">
-                                <a href="https://github.com/carstenartur/sandbox/actions/workflows/benchmark.yml">
-                                    <img src="https://github.com/carstenartur/sandbox/actions/workflows/benchmark.yml/badge.svg" alt="Benchmark Status" style="height: 20px;">
-                                </a>
-                            </p>
-                            <a href="dev/bench/">View Performance Charts →</a>
-                        </div>
-                        
-                        <div class="card">
-                            <h3>🔍 Refactoring Mining</h3>
-                            <p>LLM-powered commit analysis with DSL rule proposals</p>
-                            <p style="margin: 10px 0;">
-                                <a href="https://github.com/carstenartur/sandbox/actions/workflows/mining-core.yml">
-                                    <img src="https://github.com/carstenartur/sandbox/actions/workflows/mining-core.yml/badge.svg" alt="Mining Status" style="height: 20px;">
-                                </a>
-                            </p>
-                            <a href="mining-report/">View Mining Results →</a>
-                        </div>
-                    </div>
-                </section>
-                
-                <section class="section">
-                    <h2>📦 Distribution</h2>
-                    <div class="card-grid">
-                        <div class="card">
-                            <h3>Stable Release</h3>
-                            <span class="badge-label label-stable">Recommended</span>
-                            <p>Production-ready release with all features tested and validated.</p>
-                            <div class="url-display">https://carstenartur.github.io/sandbox/releases/</div>
-                            <p style="margin-top: 1rem;">
-                                <a href="releases/">Browse Update Site →</a>
-                            </p>
-                        </div>
-                        
-                        <div class="card">
-                            <h3>Snapshot</h3>
-                            <span class="badge-label label-dev">Development</span>
-                            <p>Latest development snapshot, updated automatically on every commit.</p>
-                            <div class="url-display">https://carstenartur.github.io/sandbox/snapshots/latest/</div>
-                            <p style="margin-top: 1rem;">
-                                <a href="snapshots/latest/">Browse Snapshot →</a>
-                            </p>
-                        </div>
-                    </div>
-                </section>
-                
-                <section class="section">
-                    <h2>🚀 Quick Install</h2>
-                    <div class="install-steps">
-                        <ol>
-                            <li>Open <strong>Eclipse IDE</strong></li>
-                            <li>Go to <strong>Help → Install New Software...</strong></li>
-                            <li>Click <strong>Add...</strong> to add a new update site</li>
-                            <li>Enter a name (e.g., "Sandbox") and paste one of the update site URLs above</li>
-                            <li>Select the cleanup features you want to install</li>
-                            <li>Follow the installation wizard and accept the license</li>
-                            <li>Restart Eclipse when prompted</li>
-                        </ol>
-                    </div>
-                </section>
-                
-                <section class="section">
-                    <h2>📚 Documentation & Links</h2>
-                    <div class="card-grid">
-                        <div class="card">
-                            <h3>Source Code</h3>
-                            <p>Browse the source code, open issues, and contribute to the project.</p>
-                            <a href="https://github.com/carstenartur/sandbox">GitHub Repository →</a>
-                        </div>
-                        
-                        <div class="card">
-                            <h3>Issues & Feedback</h3>
-                            <p>Report bugs, request features, or ask questions.</p>
-                            <a href="https://github.com/carstenartur/sandbox/issues">GitHub Issues →</a>
-                        </div>
-                        
-                        <!-- Placeholder for future feature
-                        <div class="card">
-                            <h3>API Documentation</h3>
-                            <p>Javadoc documentation for all public APIs.</p>
-                            <a href="javadoc/">View Javadoc →</a>
-                        </div>
-                        -->
-                    </div>
-                </section>
-            </div>
-            
-            <footer>
-                <p>
-                    <strong>Sandbox Project</strong> | 
-                    Eclipse Public License 2.0 | 
-                    <a href="https://github.com/carstenartur/sandbox">Source Code</a> | 
-                    <a href="https://github.com/carstenartur/sandbox/issues">Report Issues</a>
-                </p>
-                <p style="margin-top: 1rem; font-size: 0.9rem; opacity: 0.8;">
-                    © 2024–present Carsten Hammer and Contributors
-                </p>
-            </footer>
-        </body>
-        </html>
-        EOF
+      - name: Prepare snapshot and dashboard
+        run: |
+          snapshot_dir="gh-pages-content/snapshots/latest"
+          mkdir -p "$snapshot_dir"
+          cp -a sandbox_updatesite/target/repository/. "$snapshot_dir/"
+          cp build-manifest.json "$snapshot_dir/build-manifest.json"
+          cp .github/pages/index.html gh-pages-content/index.html
 
-    - name: Deploy to GitHub Pages
-      uses: peaceiris/actions-gh-pages@v4
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./gh-pages-content
-        publish_branch: gh-pages
-        keep_files: true  # Don't remove existing files (for releases)
-        user_name: 'github-actions[bot]'
-        user_email: 'github-actions[bot]@users.noreply.github.com'
-        commit_message: 'Deploy snapshot update site'
+          mkdir -p gh-pages-content/snapshots
+          timestamp="$(date +%s)000"
+          cat > gh-pages-content/snapshots/compositeContent.xml << EOF
+          <?xml version='1.0' encoding='UTF-8'?>
+          <?compositeMetadataRepository version='1.0.0'?>
+          <repository name='Sandbox Snapshots'
+                      type='org.eclipse.equinox.internal.p2.metadata.repository.CompositeMetadataRepository'
+                      version='1.0.0'>
+            <properties size='1'>
+              <property name='p2.timestamp' value='$timestamp'/>
+            </properties>
+            <children size='1'>
+              <child location='latest'/>
+            </children>
+          </repository>
+          EOF
+          cat > gh-pages-content/snapshots/compositeArtifacts.xml << EOF
+          <?xml version='1.0' encoding='UTF-8'?>
+          <?compositeArtifactRepository version='1.0.0'?>
+          <repository name='Sandbox Snapshots'
+                      type='org.eclipse.equinox.internal.p2.artifact.repository.CompositeArtifactRepository'
+                      version='1.0.0'>
+            <properties size='1'>
+              <property name='p2.timestamp' value='$timestamp'/>
+            </properties>
+            <children size='1'>
+              <child location='latest'/>
+            </children>
+          </repository>
+          EOF
 
-    - name: Report Deployed URLs
-      if: always()
-      run: |
-        echo "### 🔗 Deployed Resources" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "📊 [View Dashboard](https://carstenartur.github.io/sandbox/)" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "📦 [Latest Snapshot Update Site](https://carstenartur.github.io/sandbox/snapshots/latest/)" >> $GITHUB_STEP_SUMMARY
+      - name: Upload immutable snapshot provenance
+        uses: actions/upload-artifact@v7
+        with:
+          name: snapshot-provenance-${{ env.VALIDATED_SHA }}
+          path: build-manifest.json
+          retention-days: 90
+          if-no-files-found: error
+
+      - name: Deploy snapshot and dashboard
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./gh-pages-content
+          publish_branch: gh-pages
+          keep_files: true
+          user_name: github-actions[bot]
+          user_email: github-actions[bot]@users.noreply.github.com
+          commit_message: Deploy snapshot for ${{ env.VALIDATED_SHA }}
+
+      - name: Report deployed resources
+        if: always()
+        run: |
+          {
+            echo '### Deployed resources'
+            echo
+            echo "- [Validated commit](https://github.com/${GITHUB_REPOSITORY}/commit/${VALIDATED_SHA})"
+            if [ -n "$SOURCE_JAVA_CI_RUN_URL" ]; then
+              echo "- [Source Java CI run](${SOURCE_JAVA_CI_RUN_URL})"
+            fi
+            echo '- [Project dashboard](https://carstenartur.github.io/sandbox/)'
+            echo '- [Latest snapshot update site](https://carstenartur.github.io/sandbox/snapshots/latest/)'
+            echo '- [Snapshot build manifest](https://carstenartur.github.io/sandbox/snapshots/latest/build-manifest.json)'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/post-merge-provenance.yml
+++ b/.github/workflows/post-merge-provenance.yml
@@ -9,6 +9,9 @@ on:
       - '.github/scripts/test_build_provenance.py'
       - '.github/workflows/post-merge-provenance.yml'
       - '.github/workflows/core-module-build.yml'
+      - '.github/workflows/deploy-snapshot.yml'
+      - '.github/pages/index.html'
+      - 'docs/build-provenance.md'
   workflow_run:
     workflows: [ 'Java CI with Maven' ]
     types: [ completed ]
@@ -81,6 +84,12 @@ jobs:
             --output related-workflow-runs.json \
             --timeout-seconds 3600 \
             --interval-seconds 30
+      - name: Download executed Java CI test reports
+        run: |
+          mkdir -p source-java-ci-artifacts
+          gh run download "$SOURCE_JAVA_CI_RUN_ID" \
+            --pattern 'test-reports-*' \
+            --dir source-java-ci-artifacts
       - name: Generate test inventory
         run: python3 .github/scripts/generate_test_report.py > /tmp/test-report-generation.log
       - name: Generate provenance manifest and dashboard
@@ -89,6 +98,8 @@ jobs:
           commit_dir="$publish_dir/$COMMIT_SHA"
           mkdir -p "$commit_dir"
           python3 .github/scripts/generate_build_manifest.py \
+            --commit-sha "$COMMIT_SHA" \
+            --source-ref refs/heads/main \
             --related-workflows related-workflow-runs.json \
             --output "$commit_dir/build-manifest.json" \
             --html-output "$publish_dir/index.html"

--- a/.github/workflows/post-merge-provenance.yml
+++ b/.github/workflows/post-merge-provenance.yml
@@ -1,0 +1,117 @@
+name: Post-merge Build Provenance
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '.github/scripts/generate_build_manifest.py'
+      - '.github/scripts/collect_commit_workflows.py'
+      - '.github/scripts/test_build_provenance.py'
+      - '.github/workflows/post-merge-provenance.yml'
+      - '.github/workflows/core-module-build.yml'
+  workflow_run:
+    workflows: [ 'Java CI with Maven' ]
+    types: [ completed ]
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: post-merge-provenance-${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha }}
+  cancel-in-progress: false
+
+jobs:
+  validate-scripts:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      - name: Run provenance unit tests
+        run: python3 .github/scripts/test_build_provenance.py
+      - name: Generate a local manifest fixture
+        run: |
+          python3 .github/scripts/generate_test_report.py > /tmp/test-report-generation.log
+          python3 .github/scripts/generate_build_manifest.py \
+            --output build-manifest.json \
+            --html-output build-provenance.html
+          python3 -m json.tool build-manifest.json > /dev/null
+
+  publish-main-provenance:
+    if: >-
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+    permissions:
+      actions: read
+      contents: write
+    env:
+      COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
+      GITHUB_TOKEN: ${{ github.token }}
+      SOURCE_JAVA_CI_RUN_ID: ${{ github.event.workflow_run.id }}
+      SOURCE_JAVA_CI_RUN_URL: ${{ github.event.workflow_run.html_url }}
+    steps:
+      - name: Checkout validated main commit
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1
+        with:
+          maven-version: 3.9.14
+      - name: Run provenance unit tests
+        run: python3 .github/scripts/test_build_provenance.py
+      - name: Collect exact validation runs for the main commit
+        run: |
+          python3 .github/scripts/collect_commit_workflows.py \
+            --commit "$COMMIT_SHA" \
+            --output related-workflow-runs.json \
+            --timeout-seconds 3600 \
+            --interval-seconds 30
+      - name: Generate test inventory
+        run: python3 .github/scripts/generate_test_report.py > /tmp/test-report-generation.log
+      - name: Generate provenance manifest and dashboard
+        run: |
+          publish_dir="/tmp/gh-pages/provenance"
+          commit_dir="$publish_dir/$COMMIT_SHA"
+          mkdir -p "$commit_dir"
+          python3 .github/scripts/generate_build_manifest.py \
+            --related-workflows related-workflow-runs.json \
+            --output "$commit_dir/build-manifest.json" \
+            --html-output "$publish_dir/index.html"
+          cp "$commit_dir/build-manifest.json" "$publish_dir/latest.json"
+          cp test-report.json "$commit_dir/test-report.json"
+          cp related-workflow-runs.json "$commit_dir/related-workflow-runs.json"
+      - name: Upload immutable provenance artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: build-provenance-${{ github.event.workflow_run.head_sha }}
+          path: |
+            /tmp/gh-pages/provenance/${{ github.event.workflow_run.head_sha }}/build-manifest.json
+            /tmp/gh-pages/provenance/${{ github.event.workflow_run.head_sha }}/test-report.json
+            /tmp/gh-pages/provenance/${{ github.event.workflow_run.head_sha }}/related-workflow-runs.json
+          retention-days: 90
+          if-no-files-found: error
+      - name: Publish provenance dashboard
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: /tmp/gh-pages/provenance
+          destination_dir: provenance
+          keep_files: true
+          user_name: github-actions[bot]
+          user_email: github-actions[bot]@users.noreply.github.com
+          commit_message: Publish build provenance for ${{ github.event.workflow_run.head_sha }}

--- a/docs/build-provenance.md
+++ b/docs/build-provenance.md
@@ -22,7 +22,7 @@ The workflow artifacts use immutable names containing the full commit SHA and ar
 
 `.github/workflows/post-merge-provenance.yml` is triggered only after a successful `Java CI with Maven` run. Publication proceeds only when the triggering run represents a push to `main`.
 
-The workflow checks out `github.event.workflow_run.head_sha`, not the moving default branch. It then waits until the following push workflows for that exact SHA have completed:
+The workflow checks out `github.event.workflow_run.head_sha`, not the moving default branch. It then waits until the following push workflows for that exact SHA have completed successfully:
 
 - Java CI with Maven;
 - Core Module Build;
@@ -30,11 +30,11 @@ The workflow checks out `github.event.workflow_run.head_sha`, not the moving def
 - Codacy Security Scan;
 - Test Report.
 
-A failed, missing or indefinitely incomplete required workflow prevents provenance publication. `Core Module Build` consequently runs for every `main` push, while retaining path filtering for pull requests.
+A failed, cancelled, skipped, neutral, missing or indefinitely incomplete required workflow prevents provenance publication. `Core Module Build` consequently runs for every `main` push, while retaining path filtering for pull requests.
 
 ## Snapshot workflow
 
-`.github/workflows/deploy-snapshot.yml` also checks out the exact successful Java CI `head_sha`. The p2 repository is built only from that checkout. Its manifest contains:
+`.github/workflows/deploy-snapshot.yml` has no manual publication path. It runs only after a successful Java CI push run on `main`, checks out that exact `head_sha`, and builds the p2 repository only from that checkout. Its manifest contains:
 
 - validated commit SHA and commit URL;
 - source Java CI run ID and URL;
@@ -45,7 +45,7 @@ A failed, missing or indefinitely incomplete required workflow prevents provenan
 - individual p2 metadata hashes;
 - optional patched JDT UI commit/version when supplied by the product build.
 
-This removes the race in which a later `main` commit could otherwise be checked out after the triggering Java CI run had finished.
+This removes both the race in which a later `main` commit could be checked out after the triggering Java CI run and the possibility of manually publishing an unvalidated ref as the latest snapshot.
 
 ## Manifest schema
 
@@ -80,8 +80,10 @@ python3 -m json.tool build-manifest.json
 
 - Repository POM, target definitions and CI-generated XML are trusted inputs. The scripts do not process arbitrary uploaded XML.
 - The collector accepts only workflow runs whose `head_sha` exactly matches the requested commit and whose event is `push`.
+- Every required workflow must conclude with `success`; skipped or neutral checks do not prove validation.
 - A later rerun supersedes an earlier attempt of the same workflow for the same SHA.
 - Pull-request validation never publishes to GitHub Pages.
+- The snapshot workflow cannot be dispatched manually against an unvalidated ref.
 - The provenance workflows do not search for or comment on unrelated pull requests.
 - A manifest records `not_built_in_this_run` when no product or update-site output exists instead of implying that an artifact was validated.
 

--- a/docs/build-provenance.md
+++ b/docs/build-provenance.md
@@ -1,0 +1,88 @@
+# Build provenance
+
+## Purpose
+
+Every published snapshot and every validated commit on `main` must be traceable to an exact Git commit and exact GitHub Actions runs. Pull-request checks alone are not sufficient because a squash merge creates a new commit SHA on `main`.
+
+Sandbox therefore publishes two complementary manifests:
+
+1. **Commit provenance** records the exact post-merge Java CI, Core Module Build, CodeQL, Codacy Security Scan and Test Report runs for one `main` commit.
+2. **Snapshot provenance** records the exact commit checked out by the product/update-site build, the Java CI run that authorized publication, and SHA-256 digests of the generated Tycho product tree and p2 repository.
+
+## Published locations
+
+- Latest validated commit: `https://carstenartur.github.io/sandbox/provenance/latest.json`
+- Commit-specific manifest: `https://carstenartur.github.io/sandbox/provenance/<commit-sha>/build-manifest.json`
+- Provenance dashboard: `https://carstenartur.github.io/sandbox/provenance/`
+- Latest snapshot manifest: `https://carstenartur.github.io/sandbox/snapshots/latest/build-manifest.json`
+
+The workflow artifacts use immutable names containing the full commit SHA and are retained for 90 days.
+
+## Commit workflow
+
+`.github/workflows/post-merge-provenance.yml` is triggered only after a successful `Java CI with Maven` run. Publication proceeds only when the triggering run represents a push to `main`.
+
+The workflow checks out `github.event.workflow_run.head_sha`, not the moving default branch. It then waits until the following push workflows for that exact SHA have completed:
+
+- Java CI with Maven;
+- Core Module Build;
+- CodeQL;
+- Codacy Security Scan;
+- Test Report.
+
+A failed, missing or indefinitely incomplete required workflow prevents provenance publication. `Core Module Build` consequently runs for every `main` push, while retaining path filtering for pull requests.
+
+## Snapshot workflow
+
+`.github/workflows/deploy-snapshot.yml` also checks out the exact successful Java CI `head_sha`. The p2 repository is built only from that checkout. Its manifest contains:
+
+- validated commit SHA and commit URL;
+- source Java CI run ID and URL;
+- project, Java, Maven, Tycho, SpotBugs and Eclipse target versions;
+- SHA-256 hashes of target-definition files;
+- static test totals and disabled-test count;
+- complete product-tree and update-site tree digests;
+- individual p2 metadata hashes;
+- optional patched JDT UI commit/version when supplied by the product build.
+
+This removes the race in which a later `main` commit could otherwise be checked out after the triggering Java CI run had finished.
+
+## Manifest schema
+
+The JSON document currently uses `schema_version: 1`. Top-level fields are:
+
+- `repository`, `commit_sha`, `commit_url`, `ref` and `event_name`;
+- `provenance_workflow`, including the source Java CI run;
+- `toolchain`, including root POM properties, runtime versions, p2 repository URLs and target-definition hashes;
+- `tests.inventory` from the repository test scanner and `tests.executed` when JUnit XML is available;
+- `artifacts.products`, `artifacts.product_tree` and `artifacts.update_site`;
+- `related_workflows` for the exact post-merge validation runs;
+- `patched_jdt_ui` for the optional pinned fork provenance.
+
+Tree digests are deterministic: files are sorted by repository-relative path, and the digest covers each path plus the SHA-256 of its bytes. This distinguishes equal files at different p2/product locations and is independent of filesystem traversal order.
+
+## Local verification
+
+Run the scripts without publishing:
+
+```bash
+python3 .github/scripts/test_build_provenance.py
+python3 .github/scripts/generate_test_report.py
+python3 .github/scripts/generate_build_manifest.py \
+  --output build-manifest.json \
+  --html-output build-provenance.html
+python3 -m json.tool build-manifest.json
+```
+
+`collect_commit_workflows.py` additionally requires `GITHUB_TOKEN`, `GITHUB_REPOSITORY` and an exact commit SHA because it queries the GitHub Actions API.
+
+## Security and operational boundaries
+
+- Repository POM, target definitions and CI-generated XML are trusted inputs. The scripts do not process arbitrary uploaded XML.
+- The collector accepts only workflow runs whose `head_sha` exactly matches the requested commit and whose event is `push`.
+- A later rerun supersedes an earlier attempt of the same workflow for the same SHA.
+- Pull-request validation never publishes to GitHub Pages.
+- The provenance workflows do not search for or comment on unrelated pull requests.
+- A manifest records `not_built_in_this_run` when no product or update-site output exists instead of implying that an artifact was validated.
+
+Related issue: #1218.


### PR DESCRIPTION
## Summary

Makes every validated `main` commit and every published snapshot traceable to the exact commit, workflow runs, toolchain, test inventory and generated distribution bytes.

## Changes

- add a deterministic JSON build-manifest generator with SHA-256 tree digests for Tycho products and p2 repositories;
- add a GitHub Actions collector that accepts only push runs for the exact requested commit and requires successful Java CI, Core Module Build, CodeQL, Codacy Security Scan and Test Report conclusions;
- publish immutable commit-specific provenance artifacts and a GitHub Pages provenance dashboard after successful post-merge validation;
- download the completed Java CI test-report artifact so the manifest records executed test totals as well as the static test inventory;
- run Core Module Build for every `main` push while retaining pull-request path filtering;
- fix snapshot publication to check out `workflow_run.head_sha` instead of the moving default branch;
- remove manual snapshot publication so an unvalidated ref cannot replace the latest validated snapshot;
- publish the snapshot manifest beside the update site and bind it to the source Java CI run;
- move the project dashboard out of an embedded workflow heredoc into a maintainable static page;
- add unit tests for exact workflow selection, strict successful conclusions, explicit commit identity, deterministic digests and manifest contents;
- document trust boundaries, locations and local verification.

## Provenance guarantees

- pull-request runs are never mistaken for post-merge validation;
- later `main` commits cannot replace the commit authorized by the triggering Java CI run;
- failed, cancelled, skipped, neutral, missing or incomplete required workflows block commit-provenance publication;
- snapshot publication has no manual path around the successful `main` Java CI trigger;
- product/update-site absence is represented explicitly instead of implying validation;
- no stale or unrelated pull request is searched for or commented on during push workflows.

Closes #1218.