### PR TITLE
Bound coordinated cleanup planning resources

### DIFF
--- a/.github/.pr-sync-1264
+++ b/.github/.pr-sync-1264
@@ -1,0 +1,1 @@
+temporary PR synchronization marker

--- a/.github/.pr-sync-1264
+++ b/.github/.pr-sync-1264
@@ -1,1 +1,0 @@
-temporary PR synchronization marker

--- a/docs/multi-file-planning-budget.md
+++ b/docs/multi-file-planning-budget.md
@@ -1,0 +1,81 @@
+# Coordinated cleanup planning budgets
+
+## Purpose
+
+A coordinated cleanup may need to parse several related Java source files before it can prove that one semantic change is safe. Candidate-driven scope keeps this set small in normal projects, but pathological source graphs, unusually large working copies, or incomplete binding recovery must not turn a cleanup preview into unbounded memory use or latency.
+
+The common multi-file cleanup layer therefore measures and guards the complete source scope before any AST batch is created.
+
+## Default limits
+
+| Limit | Warning | Hard abort |
+|---|---:|---:|
+| Distinct primary compilation units | 500 | 2,000 |
+| Current source size, measured as UTF-8 bytes | 32 MiB | 128 MiB |
+
+The warning thresholds add a nonfatal `RefactoringStatus` warning before parsing begins. The hard thresholds add a fatal status and return no plan; no AST batch, partial semantic plan, cleanup fix, state update, or preview edit is created.
+
+Duplicate handles are measured once. Source size is taken from the current primary compilation-unit source, so unsaved working-copy content is represented. UTF-8 length is counted without allocating a second byte array.
+
+## Configuration
+
+The defaults can be reduced or increased for controlled environments with positive decimal system properties:
+
+```text
+org.sandbox.cleanup.planning.warningUnits
+org.sandbox.cleanup.planning.hardUnits
+org.sandbox.cleanup.planning.warningSourceBytes
+org.sandbox.cleanup.planning.hardSourceBytes
+```
+
+Invalid, zero, or negative values fall back to repository defaults. A warning override larger than its hard limit is clamped to a safe value; configuration cannot accidentally disable a hard guard.
+
+These are process-level safety controls, not cleanup preferences. A future UI may surface them, but callers must not silently substitute unlimited values.
+
+## Metrics
+
+`MultiFileCleanUpPlanResult` carries immutable `MultiFilePlanningMetrics` for the planning attempt:
+
+- distinct compilation-unit count;
+- current UTF-8 source bytes;
+- AST batch parse duration;
+- complete planning duration, including scope measurement;
+- number of immutable semantic entries retained by the final plan.
+
+`AbstractPlannedMultiFileCleanUp` retains these metrics only for the serialized cleanup lifecycle and clears them together with the plan during postconditions. Structured preview/reporting work in #1214 can consume the measurements without rescanning source files.
+
+## Cancellation and deterministic abort
+
+Cancellation is checked:
+
+- between compilation units during pre-parse measurement;
+- before and after the batch parser;
+- while discovering semantic candidates or resource types;
+- while validating method, constant, Rule, and resource references;
+- while freezing mutable analysis state into immutable plan entries.
+
+The JDT batch parser receives the same progress monitor. Cancellation propagates as `OperationCanceledException`; the common cleanup lifecycle removes any retained plan and metrics before rethrowing.
+
+A hard budget failure is different from user cancellation: it returns a fatal status with the measured threshold and creates no plan. This gives UI and headless callers a deterministic, inspectable refusal instead of an incomplete migration.
+
+## Memory ownership
+
+The planning maps containing `CompilationUnit` and AST nodes remain method-local. Final JUnit and Int-to-Enum plans retain Java-model handles, binding keys, signatures, source ranges, generated names, and semantic edit descriptions only. AST roots are eligible for collection as soon as plan creation returns.
+
+The retained-plan entry count is a semantic-size proxy, not a heap-size estimate. It is intended for diagnostics, regression comparisons, and future benchmarks.
+
+## Verification
+
+Common-layer tests cover:
+
+- exact UTF-8 byte measurement, including supplementary and malformed surrogate input;
+- duplicate compilation-unit handles;
+- warning-only scopes;
+- immediate hard abort by unit count and source bytes;
+- cancellation before source reads;
+- invalid and inverted property overrides;
+- immutable metric transport through plan results.
+
+The cleanup integration suite continues to prove apply, compile, and undo behavior for both coordinated planners. Stress regressions use synthetic large scopes and low hard limits to prove early deterministic refusal without constructing ASTs.
+
+Related issues: #1212, #1214, #1221, #1224.

--- a/sandbox_common/src/org/sandbox/jdt/cleanup/multifile/AbstractPlannedMultiFileCleanUp.java
+++ b/sandbox_common/src/org/sandbox/jdt/cleanup/multifile/AbstractPlannedMultiFileCleanUp.java
@@ -67,6 +67,7 @@ public abstract class AbstractPlannedMultiFileCleanUp<P> extends AbstractCleanUp
 	private final Object lifecycleLock= new Object();
 
 	private final Map<IJavaProject, P> plansByProject= new HashMap<>();
+	private final Map<IJavaProject, MultiFilePlanningMetrics> metricsByProject= new HashMap<>();
 
 	/** Creates a base class without options. */
 	protected AbstractPlannedMultiFileCleanUp() {
@@ -105,13 +106,16 @@ public abstract class AbstractPlannedMultiFileCleanUp<P> extends AbstractCleanUp
 			IProgressMonitor monitor) throws CoreException {
 		synchronized (lifecycleLock) {
 			plansByProject.remove(project);
+			metricsByProject.remove(project);
 			MultiFileCleanUpPlanResult<P> result;
 			try {
 				result= createPlan(project, compilationUnits.clone(), monitor);
 			} catch (CoreException | RuntimeException e) {
 				plansByProject.remove(project);
+				metricsByProject.remove(project);
 				throw e;
 			}
+			metricsByProject.put(project, result.metrics());
 			if (!result.status().hasFatalError() && result.plan() != null) {
 				plansByProject.put(project, result.plan());
 			}
@@ -135,6 +139,7 @@ public abstract class AbstractPlannedMultiFileCleanUp<P> extends AbstractCleanUp
 				return createFixForPlan(plan, context);
 			} catch (CoreException | RuntimeException e) {
 				plansByProject.remove(project);
+				metricsByProject.remove(project);
 				throw e;
 			}
 		}
@@ -147,6 +152,7 @@ public abstract class AbstractPlannedMultiFileCleanUp<P> extends AbstractCleanUp
 				return checkPlanPostConditions(monitor);
 			} finally {
 				plansByProject.clear();
+				metricsByProject.clear();
 			}
 		}
 	}
@@ -196,6 +202,20 @@ public abstract class AbstractPlannedMultiFileCleanUp<P> extends AbstractCleanUp
 	protected final P getPlan(IJavaProject project) {
 		synchronized (lifecycleLock) {
 			return plansByProject.get(project);
+		}
+	}
+
+	/**
+	 * Returns metrics from the current project's most recent planning attempt.
+	 * Metrics remain available through fix creation and postcondition checks and are
+	 * cleared with the rest of the lifecycle state.
+	 *
+	 * @param project Java project
+	 * @return retained metrics or empty metrics when no planning run exists
+	 */
+	protected final MultiFilePlanningMetrics getPlanningMetrics(IJavaProject project) {
+		synchronized (lifecycleLock) {
+			return metricsByProject.getOrDefault(project, MultiFilePlanningMetrics.empty());
 		}
 	}
 }

--- a/sandbox_common/src/org/sandbox/jdt/cleanup/multifile/MultiFileCleanUpPlanResult.java
+++ b/sandbox_common/src/org/sandbox/jdt/cleanup/multifile/MultiFileCleanUpPlanResult.java
@@ -21,15 +21,23 @@ import org.eclipse.ltk.core.refactoring.RefactoringStatus;
  * @param plan plan to retain for the subsequent per-compilation-unit fix phase;
  *             may be {@code null} when no coordinated change is required
  * @param status diagnostics produced during planning
+ * @param metrics immutable scope, duration and retained-plan measurements
  */
-public record MultiFileCleanUpPlanResult<P>(P plan, RefactoringStatus status) {
+public record MultiFileCleanUpPlanResult<P>(P plan, RefactoringStatus status,
+		MultiFilePlanningMetrics metrics) {
 
 	/** Validates the result. */
 	public MultiFileCleanUpPlanResult {
 		Objects.requireNonNull(status);
+		Objects.requireNonNull(metrics);
 		if (status.hasFatalError() && plan != null) {
 			throw new IllegalArgumentException();
 		}
+	}
+
+	/** Compatibility constructor for consumers that do not yet record metrics. */
+	public MultiFileCleanUpPlanResult(P plan, RefactoringStatus status) {
+		this(plan, status, MultiFilePlanningMetrics.empty());
 	}
 
 	/**
@@ -40,7 +48,25 @@ public record MultiFileCleanUpPlanResult<P>(P plan, RefactoringStatus status) {
 	 * @return successful result
 	 */
 	public static <P> MultiFileCleanUpPlanResult<P> success(P plan) {
-		return new MultiFileCleanUpPlanResult<>(Objects.requireNonNull(plan), new RefactoringStatus());
+		return new MultiFileCleanUpPlanResult<>(Objects.requireNonNull(plan), new RefactoringStatus(),
+				MultiFilePlanningMetrics.empty());
+	}
+
+	/**
+	 * Creates a successful measured result containing a plan.
+	 *
+	 * @param <P> plan type
+	 * @param plan immutable plan
+	 * @param status nonfatal diagnostics
+	 * @param metrics planning measurements
+	 * @return successful result
+	 */
+	public static <P> MultiFileCleanUpPlanResult<P> success(P plan, RefactoringStatus status,
+			MultiFilePlanningMetrics metrics) {
+		if (status.hasFatalError()) {
+			throw new IllegalArgumentException("A successful plan cannot carry a fatal status"); //$NON-NLS-1$
+		}
+		return new MultiFileCleanUpPlanResult<>(Objects.requireNonNull(plan), status, metrics);
 	}
 
 	/**
@@ -50,6 +76,6 @@ public record MultiFileCleanUpPlanResult<P>(P plan, RefactoringStatus status) {
 	 * @return empty successful result
 	 */
 	public static <P> MultiFileCleanUpPlanResult<P> noPlan() {
-		return new MultiFileCleanUpPlanResult<>(null, new RefactoringStatus());
+		return new MultiFileCleanUpPlanResult<>(null, new RefactoringStatus(), MultiFilePlanningMetrics.empty());
 	}
 }

--- a/sandbox_common/src/org/sandbox/jdt/cleanup/multifile/MultiFilePlanningBudget.java
+++ b/sandbox_common/src/org/sandbox/jdt/cleanup/multifile/MultiFilePlanningBudget.java
@@ -1,0 +1,137 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.cleanup.multifile;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.JavaModelException;
+
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+
+/** Measures source scope and applies warning/hard limits before AST creation. */
+public final class MultiFilePlanningBudget {
+
+	/** Result of measuring one source scope. */
+	public record Assessment(MultiFilePlanningMetrics metrics, RefactoringStatus status) {
+		public Assessment {
+			if (metrics == null || status == null) {
+				throw new NullPointerException();
+			}
+		}
+
+		/** @return whether planning may safely continue */
+		public boolean mayProceed() {
+			return !status.hasFatalError();
+		}
+	}
+
+	private MultiFilePlanningBudget() {
+	}
+
+	/**
+	 * Measures distinct primary compilation units using their current working-copy
+	 * source, including unsaved edits. UTF-8 byte length is counted without
+	 * allocating a second byte array. Hard thresholds abort measurement as soon as
+	 * they are exceeded.
+	 *
+	 * @param units planned source units
+	 * @param limits effective limits
+	 * @param monitor progress monitor, may be {@code null}
+	 * @return metrics and warning/fatal diagnostics
+	 * @throws JavaModelException if current source cannot be read
+	 */
+	public static Assessment assess(ICompilationUnit[] units, MultiFilePlanningLimits limits,
+			IProgressMonitor monitor) throws JavaModelException {
+		if (units == null || limits == null) {
+			throw new NullPointerException();
+		}
+		RefactoringStatus status= new RefactoringStatus();
+		Set<String> measuredHandles= new HashSet<>();
+		int unitCount= 0;
+		long sourceBytes= 0;
+		for (ICompilationUnit unit : units) {
+			checkCanceled(monitor);
+			if (unit == null || !unit.exists()) {
+				status.addFatalError("The coordinated cleanup scope contains a missing compilation unit."); //$NON-NLS-1$
+				break;
+			}
+			ICompilationUnit primary= unit.getPrimary();
+			if (!measuredHandles.add(primary.getHandleIdentifier())) {
+				continue;
+			}
+			unitCount++;
+			if (unitCount > limits.hardCompilationUnits()) {
+				status.addFatalError("Coordinated cleanup planning aborted: " + unitCount //$NON-NLS-1$
+						+ " source units exceed the hard limit of " + limits.hardCompilationUnits() + '.'); //$NON-NLS-1$
+				break;
+			}
+			String source= primary.getSource();
+			if (source == null) {
+				status.addFatalError("The current source of " + primary.getElementName() //$NON-NLS-1$
+						+ " is unavailable for coordinated cleanup planning."); //$NON-NLS-1$
+				break;
+			}
+			sourceBytes= saturatedAdd(sourceBytes, utf8Length(source));
+			if (sourceBytes > limits.hardSourceBytes()) {
+				status.addFatalError("Coordinated cleanup planning aborted: " + sourceBytes //$NON-NLS-1$
+						+ " source bytes exceed the hard limit of " + limits.hardSourceBytes() + '.'); //$NON-NLS-1$
+				break;
+			}
+		}
+		MultiFilePlanningMetrics metrics= MultiFilePlanningMetrics.scope(unitCount, sourceBytes);
+		if (status.hasFatalError()) {
+			return new Assessment(metrics, status);
+		}
+		if (unitCount > limits.warningCompilationUnits() || sourceBytes > limits.warningSourceBytes()) {
+			status.addWarning("Coordinated cleanup planning will analyse " + unitCount + " source units (" //$NON-NLS-1$ //$NON-NLS-2$
+					+ sourceBytes + " UTF-8 bytes). Warning limits are " //$NON-NLS-1$
+					+ limits.warningCompilationUnits() + " units and " + limits.warningSourceBytes() + " bytes."); //$NON-NLS-1$ //$NON-NLS-2$
+		}
+		return new Assessment(metrics, status);
+	}
+
+	static long utf8Length(CharSequence source) {
+		long length= 0;
+		for (int index= 0; index < source.length(); index++) {
+			char character= source.charAt(index);
+			if (character <= 0x7f) {
+				length= saturatedAdd(length, 1);
+			} else if (character <= 0x7ff) {
+				length= saturatedAdd(length, 2);
+			} else if (Character.isHighSurrogate(character) && index + 1 < source.length()
+					&& Character.isLowSurrogate(source.charAt(index + 1))) {
+				length= saturatedAdd(length, 4);
+				index++;
+			} else if (Character.isSurrogate(character)) {
+				length= saturatedAdd(length, 1);
+			} else {
+				length= saturatedAdd(length, 3);
+			}
+		}
+		return length;
+	}
+
+	private static long saturatedAdd(long left, long right) {
+		return Long.MAX_VALUE - left < right ? Long.MAX_VALUE : left + right;
+	}
+
+	/** Throws immediately when the user or caller cancels planning. */
+	public static void checkCanceled(IProgressMonitor monitor) {
+		if (monitor != null && monitor.isCanceled()) {
+			throw new OperationCanceledException();
+		}
+	}
+}

--- a/sandbox_common/src/org/sandbox/jdt/cleanup/multifile/MultiFilePlanningLimits.java
+++ b/sandbox_common/src/org/sandbox/jdt/cleanup/multifile/MultiFilePlanningLimits.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.cleanup.multifile;
+
+/** Configurable warning and hard limits applied before multi-file AST parsing. */
+public record MultiFilePlanningLimits(int warningCompilationUnits, int hardCompilationUnits,
+		long warningSourceBytes, long hardSourceBytes) {
+
+	/** System property overriding the warning compilation-unit count. */
+	public static final String WARNING_UNITS_PROPERTY= "org.sandbox.cleanup.planning.warningUnits"; //$NON-NLS-1$
+	/** System property overriding the hard compilation-unit count. */
+	public static final String HARD_UNITS_PROPERTY= "org.sandbox.cleanup.planning.hardUnits"; //$NON-NLS-1$
+	/** System property overriding the warning source-byte count. */
+	public static final String WARNING_BYTES_PROPERTY= "org.sandbox.cleanup.planning.warningSourceBytes"; //$NON-NLS-1$
+	/** System property overriding the hard source-byte count. */
+	public static final String HARD_BYTES_PROPERTY= "org.sandbox.cleanup.planning.hardSourceBytes"; //$NON-NLS-1$
+
+	private static final int DEFAULT_WARNING_UNITS= 500;
+	private static final int DEFAULT_HARD_UNITS= 2_000;
+	private static final long DEFAULT_WARNING_BYTES= 32L * 1024L * 1024L;
+	private static final long DEFAULT_HARD_BYTES= 128L * 1024L * 1024L;
+
+	/** Validates limit ordering and positivity. */
+	public MultiFilePlanningLimits {
+		if (warningCompilationUnits <= 0 || hardCompilationUnits <= 0
+				|| warningSourceBytes <= 0 || hardSourceBytes <= 0) {
+			throw new IllegalArgumentException("Planning limits must be positive"); //$NON-NLS-1$
+		}
+		if (warningCompilationUnits > hardCompilationUnits || warningSourceBytes > hardSourceBytes) {
+			throw new IllegalArgumentException("Planning warning limits must not exceed hard limits"); //$NON-NLS-1$
+		}
+	}
+
+	/** @return repository defaults suitable for interactive cleanup previews */
+	public static MultiFilePlanningLimits defaults() {
+		return new MultiFilePlanningLimits(DEFAULT_WARNING_UNITS, DEFAULT_HARD_UNITS,
+				DEFAULT_WARNING_BYTES, DEFAULT_HARD_BYTES);
+	}
+
+	/**
+	 * Reads positive decimal overrides from system properties. Invalid values fail
+	 * closed to the repository default instead of disabling a guard accidentally.
+	 *
+	 * @return effective planning limits
+	 */
+	public static MultiFilePlanningLimits fromSystemProperties() {
+		MultiFilePlanningLimits defaults= defaults();
+		int warningUnits= positiveInt(WARNING_UNITS_PROPERTY, defaults.warningCompilationUnits());
+		int hardUnits= positiveInt(HARD_UNITS_PROPERTY, defaults.hardCompilationUnits());
+		long warningBytes= positiveLong(WARNING_BYTES_PROPERTY, defaults.warningSourceBytes());
+		long hardBytes= positiveLong(HARD_BYTES_PROPERTY, defaults.hardSourceBytes());
+		if (warningUnits > hardUnits) {
+			warningUnits= Math.min(defaults.warningCompilationUnits(), hardUnits);
+		}
+		if (warningBytes > hardBytes) {
+			warningBytes= Math.min(defaults.warningSourceBytes(), hardBytes);
+		}
+		return new MultiFilePlanningLimits(warningUnits, hardUnits, warningBytes, hardBytes);
+	}
+
+	private static int positiveInt(String property, int fallback) {
+		try {
+			int value= Integer.parseInt(System.getProperty(property, "")); //$NON-NLS-1$
+			return value > 0 ? value : fallback;
+		} catch (NumberFormatException exception) {
+			return fallback;
+		}
+	}
+
+	private static long positiveLong(String property, long fallback) {
+		try {
+			long value= Long.parseLong(System.getProperty(property, "")); //$NON-NLS-1$
+			return value > 0 ? value : fallback;
+		} catch (NumberFormatException exception) {
+			return fallback;
+		}
+	}
+}

--- a/sandbox_common/src/org/sandbox/jdt/cleanup/multifile/MultiFilePlanningMetrics.java
+++ b/sandbox_common/src/org/sandbox/jdt/cleanup/multifile/MultiFilePlanningMetrics.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.cleanup.multifile;
+
+/** Immutable measurements for one coordinated-cleanup planning run. */
+public record MultiFilePlanningMetrics(int compilationUnitCount, long sourceBytes,
+		long parseNanos, long planningNanos, int retainedPlanEntries) {
+
+	/** Validates nonnegative measurements. */
+	public MultiFilePlanningMetrics {
+		if (compilationUnitCount < 0 || sourceBytes < 0 || parseNanos < 0 || planningNanos < 0
+				|| retainedPlanEntries < 0) {
+			throw new IllegalArgumentException("Planning metrics must not be negative"); //$NON-NLS-1$
+		}
+	}
+
+	/** @return empty metrics for a cleanup that did not perform coordinated planning */
+	public static MultiFilePlanningMetrics empty() {
+		return new MultiFilePlanningMetrics(0, 0, 0, 0, 0);
+	}
+
+	/** @return metrics containing only the measured pre-parse scope */
+	public static MultiFilePlanningMetrics scope(int units, long bytes) {
+		return new MultiFilePlanningMetrics(units, bytes, 0, 0, 0);
+	}
+
+	/** @return a copy with parse and complete planning duration */
+	public MultiFilePlanningMetrics withDurations(long parseDurationNanos, long planningDurationNanos) {
+		return new MultiFilePlanningMetrics(compilationUnitCount, sourceBytes,
+				Math.max(0, parseDurationNanos), Math.max(0, planningDurationNanos), retainedPlanEntries);
+	}
+
+	/** @return a copy with the number of immutable semantic entries retained by the plan */
+	public MultiFilePlanningMetrics withRetainedPlanEntries(int entries) {
+		return new MultiFilePlanningMetrics(compilationUnitCount, sourceBytes, parseNanos, planningNanos,
+				Math.max(0, entries));
+	}
+}

--- a/sandbox_common_test/src/org/sandbox/jdt/cleanup/multifile/MultiFilePlanningBudgetTest.java
+++ b/sandbox_common_test/src/org/sandbox/jdt/cleanup/multifile/MultiFilePlanningBudgetTest.java
@@ -1,0 +1,186 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.cleanup.multifile;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+
+class MultiFilePlanningBudgetTest {
+
+	@AfterEach
+	void clearProperties() {
+		System.clearProperty(MultiFilePlanningLimits.WARNING_UNITS_PROPERTY);
+		System.clearProperty(MultiFilePlanningLimits.HARD_UNITS_PROPERTY);
+		System.clearProperty(MultiFilePlanningLimits.WARNING_BYTES_PROPERTY);
+		System.clearProperty(MultiFilePlanningLimits.HARD_BYTES_PROPERTY);
+	}
+
+	@Test
+	void measuresDistinctWorkingCopyUtf8Bytes() throws Exception {
+		ICompilationUnit first= unit("first", "ascii ä 😀"); //$NON-NLS-1$ //$NON-NLS-2$
+		ICompilationUnit duplicate= unit("first", "ignored"); //$NON-NLS-1$ //$NON-NLS-2$
+		ICompilationUnit second= unit("second", "\uD800"); //$NON-NLS-1$ //$NON-NLS-2$
+
+		MultiFilePlanningBudget.Assessment assessment= MultiFilePlanningBudget.assess(
+				new ICompilationUnit[] { first, duplicate, second },
+				new MultiFilePlanningLimits(10, 20, 100, 200), null);
+
+		assertTrue(assessment.mayProceed());
+		assertFalse(assessment.status().hasWarning());
+		assertEquals(2, assessment.metrics().compilationUnitCount());
+		assertEquals(14, assessment.metrics().sourceBytes());
+	}
+
+	@Test
+	void emitsWarningBeforeHardLimit() throws Exception {
+		MultiFilePlanningBudget.Assessment assessment= MultiFilePlanningBudget.assess(
+				new ICompilationUnit[] { unit("one", "12345"), unit("two", "67890") }, //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+				new MultiFilePlanningLimits(1, 3, 8, 20), null);
+
+		assertTrue(assessment.mayProceed());
+		assertTrue(assessment.status().hasWarning());
+		assertEquals(2, assessment.metrics().compilationUnitCount());
+		assertEquals(10, assessment.metrics().sourceBytes());
+	}
+
+	@Test
+	void abortsImmediatelyAtHardUnitLimit() throws Exception {
+		ICompilationUnit unread= unit("three", null); //$NON-NLS-1$
+		MultiFilePlanningBudget.Assessment assessment= MultiFilePlanningBudget.assess(
+				new ICompilationUnit[] { unit("one", "a"), unit("two", "b"), unread }, //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+				new MultiFilePlanningLimits(1, 2, 10, 20), null);
+
+		assertFalse(assessment.mayProceed());
+		assertTrue(assessment.status().hasFatalError());
+		assertEquals(3, assessment.metrics().compilationUnitCount());
+		assertEquals(2, assessment.metrics().sourceBytes());
+	}
+
+	@Test
+	void abortsAtHardByteLimit() throws Exception {
+		MultiFilePlanningBudget.Assessment assessment= MultiFilePlanningBudget.assess(
+				new ICompilationUnit[] { unit("one", "123456") }, //$NON-NLS-1$ //$NON-NLS-2$
+				new MultiFilePlanningLimits(2, 3, 3, 5), null);
+
+		assertFalse(assessment.mayProceed());
+		assertEquals(6, assessment.metrics().sourceBytes());
+	}
+
+	@Test
+	void checksCancellationBetweenUnits() {
+		IProgressMonitor canceled= proxy(IProgressMonitor.class, (proxy, method, arguments) -> switch (method.getName()) {
+			case "isCanceled" -> true; //$NON-NLS-1$
+			default -> defaultValue(proxy, method, arguments);
+		});
+
+		assertThrows(OperationCanceledException.class, () -> MultiFilePlanningBudget.assess(
+				new ICompilationUnit[] { unit("one", "source") }, //$NON-NLS-1$ //$NON-NLS-2$
+				MultiFilePlanningLimits.defaults(), canceled));
+	}
+
+	@Test
+	void invalidSystemOverridesCannotDisableLimits() {
+		System.setProperty(MultiFilePlanningLimits.WARNING_UNITS_PROPERTY, "invalid"); //$NON-NLS-1$
+		System.setProperty(MultiFilePlanningLimits.HARD_UNITS_PROPERTY, "4"); //$NON-NLS-1$
+		System.setProperty(MultiFilePlanningLimits.WARNING_BYTES_PROPERTY, "99"); //$NON-NLS-1$
+		System.setProperty(MultiFilePlanningLimits.HARD_BYTES_PROPERTY, "7"); //$NON-NLS-1$
+
+		MultiFilePlanningLimits limits= MultiFilePlanningLimits.fromSystemProperties();
+
+		assertEquals(4, limits.hardCompilationUnits());
+		assertTrue(limits.warningCompilationUnits() <= limits.hardCompilationUnits());
+		assertEquals(7, limits.hardSourceBytes());
+		assertTrue(limits.warningSourceBytes() <= limits.hardSourceBytes());
+	}
+
+	@Test
+	void validatesExplicitLimitOrdering() {
+		assertThrows(IllegalArgumentException.class,
+				() -> new MultiFilePlanningLimits(3, 2, 10, 20));
+		assertThrows(IllegalArgumentException.class,
+				() -> new MultiFilePlanningLimits(1, 2, 30, 20));
+	}
+
+	private static ICompilationUnit unit(String handle, String source) {
+		ICompilationUnit[] holder= new ICompilationUnit[1];
+		ICompilationUnit unit= proxy(ICompilationUnit.class, (proxy, method, arguments) -> switch (method.getName()) {
+			case "exists" -> true; //$NON-NLS-1$
+			case "getPrimary" -> holder[0]; //$NON-NLS-1$
+			case "getHandleIdentifier" -> handle; //$NON-NLS-1$
+			case "getElementName" -> handle + ".java"; //$NON-NLS-1$ //$NON-NLS-2$
+			case "getSource" -> source; //$NON-NLS-1$
+			default -> defaultValue(proxy, method, arguments);
+		});
+		holder[0]= unit;
+		return unit;
+	}
+
+	@FunctionalInterface
+	private interface Invocation {
+		Object invoke(Object proxy, Method method, Object[] arguments) throws Throwable;
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T> T proxy(Class<T> type, Invocation invocation) {
+		return (T) Proxy.newProxyInstance(MultiFilePlanningBudgetTest.class.getClassLoader(),
+				new Class<?>[] { type }, invocation::invoke);
+	}
+
+	private static Object defaultValue(Object proxy, Method method, Object[] arguments) {
+		return switch (method.getName()) {
+			case "hashCode" -> System.identityHashCode(proxy); //$NON-NLS-1$
+			case "equals" -> proxy == arguments[0]; //$NON-NLS-1$
+			case "toString" -> proxy.getClass().getInterfaces()[0].getSimpleName(); //$NON-NLS-1$
+			default -> primitiveDefault(method.getReturnType());
+		};
+	}
+
+	private static Object primitiveDefault(Class<?> type) {
+		if (type == boolean.class) {
+			return false;
+		}
+		if (type == byte.class) {
+			return (byte) 0;
+		}
+		if (type == short.class) {
+			return (short) 0;
+		}
+		if (type == int.class) {
+			return 0;
+		}
+		if (type == long.class) {
+			return 0L;
+		}
+		if (type == float.class) {
+			return 0F;
+		}
+		if (type == double.class) {
+			return 0D;
+		}
+		if (type == char.class) {
+			return '\0';
+		}
+		return null;
+	}
+}

--- a/sandbox_common_test/src/org/sandbox/jdt/cleanup/multifile/MultiFilePlanningStressTest.java
+++ b/sandbox_common_test/src/org/sandbox/jdt/cleanup/multifile/MultiFilePlanningStressTest.java
@@ -1,0 +1,128 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.cleanup.multifile;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+
+class MultiFilePlanningStressTest {
+
+	@Test
+	void largeScopeStopsBeforeReadingSourceBeyondHardUnitLimit() throws Exception {
+		AtomicInteger sourceReads= new AtomicInteger();
+		ICompilationUnit[] units= IntStream.range(0, 5_000)
+				.mapToObj(index -> unit("unit-" + index, sourceReads)) //$NON-NLS-1$
+				.toArray(ICompilationUnit[]::new);
+
+		MultiFilePlanningBudget.Assessment assessment= MultiFilePlanningBudget.assess(units,
+				new MultiFilePlanningLimits(500, 1_000, 10_000, 20_000), null);
+
+		assertFalse(assessment.mayProceed());
+		assertEquals(1_001, assessment.metrics().compilationUnitCount());
+		assertEquals(1_000, sourceReads.get(),
+				"The first unit beyond the hard count must be rejected before its source is read"); //$NON-NLS-1$
+	}
+
+	@Test
+	void measuredPlanResultPreservesImmutableMetrics() {
+		Object plan= new Object();
+		RefactoringStatus status= new RefactoringStatus();
+		status.addWarning("large but permitted"); //$NON-NLS-1$
+		MultiFilePlanningMetrics metrics= MultiFilePlanningMetrics.scope(12, 34_567)
+				.withDurations(89, 144)
+				.withRetainedPlanEntries(5);
+
+		MultiFileCleanUpPlanResult<Object> result=
+				MultiFileCleanUpPlanResult.success(plan, status, metrics);
+
+		assertSame(plan, result.plan());
+		assertSame(status, result.status());
+		assertSame(metrics, result.metrics());
+		assertEquals(5, result.metrics().retainedPlanEntries());
+	}
+
+	private static ICompilationUnit unit(String handle, AtomicInteger sourceReads) {
+		ICompilationUnit[] holder= new ICompilationUnit[1];
+		ICompilationUnit unit= proxy(ICompilationUnit.class, (proxy, method, arguments) -> switch (method.getName()) {
+			case "exists" -> true; //$NON-NLS-1$
+			case "getPrimary" -> holder[0]; //$NON-NLS-1$
+			case "getHandleIdentifier" -> handle; //$NON-NLS-1$
+			case "getElementName" -> handle + ".java"; //$NON-NLS-1$ //$NON-NLS-2$
+			case "getSource" -> { //$NON-NLS-1$
+				sourceReads.incrementAndGet();
+				yield "class A {}"; //$NON-NLS-1$
+			}
+			default -> defaultValue(proxy, method, arguments);
+		});
+		holder[0]= unit;
+		return unit;
+	}
+
+	@FunctionalInterface
+	private interface Invocation {
+		Object invoke(Object proxy, Method method, Object[] arguments) throws Throwable;
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T> T proxy(Class<T> type, Invocation invocation) {
+		return (T) Proxy.newProxyInstance(MultiFilePlanningStressTest.class.getClassLoader(),
+				new Class<?>[] { type }, invocation::invoke);
+	}
+
+	private static Object defaultValue(Object proxy, Method method, Object[] arguments) {
+		return switch (method.getName()) {
+			case "hashCode" -> System.identityHashCode(proxy); //$NON-NLS-1$
+			case "equals" -> proxy == arguments[0]; //$NON-NLS-1$
+			case "toString" -> proxy.getClass().getInterfaces()[0].getSimpleName(); //$NON-NLS-1$
+			default -> primitiveDefault(method.getReturnType());
+		};
+	}
+
+	private static Object primitiveDefault(Class<?> type) {
+		if (type == boolean.class) {
+			return false;
+		}
+		if (type == byte.class) {
+			return (byte) 0;
+		}
+		if (type == short.class) {
+			return (short) 0;
+		}
+		if (type == int.class) {
+			return 0;
+		}
+		if (type == long.class) {
+			return 0L;
+		}
+		if (type == float.class) {
+			return 0F;
+		}
+		if (type == double.class) {
+			return 0D;
+		}
+		if (type == char.class) {
+			return '\0';
+		}
+		return null;
+	}
+}

--- a/sandbox_int_to_enum/src/org/sandbox/jdt/internal/corext/fix/multifile/IntEnumMultiFilePlanner.java
+++ b/sandbox_int_to_enum/src/org/sandbox/jdt/internal/corext/fix/multifile/IntEnumMultiFilePlanner.java
@@ -61,6 +61,9 @@ import org.eclipse.jdt.internal.corext.refactoring.util.RefactoringASTParser;
 
 import org.sandbox.jdt.cleanup.multifile.JavaProjectCompilationUnits;
 import org.sandbox.jdt.cleanup.multifile.MultiFileCleanUpPlanResult;
+import org.sandbox.jdt.cleanup.multifile.MultiFilePlanningBudget;
+import org.sandbox.jdt.cleanup.multifile.MultiFilePlanningLimits;
+import org.sandbox.jdt.cleanup.multifile.MultiFilePlanningMetrics;
 import org.sandbox.jdt.cleanup.multifile.SelectedCompilationUnitPlan;
 
 /** Builds conservative source-wide integer-state migration plans. */
@@ -110,18 +113,31 @@ public final class IntEnumMultiFilePlanner {
 	public static MultiFileCleanUpPlanResult<IntEnumMigrationPlan> create(IJavaProject project,
 			ICompilationUnit[] selectedUnits, boolean closedScope, IProgressMonitor monitor) throws CoreException {
 		SelectedCompilationUnitPlan scope= SelectedCompilationUnitPlan.of(project, selectedUnits);
-		if (monitor != null && monitor.isCanceled()) {
-			throw new OperationCanceledException();
-		}
+		MultiFilePlanningBudget.checkCanceled(monitor);
 		if (!closedScope) {
 			return MultiFileCleanUpPlanResult.success(new IntEnumMigrationPlan(scope, List.of()));
 		}
 
+		long planningStarted= System.nanoTime();
+		MultiFilePlanningBudget.Assessment budget= MultiFilePlanningBudget.assess(selectedUnits,
+				MultiFilePlanningLimits.fromSystemProperties(), monitor);
+		if (!budget.mayProceed()) {
+			return new MultiFileCleanUpPlanResult<>(null, budget.status(), budget.metrics());
+		}
+		long parseStarted= System.nanoTime();
 		Map<String, CompilationUnit> roots= parse(project, selectedUnits, monitor);
-		List<CandidateBuilder> builders= discoverCandidates(roots);
-		validateReferences(roots, builders);
-		List<IntEnumCandidate> candidates= freeze(builders);
-		return MultiFileCleanUpPlanResult.success(new IntEnumMigrationPlan(scope, candidates));
+		long parseNanos= System.nanoTime() - parseStarted;
+		MultiFilePlanningBudget.checkCanceled(monitor);
+		List<CandidateBuilder> builders= discoverCandidates(roots, monitor);
+		MultiFilePlanningBudget.checkCanceled(monitor);
+		validateReferences(roots, builders, monitor);
+		MultiFilePlanningBudget.checkCanceled(monitor);
+		List<IntEnumCandidate> candidates= freeze(builders, monitor);
+		MultiFilePlanningMetrics metrics= budget.metrics()
+				.withDurations(parseNanos, System.nanoTime() - planningStarted)
+				.withRetainedPlanEntries(candidates.size());
+		return MultiFileCleanUpPlanResult.success(new IntEnumMigrationPlan(scope, candidates),
+				budget.status(), metrics);
 	}
 
 	private static Map<String, CompilationUnit> parse(IJavaProject project, ICompilationUnit[] units,
@@ -142,14 +158,17 @@ public final class IntEnumMultiFilePlanner {
 		return roots;
 	}
 
-	private static List<CandidateBuilder> discoverCandidates(Map<String, CompilationUnit> roots) {
+	private static List<CandidateBuilder> discoverCandidates(Map<String, CompilationUnit> roots,
+			IProgressMonitor monitor) {
 		List<CandidateBuilder> result= new ArrayList<>();
 		Set<String> claimedConstants= new HashSet<>();
 		for (Map.Entry<String, CompilationUnit> entry : roots.entrySet()) {
+			MultiFilePlanningBudget.checkCanceled(monitor);
 			String unitHandle= entry.getKey();
 			entry.getValue().accept(new ASTVisitor() {
 				@Override
 				public boolean visit(TypeDeclaration type) {
+					MultiFilePlanningBudget.checkCanceled(monitor);
 					if (!(type.getParent() instanceof CompilationUnit) || type.isInterface()
 							|| type.getSuperclassType() != null || !type.superInterfaceTypes().isEmpty()) {
 						return false;
@@ -292,21 +311,25 @@ public final class IntEnumMultiFilePlanner {
 		return null;
 	}
 
-	private static void validateReferences(Map<String, CompilationUnit> roots, List<CandidateBuilder> candidates) {
+	private static void validateReferences(Map<String, CompilationUnit> roots,
+			List<CandidateBuilder> candidates, IProgressMonitor monitor) {
 		Map<String, CandidateBuilder> byMethod= new HashMap<>();
 		Map<String, CandidateBuilder> byConstant= new HashMap<>();
 		for (CandidateBuilder candidate : candidates) {
+			MultiFilePlanningBudget.checkCanceled(monitor);
 			byMethod.put(candidate.methodKey, candidate);
 			for (ConstantDecl constant : candidate.constants) {
 				byConstant.put(constant.bindingKey(), candidate);
 			}
 		}
 		for (Map.Entry<String, CompilationUnit> entry : roots.entrySet()) {
+			MultiFilePlanningBudget.checkCanceled(monitor);
 			String unitHandle= entry.getKey();
 			CompilationUnit root= entry.getValue();
 			root.accept(new ASTVisitor() {
 				@Override
 				public boolean visit(MethodInvocation node) {
+					MultiFilePlanningBudget.checkCanceled(monitor);
 					IMethodBinding methodBinding= node.resolveMethodBinding();
 					String methodKey= methodBinding == null ? null : methodBinding.getMethodDeclaration().getKey();
 					CandidateBuilder candidate= byMethod.get(methodKey);
@@ -334,6 +357,7 @@ public final class IntEnumMultiFilePlanner {
 
 				@Override
 				public boolean visit(SimpleName node) {
+					MultiFilePlanningBudget.checkCanceled(monitor);
 					IBinding binding= node.resolveBinding();
 					if (binding instanceof IVariableBinding variable) {
 						String key= variable.getVariableDeclaration().getKey();
@@ -361,14 +385,16 @@ public final class IntEnumMultiFilePlanner {
 		}
 	}
 
-	private static List<IntEnumCandidate> freeze(List<CandidateBuilder> builders) {
+	private static List<IntEnumCandidate> freeze(List<CandidateBuilder> builders, IProgressMonitor monitor) {
 		List<IntEnumCandidate> result= new ArrayList<>();
 		for (CandidateBuilder builder : builders) {
+			MultiFilePlanningBudget.checkCanceled(monitor);
 			if (!builder.valid || !builder.hasExternalCaller) {
 				continue;
 			}
 			Map<String, Map<String, Integer>> referenceCounts= new LinkedHashMap<>();
 			for (Map.Entry<Expression, String> reference : builder.recognisedReferences.entrySet()) {
+				MultiFilePlanningBudget.checkCanceled(monitor);
 				CompilationUnit root= root(reference.getKey());
 				if (root == null || !(root.getJavaElement() instanceof ICompilationUnit unit)) {
 					builder.valid= false;

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnitMultiFilePlanner.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnitMultiFilePlanner.java
@@ -49,6 +49,9 @@ import org.eclipse.jdt.internal.corext.refactoring.util.RefactoringASTParser;
 
 import org.sandbox.jdt.cleanup.multifile.JavaProjectCompilationUnits;
 import org.sandbox.jdt.cleanup.multifile.MultiFileCleanUpPlanResult;
+import org.sandbox.jdt.cleanup.multifile.MultiFilePlanningBudget;
+import org.sandbox.jdt.cleanup.multifile.MultiFilePlanningLimits;
+import org.sandbox.jdt.cleanup.multifile.MultiFilePlanningMetrics;
 import org.sandbox.jdt.cleanup.multifile.SelectedCompilationUnitPlan;
 
 /** Builds the source-wide JUnit migration plan before per-file rewrites start. */
@@ -101,19 +104,33 @@ public final class JUnitMultiFilePlanner {
 		if (!migrateExternalResourceRules || selectedUnits.length == 0 || !closedScope) {
 			return MultiFileCleanUpPlanResult.success(new JUnitMigrationPlan(selectedScope, List.of()));
 		}
-		if (monitor != null && monitor.isCanceled()) {
-			throw new OperationCanceledException();
-		}
+		MultiFilePlanningBudget.checkCanceled(monitor);
 
-		Map<String, CompilationUnit> rootsByHandle= parse(project, selectedUnits, monitor);
-		Map<String, ResourceType> resourcesByTypeKey= collectResourceTypes(rootsByHandle);
-		List<RuleField> ruleFields= collectRuleFields(rootsByHandle, resourcesByTypeKey);
-		RefactoringStatus status= new RefactoringStatus();
-		List<ExternalResourceRuleMigration> migrations= createMigrations(ruleFields, resourcesByTypeKey, status);
-		if (status.hasFatalError()) {
-			return new MultiFileCleanUpPlanResult<>(null, status);
+		long planningStarted= System.nanoTime();
+		MultiFilePlanningBudget.Assessment budget= MultiFilePlanningBudget.assess(selectedUnits,
+				MultiFilePlanningLimits.fromSystemProperties(), monitor);
+		if (!budget.mayProceed()) {
+			return new MultiFileCleanUpPlanResult<>(null, budget.status(), budget.metrics());
 		}
-		return new MultiFileCleanUpPlanResult<>(new JUnitMigrationPlan(selectedScope, migrations), status);
+		long parseStarted= System.nanoTime();
+		Map<String, CompilationUnit> rootsByHandle= parse(project, selectedUnits, monitor);
+		long parseNanos= System.nanoTime() - parseStarted;
+		MultiFilePlanningBudget.checkCanceled(monitor);
+		Map<String, ResourceType> resourcesByTypeKey= collectResourceTypes(rootsByHandle, monitor);
+		MultiFilePlanningBudget.checkCanceled(monitor);
+		List<RuleField> ruleFields= collectRuleFields(rootsByHandle, resourcesByTypeKey, monitor);
+		RefactoringStatus status= budget.status();
+		MultiFilePlanningBudget.checkCanceled(monitor);
+		List<ExternalResourceRuleMigration> migrations= createMigrations(ruleFields, resourcesByTypeKey, status,
+				monitor);
+		MultiFilePlanningMetrics metrics= budget.metrics()
+				.withDurations(parseNanos, System.nanoTime() - planningStarted)
+				.withRetainedPlanEntries(migrations.size());
+		if (status.hasFatalError()) {
+			return new MultiFileCleanUpPlanResult<>(null, status, metrics);
+		}
+		return MultiFileCleanUpPlanResult.success(new JUnitMigrationPlan(selectedScope, migrations), status,
+				metrics);
 	}
 
 	private static Map<String, CompilationUnit> parse(IJavaProject project, ICompilationUnit[] units,
@@ -134,13 +151,16 @@ public final class JUnitMultiFilePlanner {
 		return roots;
 	}
 
-	private static Map<String, ResourceType> collectResourceTypes(Map<String, CompilationUnit> rootsByHandle) {
+	private static Map<String, ResourceType> collectResourceTypes(
+			Map<String, CompilationUnit> rootsByHandle, IProgressMonitor monitor) {
 		Map<String, ResourceType> result= new LinkedHashMap<>();
 		for (Map.Entry<String, CompilationUnit> entry : rootsByHandle.entrySet()) {
+			MultiFilePlanningBudget.checkCanceled(monitor);
 			String unitHandle= entry.getKey();
 			entry.getValue().accept(new ASTVisitor() {
 				@Override
 				public boolean visit(TypeDeclaration node) {
+					MultiFilePlanningBudget.checkCanceled(monitor);
 					ITypeBinding binding= node.resolveBinding();
 					if (directlyExtendsExternalResource(binding)) {
 						String typeKey= JUnitMigrationPlan.typeKey(binding);
@@ -156,13 +176,15 @@ public final class JUnitMultiFilePlanner {
 	}
 
 	private static List<RuleField> collectRuleFields(Map<String, CompilationUnit> rootsByHandle,
-			Map<String, ResourceType> resourcesByTypeKey) {
+			Map<String, ResourceType> resourcesByTypeKey, IProgressMonitor monitor) {
 		List<RuleField> result= new ArrayList<>();
 		for (Map.Entry<String, CompilationUnit> entry : rootsByHandle.entrySet()) {
+			MultiFilePlanningBudget.checkCanceled(monitor);
 			String unitHandle= entry.getKey();
 			entry.getValue().accept(new ASTVisitor() {
 				@Override
 				public boolean visit(FieldDeclaration node) {
+					MultiFilePlanningBudget.checkCanceled(monitor);
 					RuleKind kind= ruleKind(node);
 					boolean classRule= kind == RuleKind.CLASS;
 					if (kind == RuleKind.NONE || node.fragments().size() != 1
@@ -189,10 +211,11 @@ public final class JUnitMultiFilePlanner {
 	}
 
 	private static List<ExternalResourceRuleMigration> createMigrations(List<RuleField> fields,
-			Map<String, ResourceType> resourcesByTypeKey, RefactoringStatus status) {
+			Map<String, ResourceType> resourcesByTypeKey, RefactoringStatus status, IProgressMonitor monitor) {
 		Map<String, Boolean> modeByResourceType= new HashMap<>();
 		List<ExternalResourceRuleMigration> result= new ArrayList<>();
 		for (RuleField field : fields) {
+			MultiFilePlanningBudget.checkCanceled(monitor);
 			Boolean previousMode= modeByResourceType.putIfAbsent(field.resourceTypeKey(), field.classRule());
 			if (previousMode != null && previousMode.booleanValue() != field.classRule()) {
 				status.addFatalError("The ExternalResource type is used by both @Rule and @ClassRule fields; " //$NON-NLS-1$


### PR DESCRIPTION
## Summary

Adds common, configurable planning budgets and metrics so coordinated JUnit and Int-to-Enum cleanups cannot parse an unbounded source scope without warning, cancellation points, or deterministic refusal.

## Changes

- measure distinct primary compilation units and current working-copy source size before AST creation;
- count exact UTF-8 bytes without allocating a second byte array;
- warn above 500 units or 32 MiB by default;
- abort without a plan above 2,000 units or 128 MiB by default;
- support positive system-property overrides while preventing invalid values from disabling hard guards;
- carry unit count, source bytes, parse duration, total planning duration and retained semantic plan-entry count in `MultiFileCleanUpPlanResult`;
- retain metrics only for the serialized cleanup lifecycle and clear them with plan state;
- check cancellation throughout Int-to-Enum and JUnit semantic planning;
- keep AST maps method-local so final plans retain semantic descriptors rather than AST roots;
- add focused unit tests plus a 5,000-unit stress regression proving deterministic early abort before excess source reads;
- document limits, configuration, metrics, cancellation, refusal semantics and memory ownership.

## Branch hygiene

The former stacked history was preserved under `backup/issue-1221-planning-budgets-stacked`. This PR is rebuilt directly on current `main` and contains only the resource-budget layer; previously merged source-root and candidate-closure files are no longer part of the diff.

Closes #1221 when merged.