### PR TITLE
Build patched JDT UI and verify stock-target compatibility

### DIFF
--- a/.github/.pr-sync-1271
+++ b/.github/.pr-sync-1271
@@ -1,0 +1,1 @@
+temporary PR synchronization marker

--- a/.github/.pr-sync-1271
+++ b/.github/.pr-sync-1271
@@ -1,1 +1,0 @@
-temporary PR synchronization marker

--- a/.github/patched-jdt-ui.env
+++ b/.github/patched-jdt-ui.env
@@ -1,0 +1,5 @@
+# Reproducible source coordinates for the optional patched-product build.
+PATCHED_JDT_UI_REPOSITORY=https://github.com/carstenartur/eclipse.jdt.ui.git
+PATCHED_JDT_UI_COMMIT=450bfd46089c99608dd60203e1257e1c329ad2c5
+PATCHED_JDT_UI_BUNDLE=org.eclipse.jdt.ui
+PATCHED_JDT_UI_EXPECTED_BASE_VERSION=3.39.0

--- a/.github/scripts/build_patched_jdt_ui.sh
+++ b/.github/scripts/build_patched_jdt_ui.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+CONFIG_FILE=${PATCHED_JDT_UI_CONFIG:-"$ROOT_DIR/.github/patched-jdt-ui.env"}
+OUTPUT_DIR=${1:-"$ROOT_DIR/target/patched-jdt-ui"}
+WORK_DIR=${PATCHED_JDT_UI_WORK_DIR:-"${RUNNER_TEMP:-${TMPDIR:-/tmp}}/patched-jdt-ui-source"}
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  echo "Missing patch configuration: $CONFIG_FILE" >&2
+  exit 1
+fi
+# shellcheck disable=SC1090
+source "$CONFIG_FILE"
+
+: "${PATCHED_JDT_UI_REPOSITORY:?missing PATCHED_JDT_UI_REPOSITORY}"
+: "${PATCHED_JDT_UI_COMMIT:?missing PATCHED_JDT_UI_COMMIT}"
+: "${PATCHED_JDT_UI_BUNDLE:?missing PATCHED_JDT_UI_BUNDLE}"
+: "${PATCHED_JDT_UI_EXPECTED_BASE_VERSION:?missing PATCHED_JDT_UI_EXPECTED_BASE_VERSION}"
+
+if [[ ! "$PATCHED_JDT_UI_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "PATCHED_JDT_UI_COMMIT must be an immutable 40-character SHA" >&2
+  exit 1
+fi
+
+for command in git mvn javap python3 sha256sum; do
+  command -v "$command" >/dev/null || { echo "Missing required command: $command" >&2; exit 1; }
+done
+
+rm -rf "$WORK_DIR" "$OUTPUT_DIR"
+mkdir -p "$WORK_DIR" "$OUTPUT_DIR/plugins"
+
+git -C "$WORK_DIR" init -q
+git -C "$WORK_DIR" remote add origin "$PATCHED_JDT_UI_REPOSITORY"
+git -C "$WORK_DIR" fetch --depth=1 origin "$PATCHED_JDT_UI_COMMIT"
+git -C "$WORK_DIR" checkout --detach -q FETCH_HEAD
+ACTUAL_COMMIT=$(git -C "$WORK_DIR" rev-parse HEAD)
+if [[ "$ACTUAL_COMMIT" != "$PATCHED_JDT_UI_COMMIT" ]]; then
+  echo "Checked out $ACTUAL_COMMIT instead of $PATCHED_JDT_UI_COMMIT" >&2
+  exit 1
+fi
+
+PRODUCTION_SOURCE='org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpRefactoring.java'
+SCOPE_TEST='org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/MultiFileCleanUpScopeExpansionTest.java'
+SYNC_MANIFEST='.github/fork-specific-files.txt'
+for path in "$PRODUCTION_SOURCE" "$SCOPE_TEST" "$SYNC_MANIFEST"; do
+  [[ -f "$WORK_DIR/$path" ]] || { echo "Pinned source revision is missing $path" >&2; exit 1; }
+done
+grep -Fq 'EXPAND_CLEAN_UP_SCOPE_METHOD' "$WORK_DIR/$PRODUCTION_SOURCE"
+grep -Fq 'MultiFileCleanUpScopeExpansionTest' "$WORK_DIR/$SCOPE_TEST"
+grep -Fq "$PRODUCTION_SOURCE" "$WORK_DIR/$SYNC_MANIFEST"
+grep -Fq "$SCOPE_TEST" "$WORK_DIR/$SYNC_MANIFEST"
+
+mvn --batch-mode -ntp -f "$WORK_DIR/pom.xml" \
+  -Pbuild-individual-bundles \
+  -pl "$PATCHED_JDT_UI_BUNDLE" -am \
+  -DskipTests \
+  clean verify
+
+mapfile -t candidates < <(find "$WORK_DIR/$PATCHED_JDT_UI_BUNDLE/target" -maxdepth 1 -type f \
+  -name "$PATCHED_JDT_UI_BUNDLE-*.jar" \
+  ! -name '*-sources.jar' ! -name '*-javadoc.jar' | sort)
+if (( ${#candidates[@]} != 1 )); then
+  printf 'Expected exactly one built %s bundle, found %d:\n' "$PATCHED_JDT_UI_BUNDLE" "${#candidates[@]}" >&2
+  printf '  %s\n' "${candidates[@]:-<none>}" >&2
+  exit 1
+fi
+BUNDLE_JAR=${candidates[0]}
+
+python3 - "$BUNDLE_JAR" "$OUTPUT_DIR/MANIFEST.MF" <<'PY'
+import sys
+import zipfile
+from pathlib import Path
+
+with zipfile.ZipFile(sys.argv[1]) as archive:
+    manifest = archive.read('META-INF/MANIFEST.MF')
+Path(sys.argv[2]).write_bytes(manifest)
+PY
+
+readarray -t manifest_values < <(python3 - "$OUTPUT_DIR/MANIFEST.MF" <<'PY'
+import sys
+from pathlib import Path
+
+logical=[]
+for line in Path(sys.argv[1]).read_text(encoding='utf-8').splitlines():
+    if line.startswith(' ') and logical:
+        logical[-1] += line[1:]
+    else:
+        logical.append(line)
+headers={}
+for line in logical:
+    if ':' in line:
+        key, value=line.split(':', 1)
+        headers[key.strip()]=value.strip()
+print(headers.get('Bundle-SymbolicName', '').split(';', 1)[0])
+print(headers.get('Bundle-Version', ''))
+PY
+)
+SYMBOLIC_NAME=${manifest_values[0]:-}
+BUNDLE_VERSION=${manifest_values[1]:-}
+if [[ "$SYMBOLIC_NAME" != "$PATCHED_JDT_UI_BUNDLE" ]]; then
+  echo "Unexpected Bundle-SymbolicName: $SYMBOLIC_NAME" >&2
+  exit 1
+fi
+if ! grep -Fq 'Bundle-SymbolicName: org.eclipse.jdt.ui; singleton:=true' "$OUTPUT_DIR/MANIFEST.MF"; then
+  echo 'Built bundle is not the required singleton org.eclipse.jdt.ui replacement' >&2
+  exit 1
+fi
+if [[ "$BUNDLE_VERSION" == *qualifier* || ! "$BUNDLE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+\..+$ ]]; then
+  echo "Bundle-Version was not reproducibly qualified: $BUNDLE_VERSION" >&2
+  exit 1
+fi
+if [[ "$BUNDLE_VERSION" != "$PATCHED_JDT_UI_EXPECTED_BASE_VERSION".* ]]; then
+  echo "Built version $BUNDLE_VERSION does not match expected base $PATCHED_JDT_UI_EXPECTED_BASE_VERSION" >&2
+  exit 1
+fi
+
+javap -classpath "$BUNDLE_JAR" -private org.eclipse.jdt.internal.corext.fix.CleanUpRefactoring \
+  | grep -Fq 'EXPAND_CLEAN_UP_SCOPE_METHOD'
+
+DESTINATION="$OUTPUT_DIR/plugins/${PATCHED_JDT_UI_BUNDLE}_${BUNDLE_VERSION}.jar"
+cp "$BUNDLE_JAR" "$DESTINATION"
+BUNDLE_SHA256=$(sha256sum "$DESTINATION" | awk '{print $1}')
+JAVA_VERSION=$(java -version 2>&1 | head -n 1)
+MAVEN_VERSION=$(mvn --version | head -n 1)
+
+export OUTPUT_DIR PATCHED_JDT_UI_REPOSITORY PATCHED_JDT_UI_COMMIT PATCHED_JDT_UI_BUNDLE
+export SYMBOLIC_NAME BUNDLE_VERSION BUNDLE_SHA256 JAVA_VERSION MAVEN_VERSION
+export PRODUCTION_SOURCE SCOPE_TEST
+python3 <<'PY'
+import json
+import os
+from pathlib import Path
+
+bundle = os.environ['PATCHED_JDT_UI_BUNDLE']
+version = os.environ['BUNDLE_VERSION']
+payload = {
+    'schemaVersion': 1,
+    'sourceRepository': os.environ['PATCHED_JDT_UI_REPOSITORY'],
+    'sourceCommit': os.environ['PATCHED_JDT_UI_COMMIT'],
+    'bundleSymbolicName': os.environ['SYMBOLIC_NAME'],
+    'bundleVersion': version,
+    'bundleFile': f'plugins/{bundle}_{version}.jar',
+    'bundleSha256': os.environ['BUNDLE_SHA256'],
+    'buildProfile': 'build-individual-bundles',
+    'java': os.environ['JAVA_VERSION'],
+    'maven': os.environ['MAVEN_VERSION'],
+    'scopeExpansionSource': os.environ['PRODUCTION_SOURCE'],
+    'scopeExpansionTest': os.environ['SCOPE_TEST'],
+}
+output = Path(os.environ['OUTPUT_DIR']) / 'provenance.json'
+output.write_text(json.dumps(payload, indent=2) + '\n', encoding='utf-8')
+PY
+python3 -m json.tool "$OUTPUT_DIR/provenance.json" >/dev/null
+
+printf 'Built %s %s from %s\nSHA-256: %s\n' \
+  "$SYMBOLIC_NAME" "$BUNDLE_VERSION" "$PATCHED_JDT_UI_COMMIT" "$BUNDLE_SHA256"

--- a/.github/scripts/compare_patched_jdt_ui_with_target.sh
+++ b/.github/scripts/compare_patched_jdt_ui_with_target.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+CONFIG_FILE=${PATCHED_JDT_UI_CONFIG:-"$ROOT_DIR/.github/patched-jdt-ui.env"}
+PATCH_DIR=${1:?usage: compare_patched_jdt_ui_with_target.sh PATCH_DIR [REPORT_DIR]}
+REPORT_DIR=${2:-"$ROOT_DIR/target/patched-jdt-ui-compatibility"}
+MAVEN_REPOSITORY=${MAVEN_REPOSITORY:-"$HOME/.m2/repository"}
+
+# shellcheck disable=SC1090
+source "$CONFIG_FILE"
+: "${PATCHED_JDT_UI_BUNDLE:?missing PATCHED_JDT_UI_BUNDLE}"
+
+for command in find java mvn python3; do
+  command -v "$command" >/dev/null || { echo "Missing required command: $command" >&2; exit 1; }
+done
+
+mapfile -t patched_candidates < <(find "$PATCH_DIR/plugins" -maxdepth 1 -type f \
+  -name "${PATCHED_JDT_UI_BUNDLE}_*.jar" | sort)
+if (( ${#patched_candidates[@]} != 1 )); then
+  printf 'Expected exactly one patched %s bundle below %s/plugins, found %d\n' \
+    "$PATCHED_JDT_UI_BUNDLE" "$PATCH_DIR" "${#patched_candidates[@]}" >&2
+  exit 1
+fi
+PATCHED_JAR=${patched_candidates[0]}
+
+# Remove only cached JDT UI binary/source artifacts so the following Tycho
+# resolution proves what the checked-in 2025-12 target selects in this run.
+while IFS= read -r cached; do
+  rm -f "$cached"
+done < <(find "$MAVEN_REPOSITORY" -type f \
+  \( -name 'org.eclipse.jdt.ui_*.jar' -o -name 'org.eclipse.jdt.ui-*.jar' \) 2>/dev/null)
+
+mvn --batch-mode -ntp -f "$ROOT_DIR/pom.xml" \
+  -pl sandbox_common -am \
+  -DskipTests -DskipITs -Dspotbugs.skip=true -Dlicense.skip=true \
+  package
+
+mapfile -t named_candidates < <(find "$MAVEN_REPOSITORY" -type f \
+  \( -name 'org.eclipse.jdt.ui_*.jar' -o -name 'org.eclipse.jdt.ui-*.jar' \) \
+  ! -name '*-sources.jar' ! -name '*-javadoc.jar' 2>/dev/null | sort)
+if (( ${#named_candidates[@]} == 0 )); then
+  echo "Tycho resolved the target, but no cached org.eclipse.jdt.ui candidate was found" >&2
+  exit 1
+fi
+
+mkdir -p "$REPORT_DIR"
+CANDIDATE_LIST="$REPORT_DIR/stock-candidates.txt"
+printf '%s\n' "${named_candidates[@]}" > "$CANDIDATE_LIST"
+
+python3 - "$PATCHED_JAR" "$CANDIDATE_LIST" "$REPORT_DIR" "$PATCHED_JDT_UI_BUNDLE" <<'PY'
+import hashlib
+import json
+import re
+import sys
+import zipfile
+from pathlib import Path
+
+patched_path = Path(sys.argv[1])
+candidate_paths = [Path(line) for line in Path(sys.argv[2]).read_text(encoding='utf-8').splitlines() if line]
+report_dir = Path(sys.argv[3])
+expected_symbolic_name = sys.argv[4]
+
+
+def manifest(path: Path) -> dict[str, str]:
+    with zipfile.ZipFile(path) as archive:
+        raw = archive.read('META-INF/MANIFEST.MF').decode('utf-8')
+    logical: list[str] = []
+    for line in raw.splitlines():
+        if line.startswith(' ') and logical:
+            logical[-1] += line[1:]
+        else:
+            logical.append(line)
+    headers: dict[str, str] = {}
+    for line in logical:
+        if ':' in line:
+            key, value = line.split(':', 1)
+            headers[key.strip()] = value.strip()
+    return headers
+
+
+def symbolic_name(headers: dict[str, str]) -> str:
+    return headers.get('Bundle-SymbolicName', '').split(';', 1)[0].strip()
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open('rb') as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b''):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def version_key(value: str) -> tuple[int, int, int, str]:
+    parts = value.split('.', 3)
+    if len(parts) < 3 or not all(part.isdigit() for part in parts[:3]):
+        raise ValueError(f'Not an OSGi version: {value!r}')
+    qualifier = parts[3] if len(parts) == 4 else ''
+    return int(parts[0]), int(parts[1]), int(parts[2]), qualifier
+
+
+def split_clauses(value: str) -> list[str]:
+    if not value:
+        return []
+    result: list[str] = []
+    current: list[str] = []
+    quoted = False
+    escaped = False
+    for char in value:
+        if escaped:
+            current.append(char)
+            escaped = False
+        elif char == '\\':
+            current.append(char)
+            escaped = True
+        elif char == '"':
+            current.append(char)
+            quoted = not quoted
+        elif char == ',' and not quoted:
+            clause = ''.join(current).strip()
+            if clause:
+                result.append(re.sub(r'\s+', ' ', clause))
+            current = []
+        else:
+            current.append(char)
+    clause = ''.join(current).strip()
+    if clause:
+        result.append(re.sub(r'\s+', ' ', clause))
+    return sorted(result)
+
+
+def clause_names(value: str) -> set[str]:
+    return {clause.split(';', 1)[0].strip() for clause in split_clauses(value)}
+
+patched_manifest = manifest(patched_path)
+if symbolic_name(patched_manifest) != expected_symbolic_name:
+    raise SystemExit(f'Patched bundle has unexpected symbolic name: {symbolic_name(patched_manifest)!r}')
+
+stock: list[tuple[Path, dict[str, str]]] = []
+for candidate in candidate_paths:
+    try:
+        headers = manifest(candidate)
+    except (KeyError, zipfile.BadZipFile):
+        continue
+    if symbolic_name(headers) == expected_symbolic_name:
+        stock.append((candidate, headers))
+
+versions = sorted({headers.get('Bundle-Version', '') for _, headers in stock})
+if len(versions) != 1:
+    raise SystemExit(f'Expected exactly one resolved stock {expected_symbolic_name} version, found {versions}')
+stock_version = versions[0]
+stock_candidates = [(path, headers) for path, headers in stock if headers.get('Bundle-Version', '') == stock_version]
+stock_path, stock_manifest = stock_candidates[0]
+patched_version = patched_manifest.get('Bundle-Version', '')
+
+checks: list[dict[str, object]] = []
+
+def check(name: str, passed: bool, detail: str) -> None:
+    checks.append({'name': name, 'passed': passed, 'detail': detail})
+
+try:
+    newer = version_key(patched_version) > version_key(stock_version)
+except ValueError as error:
+    newer = False
+    check('replacement-version', False, str(error))
+else:
+    check('replacement-version', newer,
+          f'patched {patched_version} must be strictly newer than stock {stock_version}')
+
+for header in ('Bundle-RequiredExecutionEnvironment', 'Require-Bundle', 'Import-Package'):
+    patched_value = split_clauses(patched_manifest.get(header, ''))
+    stock_value = split_clauses(stock_manifest.get(header, ''))
+    check(f'{header}-compatibility', patched_value == stock_value,
+          'identical' if patched_value == stock_value else
+          f'added={sorted(set(patched_value) - set(stock_value))}; removed={sorted(set(stock_value) - set(patched_value))}')
+
+stock_exports = clause_names(stock_manifest.get('Export-Package', ''))
+patched_exports = clause_names(patched_manifest.get('Export-Package', ''))
+missing_exports = sorted(stock_exports - patched_exports)
+check('Export-Package-coverage', not missing_exports,
+      'all stock exports retained' if not missing_exports else f'missing={missing_exports}')
+
+compatible = all(bool(item['passed']) for item in checks)
+payload = {
+    'schemaVersion': 1,
+    'compatibleForReplacement': compatible,
+    'target': 'sandbox_target/eclipse.target (Eclipse 2025-12)',
+    'stockBundle': {
+        'path': str(stock_path),
+        'version': stock_version,
+        'sha256': sha256(stock_path),
+    },
+    'patchedBundle': {
+        'path': str(patched_path),
+        'version': patched_version,
+        'sha256': sha256(patched_path),
+    },
+    'checks': checks,
+}
+(report_dir / 'compatibility.json').write_text(json.dumps(payload, indent=2) + '\n', encoding='utf-8')
+
+lines = [
+    '# Patched JDT UI target compatibility',
+    '',
+    f'- Stock bundle: `{expected_symbolic_name} {stock_version}`',
+    f'- Patched bundle: `{expected_symbolic_name} {patched_version}`',
+    f'- Replacement gate: **{"PASS" if compatible else "BLOCKED"}**',
+    '',
+    '| Check | Result | Detail |',
+    '|---|---:|---|',
+]
+for item in checks:
+    detail = str(item['detail']).replace('|', '\\|').replace('\n', ' ')
+    lines.append(f"| `{item['name']}` | {'PASS' if item['passed'] else 'FAIL'} | {detail} |")
+(report_dir / 'compatibility.md').write_text('\n'.join(lines) + '\n', encoding='utf-8')
+
+print(json.dumps(payload, indent=2))
+PY
+
+python3 -m json.tool "$REPORT_DIR/compatibility.json" >/dev/null

--- a/.github/scripts/compare_patched_jdt_ui_with_target.sh
+++ b/.github/scripts/compare_patched_jdt_ui_with_target.sh
@@ -5,7 +5,7 @@ ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
 CONFIG_FILE=${PATCHED_JDT_UI_CONFIG:-"$ROOT_DIR/.github/patched-jdt-ui.env"}
 PATCH_DIR=${1:?usage: compare_patched_jdt_ui_with_target.sh PATCH_DIR [REPORT_DIR]}
 REPORT_DIR=${2:-"$ROOT_DIR/target/patched-jdt-ui-compatibility"}
-MAVEN_REPOSITORY=${MAVEN_REPOSITORY:-"$REPORT_DIR/maven-repository"}
+MAVEN_REPOSITORY=${MAVEN_REPOSITORY:-"$(dirname "$REPORT_DIR")/patched-jdt-ui-compat-m2"}
 
 mkdir -p "$REPORT_DIR"
 exec > >(tee "$REPORT_DIR/compatibility-build.log") 2>&1
@@ -33,9 +33,13 @@ PATCHED_JAR=${patched_candidates[0]}
 rm -rf "$MAVEN_REPOSITORY"
 mkdir -p "$MAVEN_REPOSITORY"
 
+# The target definition is referenced as a Maven artifact by Tycho and therefore
+# must be present in the selected reactor when using an otherwise empty local
+# repository. A normal full build includes it implicitly; this focused build must
+# name it explicitly.
 mvn --batch-mode -ntp -f "$ROOT_DIR/pom.xml" \
   -Dmaven.repo.local="$MAVEN_REPOSITORY" \
-  -pl sandbox_common -am \
+  -pl sandbox_target,sandbox_common -am \
   -DskipTests -DskipITs -Dspotbugs.skip=true -Dlicense.skip=true \
   package
 

--- a/.github/scripts/compare_patched_jdt_ui_with_target.sh
+++ b/.github/scripts/compare_patched_jdt_ui_with_target.sh
@@ -5,7 +5,10 @@ ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
 CONFIG_FILE=${PATCHED_JDT_UI_CONFIG:-"$ROOT_DIR/.github/patched-jdt-ui.env"}
 PATCH_DIR=${1:?usage: compare_patched_jdt_ui_with_target.sh PATCH_DIR [REPORT_DIR]}
 REPORT_DIR=${2:-"$ROOT_DIR/target/patched-jdt-ui-compatibility"}
-MAVEN_REPOSITORY=${MAVEN_REPOSITORY:-"$HOME/.m2/repository"}
+MAVEN_REPOSITORY=${MAVEN_REPOSITORY:-"$REPORT_DIR/maven-repository"}
+
+mkdir -p "$REPORT_DIR"
+exec > >(tee "$REPORT_DIR/compatibility-build.log") 2>&1
 
 # shellcheck disable=SC1090
 source "$CONFIG_FILE"
@@ -24,29 +27,27 @@ if (( ${#patched_candidates[@]} != 1 )); then
 fi
 PATCHED_JAR=${patched_candidates[0]}
 
-# Remove only cached JDT UI binary/source artifacts so the following Tycho
-# resolution proves what the checked-in 2025-12 target selects in this run.
-while IFS= read -r cached; do
-  rm -f "$cached"
-done < <(find "$MAVEN_REPOSITORY" -type f \
-  \( -name 'org.eclipse.jdt.ui_*.jar' -o -name 'org.eclipse.jdt.ui-*.jar' \) 2>/dev/null)
+# Use an isolated local Maven repository. Scanning a shared Actions cache cannot
+# prove which JDT UI version the checked-in target selected because stale target
+# artifacts from earlier Eclipse releases may coexist there.
+rm -rf "$MAVEN_REPOSITORY"
+mkdir -p "$MAVEN_REPOSITORY"
 
 mvn --batch-mode -ntp -f "$ROOT_DIR/pom.xml" \
+  -Dmaven.repo.local="$MAVEN_REPOSITORY" \
   -pl sandbox_common -am \
   -DskipTests -DskipITs -Dspotbugs.skip=true -Dlicense.skip=true \
   package
 
-mapfile -t named_candidates < <(find "$MAVEN_REPOSITORY" -type f \
-  \( -name 'org.eclipse.jdt.ui_*.jar' -o -name 'org.eclipse.jdt.ui-*.jar' \) \
-  ! -name '*-sources.jar' ! -name '*-javadoc.jar' 2>/dev/null | sort)
-if (( ${#named_candidates[@]} == 0 )); then
-  echo "Tycho resolved the target, but no cached org.eclipse.jdt.ui candidate was found" >&2
+# Tycho's p2 cache does not guarantee Maven-style artifact file names. Inspect
+# manifests from every freshly resolved JAR and select the exact symbolic name.
+CANDIDATE_LIST="$REPORT_DIR/resolved-jars.txt"
+find "$MAVEN_REPOSITORY" -type f -name '*.jar' \
+  ! -name '*-sources.jar' ! -name '*-javadoc.jar' -print | sort > "$CANDIDATE_LIST"
+if [[ ! -s "$CANDIDATE_LIST" ]]; then
+  echo "Tycho resolved no JAR artifacts into the isolated Maven repository" >&2
   exit 1
 fi
-
-mkdir -p "$REPORT_DIR"
-CANDIDATE_LIST="$REPORT_DIR/stock-candidates.txt"
-printf '%s\n' "${named_candidates[@]}" > "$CANDIDATE_LIST"
 
 python3 - "$PATCHED_JAR" "$CANDIDATE_LIST" "$REPORT_DIR" "$PATCHED_JDT_UI_BUNDLE" <<'PY'
 import hashlib
@@ -132,6 +133,7 @@ def split_clauses(value: str) -> list[str]:
 def clause_names(value: str) -> set[str]:
     return {clause.split(';', 1)[0].strip() for clause in split_clauses(value)}
 
+
 patched_manifest = manifest(patched_path)
 if symbolic_name(patched_manifest) != expected_symbolic_name:
     raise SystemExit(f'Patched bundle has unexpected symbolic name: {symbolic_name(patched_manifest)!r}')
@@ -140,14 +142,18 @@ stock: list[tuple[Path, dict[str, str]]] = []
 for candidate in candidate_paths:
     try:
         headers = manifest(candidate)
-    except (KeyError, zipfile.BadZipFile):
+    except (KeyError, UnicodeDecodeError, zipfile.BadZipFile):
         continue
     if symbolic_name(headers) == expected_symbolic_name:
         stock.append((candidate, headers))
 
 versions = sorted({headers.get('Bundle-Version', '') for _, headers in stock})
 if len(versions) != 1:
-    raise SystemExit(f'Expected exactly one resolved stock {expected_symbolic_name} version, found {versions}')
+    locations = [str(path) for path, _ in stock]
+    raise SystemExit(
+        f'Expected exactly one freshly resolved stock {expected_symbolic_name} version, '
+        f'found {versions}; matching artifacts={locations}'
+    )
 stock_version = versions[0]
 stock_candidates = [(path, headers) for path, headers in stock if headers.get('Bundle-Version', '') == stock_version]
 stock_path, stock_manifest = stock_candidates[0]
@@ -155,8 +161,10 @@ patched_version = patched_manifest.get('Bundle-Version', '')
 
 checks: list[dict[str, object]] = []
 
+
 def check(name: str, passed: bool, detail: str) -> None:
     checks.append({'name': name, 'passed': passed, 'detail': detail})
+
 
 try:
     newer = version_key(patched_version) > version_key(stock_version)

--- a/.github/workflows/patched-jdt-ui-bundle.yml
+++ b/.github/workflows/patched-jdt-ui-bundle.yml
@@ -1,0 +1,54 @@
+name: Patched JDT UI Bundle
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '.github/patched-jdt-ui.env'
+      - '.github/scripts/build_patched_jdt_ui.sh'
+      - '.github/workflows/patched-jdt-ui-bundle.yml'
+      - 'docs/patched-jdt-ui-delivery.md'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+      - uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1
+        with:
+          maven-version: 3.9.14
+      - name: Build and verify pinned replacement bundle
+        shell: bash
+        run: |
+          set +e
+          bash .github/scripts/build_patched_jdt_ui.sh "$RUNNER_TEMP/patched-jdt-ui" \
+            > patched-jdt-ui-build.log 2>&1
+          status=$?
+          tail -n 250 patched-jdt-ui-build.log
+          exit "$status"
+      - name: Upload build diagnostics
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: patched-jdt-ui-build-log
+          path: patched-jdt-ui-build.log
+          retention-days: 2
+          if-no-files-found: error
+      - name: Upload verified bundle and provenance
+        if: success()
+        uses: actions/upload-artifact@v7
+        with:
+          name: patched-jdt-ui-${{ github.sha }}
+          path: ${{ runner.temp }}/patched-jdt-ui/
+          retention-days: 14
+          if-no-files-found: error

--- a/.github/workflows/patched-jdt-ui-bundle.yml
+++ b/.github/workflows/patched-jdt-ui-bundle.yml
@@ -57,17 +57,18 @@ jobs:
   target-compatibility:
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'
-          cache: maven
       - uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1
         with:
           maven-version: 3.9.14
+      - name: Prepare compatibility evidence directory
+        run: mkdir -p "$RUNNER_TEMP/patched-jdt-ui-compatibility"
       - name: Download verified replacement bundle
         uses: actions/download-artifact@v7
         with:
@@ -80,18 +81,34 @@ jobs:
             "$RUNNER_TEMP/patched-jdt-ui" \
             "$RUNNER_TEMP/patched-jdt-ui-compatibility"
       - name: Publish compatibility summary
+        if: always()
         shell: bash
         run: |
-          cat "$RUNNER_TEMP/patched-jdt-ui-compatibility/compatibility.md" >> "$GITHUB_STEP_SUMMARY"
-          if ! python3 - "$RUNNER_TEMP/patched-jdt-ui-compatibility/compatibility.json" <<'PY'
+          report="$RUNNER_TEMP/patched-jdt-ui-compatibility/compatibility.md"
+          result="$RUNNER_TEMP/patched-jdt-ui-compatibility/compatibility.json"
+          log="$RUNNER_TEMP/patched-jdt-ui-compatibility/compatibility-build.log"
+          if [[ -s "$report" && -s "$result" ]]; then
+            cat "$report" >> "$GITHUB_STEP_SUMMARY"
+            if ! python3 - "$result" <<'PY'
           import json
           import sys
           with open(sys.argv[1], encoding='utf-8') as stream:
               compatible = json.load(stream)['compatibleForReplacement']
           raise SystemExit(0 if compatible else 1)
           PY
-          then
-            echo '::warning::The pinned bundle is not yet eligible for p2 replacement. The report records the exact stock-target incompatibility; publication remains disabled.'
+            then
+              echo '::warning::The pinned bundle is not yet eligible for p2 replacement. The report records the exact stock-target incompatibility; publication remains disabled.'
+            fi
+          else
+            {
+              echo '### Patched JDT UI target compatibility'
+              echo
+              echo '**ERROR:** target resolution or manifest inspection did not produce a compatibility report.'
+              echo
+              echo '```text'
+              tail -n 120 "$log" 2>/dev/null || echo 'No compatibility log was produced.'
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
           fi
       - name: Upload stock-target compatibility report
         if: always()
@@ -100,4 +117,4 @@ jobs:
           name: patched-jdt-ui-target-compatibility-${{ github.sha }}
           path: ${{ runner.temp }}/patched-jdt-ui-compatibility/
           retention-days: 14
-          if-no-files-found: error
+          if-no-files-found: warn

--- a/.github/workflows/patched-jdt-ui-bundle.yml
+++ b/.github/workflows/patched-jdt-ui-bundle.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - '.github/patched-jdt-ui.env'
       - '.github/scripts/build_patched_jdt_ui.sh'
+      - '.github/scripts/compare_patched_jdt_ui_with_target.sh'
       - '.github/workflows/patched-jdt-ui-bundle.yml'
       - 'docs/patched-jdt-ui-delivery.md'
 
@@ -50,5 +51,53 @@ jobs:
         with:
           name: patched-jdt-ui-${{ github.sha }}
           path: ${{ runner.temp }}/patched-jdt-ui/
+          retention-days: 14
+          if-no-files-found: error
+
+  target-compatibility:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+      - uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1
+        with:
+          maven-version: 3.9.14
+      - name: Download verified replacement bundle
+        uses: actions/download-artifact@v7
+        with:
+          name: patched-jdt-ui-${{ github.sha }}
+          path: ${{ runner.temp }}/patched-jdt-ui
+      - name: Resolve the Sandbox target and compare manifests
+        shell: bash
+        run: |
+          bash .github/scripts/compare_patched_jdt_ui_with_target.sh \
+            "$RUNNER_TEMP/patched-jdt-ui" \
+            "$RUNNER_TEMP/patched-jdt-ui-compatibility"
+      - name: Publish compatibility summary
+        shell: bash
+        run: |
+          cat "$RUNNER_TEMP/patched-jdt-ui-compatibility/compatibility.md" >> "$GITHUB_STEP_SUMMARY"
+          if ! python3 - "$RUNNER_TEMP/patched-jdt-ui-compatibility/compatibility.json" <<'PY'
+          import json
+          import sys
+          with open(sys.argv[1], encoding='utf-8') as stream:
+              compatible = json.load(stream)['compatibleForReplacement']
+          raise SystemExit(0 if compatible else 1)
+          PY
+          then
+            echo '::warning::The pinned bundle is not yet eligible for p2 replacement. The report records the exact stock-target incompatibility; publication remains disabled.'
+          fi
+      - name: Upload stock-target compatibility report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: patched-jdt-ui-target-compatibility-${{ github.sha }}
+          path: ${{ runner.temp }}/patched-jdt-ui-compatibility/
           retention-days: 14
           if-no-files-found: error

--- a/docs/patched-jdt-ui-delivery.md
+++ b/docs/patched-jdt-ui-delivery.md
@@ -1,0 +1,45 @@
+# Patched JDT UI delivery
+
+## Purpose
+
+The normal Sandbox target and cleanup test reactor use the stock Eclipse JDT UI bundle. Automatic multi-file cleanup scope expansion is an optional product capability that requires a reviewed replacement of the singleton `org.eclipse.jdt.ui` bundle.
+
+This document covers the reproducible source-bundle stage only. Minimal p2 publication, exact-IU resolution, product startup and stock-versus-patched smoke tests remain tracked in #1209 and #1215.
+
+## Pinned source
+
+The immutable coordinates are stored in `.github/patched-jdt-ui.env`:
+
+- repository: `https://github.com/carstenartur/eclipse.jdt.ui.git`;
+- commit: `450bfd46089c99608dd60203e1257e1c329ad2c5`;
+- bundle: `org.eclipse.jdt.ui`;
+- expected base version: `3.39.0`.
+
+The commit is the merged result of `carstenartur/eclipse.jdt.ui#95`. Its fork synchronization manifest preserves both the modified `CleanUpRefactoring.java` source and `MultiFileCleanUpScopeExpansionTest.java`.
+
+## Local rebuild
+
+Requirements are Git, Java 21, Maven 3.9.x, JDK tools, Python 3 and access to the pinned fork plus Eclipse build repositories.
+
+```bash
+bash .github/scripts/build_patched_jdt_ui.sh target/patched-jdt-ui
+```
+
+The script:
+
+1. fetches and checks out only the exact 40-character commit;
+2. verifies the productive patch source, PDE test and synchronization entries;
+3. invokes the upstream `build-individual-bundles` Maven profile for `org.eclipse.jdt.ui`;
+4. requires exactly one non-source bundle artifact;
+5. validates the singleton bundle symbolic name;
+6. requires a qualified `3.39.0.*` OSGi version;
+7. verifies the compiled `CleanUpRefactoring` contains the scope-expansion marker;
+8. emits the bundle, manifest evidence and `provenance.json` with SHA-256.
+
+Generated JARs are not committed. CI publishes the verified output as a short-lived artifact.
+
+## Trust boundary
+
+Passing this stage proves the source revision, patch paths, singleton identity, compiled capability marker and artifact checksum. It deliberately does not yet prove p2 replacement selection, product installation/startup, runtime cleanup expansion or rollback. Those checks belong to the p2/product stages before an installation channel is published.
+
+The stock target remains the default and has no dependency on this optional bundle artifact.

--- a/docs/patched-jdt-ui-delivery.md
+++ b/docs/patched-jdt-ui-delivery.md
@@ -4,7 +4,7 @@
 
 The normal Sandbox target and cleanup test reactor use the stock Eclipse JDT UI bundle. Automatic multi-file cleanup scope expansion is an optional product capability that requires a reviewed replacement of the singleton `org.eclipse.jdt.ui` bundle.
 
-This document covers the reproducible source-bundle stage only. Minimal p2 publication, exact-IU resolution, product startup and stock-versus-patched smoke tests remain tracked in #1209 and #1215.
+This document covers the reproducible source-bundle and stock-target compatibility stages. Minimal p2 publication, exact-IU product resolution, product startup and stock-versus-patched runtime smoke tests remain tracked in #1209 and #1215.
 
 ## Pinned source
 
@@ -38,8 +38,31 @@ The script:
 
 Generated JARs are not committed. CI publishes the verified output as a short-lived artifact.
 
+## Stock-target compatibility gate
+
+After building the bundle, CI runs:
+
+```bash
+bash .github/scripts/compare_patched_jdt_ui_with_target.sh \
+  target/patched-jdt-ui \
+  target/patched-jdt-ui-compatibility
+```
+
+The comparison removes only cached `org.eclipse.jdt.ui` artifacts, resolves `sandbox_target/eclipse.target` through the normal Tycho build and identifies the single stock JDT UI bundle selected from Eclipse 2025-12. It then records:
+
+- the exact stock and patched OSGi versions and SHA-256 checksums;
+- whether the patched version is strictly newer, as required for singleton replacement;
+- normalized differences in `Bundle-RequiredExecutionEnvironment`, `Require-Bundle` and `Import-Package`;
+- whether every stock `Export-Package` remains present in the patched bundle.
+
+Results are written to `compatibility.json` and `compatibility.md` and uploaded as a workflow artifact. A blocked result is emitted as an Actions warning and prevents the next p2-publication stage from being introduced. The source-bundle job may still remain green because it proves a different property: reproducibility of the pinned source build.
+
+The comparison is deliberately strict. A manifest difference is treated as unresolved compatibility work rather than assumed safe. Once the report passes, the next stage can publish a minimal p2 repository and prove exact IU selection in a patched product.
+
 ## Trust boundary
 
-Passing this stage proves the source revision, patch paths, singleton identity, compiled capability marker and artifact checksum. It deliberately does not yet prove p2 replacement selection, product installation/startup, runtime cleanup expansion or rollback. Those checks belong to the p2/product stages before an installation channel is published.
+Passing the source-bundle stage proves the source revision, patch paths, singleton identity, compiled capability marker and artifact checksum. Passing the compatibility stage additionally proves that the resolved 2025-12 stock bundle can be replaced without changing its declared execution environment, imports, required bundles or exported package surface under the current strict policy.
+
+Neither stage proves p2 installation, product startup, runtime cleanup expansion, apply/undo behavior or rollback. Those checks belong to the p2/product stages before an installation channel is published.
 
 The stock target remains the default and has no dependency on this optional bundle artifact.


### PR DESCRIPTION
## Summary

Implements the reproducible source-bundle stage and an automated fail-closed compatibility assessment for the optional patched JDT UI product.

## Changes

- pin the reviewed fork source to immutable commit `450bfd46089c99608dd60203e1257e1c329ad2c5`;
- build `org.eclipse.jdt.ui` through the upstream `build-individual-bundles` profile;
- verify productive patch source, PDE scope-expansion test and fork synchronization entries before building;
- require the expected singleton symbolic name and a qualified `3.39.0.*` bundle version;
- inspect the compiled `CleanUpRefactoring` for the scope-expansion capability marker;
- publish only a short-lived CI artifact containing the bundle, manifest evidence and SHA-256 provenance;
- resolve the checked-in Eclipse 2025-12 target in a separate job and identify its exact stock `org.eclipse.jdt.ui` bundle;
- compare replacement-version ordering, execution environment, required bundles, imported packages and exported-package coverage;
- upload machine-readable JSON and Markdown compatibility evidence and warn when p2 replacement remains blocked;
- document the trust boundary and keep the normal Sandbox target independent of the fork.

## Remaining #1209 work

This PR deliberately does not create or publish a p2 repository. Publication is allowed only after the strict stock-target report passes. The subsequent stages must publish an exact-version feature/IU, prove singleton selection, build/start a patched product, exercise scope expansion/apply/undo and retain a stock-product regression and rollback path.

Refs #1209
Refs #1215.