### PR TITLE
Restore candidate-gated coordinated cleanup scope

### DIFF
--- a/sandbox_int_to_enum/src/org/sandbox/jdt/internal/corext/fix/multifile/IntEnumScopeCandidateDetector.java
+++ b/sandbox_int_to_enum/src/org/sandbox/jdt/internal/corext/fix/multifile/IntEnumScopeCandidateDetector.java
@@ -158,6 +158,7 @@ public final class IntEnumScopeCandidateDetector {
 			if (unit != null && unit.exists() && project.equals(unit.getJavaProject())) {
 				units.add(unit.getPrimary());
 			}
+		}
 		return units;
 	}
 

--- a/sandbox_int_to_enum/src/org/sandbox/jdt/internal/corext/fix/multifile/IntEnumScopeCandidateDetector.java
+++ b/sandbox_int_to_enum/src/org/sandbox/jdt/internal/corext/fix/multifile/IntEnumScopeCandidateDetector.java
@@ -22,6 +22,7 @@ import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.dom.ASTParser;
 import org.eclipse.jdt.core.dom.ASTRequestor;
 import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.CompilationUnit;
@@ -36,7 +37,6 @@ import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
 import org.eclipse.jdt.core.dom.Type;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
-import org.eclipse.jdt.core.dom.ASTParser;
 import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
 
 /** Lightweight selected-scope detector for project-wide Int-to-Enum planning. */
@@ -61,41 +61,31 @@ public final class IntEnumScopeCandidateDetector {
 
 	/**
 	 * Finds the candidate methods and constants whose references define the
-	 * coordinated source closure. A structural candidate with a missing binding is
-	 * reported as incomplete so the caller can use its conservative fallback.
+	 * coordinated source closure. Candidate recognition deliberately uses a first,
+	 * binding-independent parse. Binding resolution is a second refinement step;
+	 * when it cannot reproduce or resolve the structural candidate, the result stays
+	 * a candidate but is marked incomplete so the caller uses the conservative
+	 * complete-policy fallback instead of silently suppressing the cleanup.
 	 */
 	public static SearchSeeds findSearchSeeds(IJavaProject project, Collection<ICompilationUnit> currentScope,
 			IProgressMonitor monitor) {
-		if (project == null || currentScope == null || currentScope.isEmpty()) {
-			return new SearchSeeds(false, true, List.of());
-		}
-		checkCanceled(monitor);
-		Set<ICompilationUnit> units= new LinkedHashSet<>();
-		for (ICompilationUnit unit : currentScope) {
-			if (unit != null && unit.exists() && project.equals(unit.getJavaProject())) {
-				units.add(unit.getPrimary());
-			}
-		}
-		if (units.isEmpty()) {
+		Set<ICompilationUnit> units= normalize(project, currentScope);
+		if (units.isEmpty() || !containsStructuralCandidate(project, units, monitor)) {
 			return new SearchSeeds(false, true, List.of());
 		}
 
-		boolean[] candidateFound= { false };
+		checkCanceled(monitor);
+		boolean[] resolvedCandidate= { false };
 		boolean[] complete= { true };
 		Set<IJavaElement> elements= new LinkedHashSet<>();
-		ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
-		parser.setProject(project);
-		parser.setResolveBindings(true);
-		parser.setBindingsRecovery(IASTSharedValues.SHARED_BINDING_RECOVERY);
-		parser.setStatementsRecovery(IASTSharedValues.SHARED_AST_STATEMENT_RECOVERY);
+		ASTParser parser= newParser(project, true);
 		parser.createASTs(units.toArray(ICompilationUnit[]::new), new String[0], new ASTRequestor() {
 			@Override
 			public void acceptAST(ICompilationUnit source, CompilationUnit ast) {
 				ast.accept(new ASTVisitor() {
 					@Override
 					public boolean visit(TypeDeclaration type) {
-						if (!(type.getParent() instanceof CompilationUnit) || type.isInterface()
-								|| type.getSuperclassType() != null || !type.superInterfaceTypes().isEmpty()) {
+						if (!isCandidateOwner(type)) {
 							return false;
 						}
 						List<VariableDeclarationFragment> constants= packagePrivateIntConstants(type);
@@ -103,7 +93,7 @@ public final class IntEnumScopeCandidateDetector {
 						if (constants.size() < 2 || methods.isEmpty()) {
 							return false;
 						}
-						candidateFound[0]= true;
+						resolvedCandidate[0]= true;
 						for (VariableDeclarationFragment constant : constants) {
 							IVariableBinding binding= constant.resolveBinding();
 							complete[0]&= addJavaElement(binding, elements);
@@ -118,7 +108,62 @@ public final class IntEnumScopeCandidateDetector {
 			}
 		}, monitor);
 		checkCanceled(monitor);
-		return new SearchSeeds(candidateFound[0], complete[0], new ArrayList<>(elements));
+		return new SearchSeeds(true, complete[0] && resolvedCandidate[0], new ArrayList<>(elements));
+	}
+
+	private static boolean containsStructuralCandidate(IJavaProject project, Set<ICompilationUnit> units,
+			IProgressMonitor monitor) {
+		checkCanceled(monitor);
+		boolean[] candidate= { false };
+		ASTParser parser= newParser(project, false);
+		parser.createASTs(units.toArray(ICompilationUnit[]::new), new String[0], new ASTRequestor() {
+			@Override
+			public void acceptAST(ICompilationUnit source, CompilationUnit ast) {
+				if (candidate[0]) {
+					return;
+				}
+				ast.accept(new ASTVisitor() {
+					@Override
+					public boolean visit(TypeDeclaration type) {
+						if (isCandidateOwner(type)
+								&& packagePrivateIntConstants(type).size() >= 2
+								&& !packagePrivateIntStateMethods(type).isEmpty()) {
+							candidate[0]= true;
+						}
+						return false;
+					}
+				});
+			}
+		}, monitor);
+		checkCanceled(monitor);
+		return candidate[0];
+	}
+
+	private static ASTParser newParser(IJavaProject project, boolean resolveBindings) {
+		ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
+		parser.setProject(project);
+		parser.setResolveBindings(resolveBindings);
+		parser.setBindingsRecovery(resolveBindings && IASTSharedValues.SHARED_BINDING_RECOVERY);
+		parser.setStatementsRecovery(IASTSharedValues.SHARED_AST_STATEMENT_RECOVERY);
+		return parser;
+	}
+
+	private static Set<ICompilationUnit> normalize(IJavaProject project,
+			Collection<ICompilationUnit> currentScope) {
+		Set<ICompilationUnit> units= new LinkedHashSet<>();
+		if (project == null || currentScope == null) {
+			return units;
+		}
+		for (ICompilationUnit unit : currentScope) {
+			if (unit != null && unit.exists() && project.equals(unit.getJavaProject())) {
+				units.add(unit.getPrimary());
+			}
+		return units;
+	}
+
+	private static boolean isCandidateOwner(TypeDeclaration type) {
+		return type.getParent() instanceof CompilationUnit && !type.isInterface()
+				&& type.getSuperclassType() == null && type.superInterfaceTypes().isEmpty();
 	}
 
 	private static List<VariableDeclarationFragment> packagePrivateIntConstants(TypeDeclaration type) {

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnitScopeCandidateDetector.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnitScopeCandidateDetector.java
@@ -59,34 +59,23 @@ public final class JUnitScopeCandidateDetector {
 
 	/**
 	 * Finds source resource types referenced by selected declarations or Rule fields.
-	 * Syntactically recognizable candidates with missing bindings are marked
-	 * incomplete so callers preserve the existing complete-policy fallback.
+	 * Candidate recognition deliberately runs first without binding resolution. The
+	 * second pass refines that structural result into exact Java elements. Missing
+	 * bindings therefore produce an incomplete candidate and conservative fallback,
+	 * never a false negative that suppresses scope expansion entirely.
 	 */
 	public static SearchSeeds findSearchSeeds(IJavaProject project, Collection<ICompilationUnit> currentScope,
 			IProgressMonitor monitor) {
-		if (project == null || currentScope == null || currentScope.isEmpty()) {
-			return new SearchSeeds(false, true, List.of());
-		}
-		checkCanceled(monitor);
-		Set<ICompilationUnit> units= new LinkedHashSet<>();
-		for (ICompilationUnit unit : currentScope) {
-			if (unit != null && unit.exists() && project.equals(unit.getJavaProject())) {
-				units.add(unit.getPrimary());
-			}
-		}
-		if (units.isEmpty()) {
+		Set<ICompilationUnit> units= normalize(project, currentScope);
+		if (units.isEmpty() || !containsStructuralCandidate(project, units, monitor)) {
 			return new SearchSeeds(false, true, List.of());
 		}
 
-		boolean[] candidateFound= { false };
+		checkCanceled(monitor);
+		boolean[] resolvedCandidate= { false };
 		boolean[] complete= { true };
 		Set<IJavaElement> elements= new LinkedHashSet<>();
-		ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
-		parser.setProject(project);
-		parser.setResolveBindings(true);
-		parser.setBindingsRecovery(IASTSharedValues.SHARED_BINDING_RECOVERY);
-		parser.setStatementsRecovery(IASTSharedValues.SHARED_AST_STATEMENT_RECOVERY);
-		parser.setCompilerOptions(RefactoringASTParser.getCompilerOptions(project));
+		ASTParser parser= newParser(project, true);
 		parser.createASTs(units.toArray(ICompilationUnit[]::new), new String[0], new ASTRequestor() {
 			@Override
 			public void acceptAST(ICompilationUnit source, CompilationUnit ast) {
@@ -97,13 +86,13 @@ public final class JUnitScopeCandidateDetector {
 						ITypeBinding superclass= binding == null ? null : binding.getSuperclass();
 						if (superclass != null && ORG_JUNIT_RULES_EXTERNAL_RESOURCE.equals(
 								superclass.getErasure().getQualifiedName())) {
-							candidateFound[0]= true;
+							resolvedCandidate[0]= true;
 							complete[0]&= addJavaElement(binding, elements);
 							return false;
 						}
-						if (binding == null && node.getSuperclassType() != null
+						if (node.getSuperclassType() != null
 								&& "ExternalResource".equals(simpleName(node.getSuperclassType().toString()))) { //$NON-NLS-1$
-							candidateFound[0]= true;
+							resolvedCandidate[0]= true;
 							complete[0]= false;
 						}
 						return true;
@@ -130,7 +119,7 @@ public final class JUnitScopeCandidateDetector {
 						if (!ruleField) {
 							return true;
 						}
-						candidateFound[0]= true;
+						resolvedCandidate[0]= true;
 						if (unresolvedRuleAnnotation) {
 							complete[0]= false;
 						}
@@ -142,7 +131,70 @@ public final class JUnitScopeCandidateDetector {
 			}
 		}, monitor);
 		checkCanceled(monitor);
-		return new SearchSeeds(candidateFound[0], complete[0], new ArrayList<>(elements));
+		return new SearchSeeds(true, complete[0] && resolvedCandidate[0], new ArrayList<>(elements));
+	}
+
+	private static boolean containsStructuralCandidate(IJavaProject project, Set<ICompilationUnit> units,
+			IProgressMonitor monitor) {
+		checkCanceled(monitor);
+		boolean[] candidate= { false };
+		ASTParser parser= newParser(project, false);
+		parser.createASTs(units.toArray(ICompilationUnit[]::new), new String[0], new ASTRequestor() {
+			@Override
+			public void acceptAST(ICompilationUnit source, CompilationUnit ast) {
+				if (candidate[0]) {
+					return;
+				}
+				ast.accept(new ASTVisitor() {
+					@Override
+					public boolean visit(TypeDeclaration node) {
+						if (node.getSuperclassType() != null
+								&& "ExternalResource".equals(simpleName(node.getSuperclassType().toString()))) { //$NON-NLS-1$
+							candidate[0]= true;
+							return false;
+						}
+						return true;
+					}
+
+					@Override
+					public boolean visit(FieldDeclaration node) {
+						for (Object modifier : node.modifiers()) {
+							if (modifier instanceof Annotation annotation
+									&& isSyntacticRuleName(annotation.getTypeName().getFullyQualifiedName())) {
+								candidate[0]= true;
+								break;
+							}
+						}
+						return !candidate[0];
+					}
+				});
+			}
+		}, monitor);
+		checkCanceled(monitor);
+		return candidate[0];
+	}
+
+	private static ASTParser newParser(IJavaProject project, boolean resolveBindings) {
+		ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
+		parser.setProject(project);
+		parser.setResolveBindings(resolveBindings);
+		parser.setBindingsRecovery(resolveBindings && IASTSharedValues.SHARED_BINDING_RECOVERY);
+		parser.setStatementsRecovery(IASTSharedValues.SHARED_AST_STATEMENT_RECOVERY);
+		parser.setCompilerOptions(RefactoringASTParser.getCompilerOptions(project));
+		return parser;
+	}
+
+	private static Set<ICompilationUnit> normalize(IJavaProject project,
+			Collection<ICompilationUnit> currentScope) {
+		Set<ICompilationUnit> units= new LinkedHashSet<>();
+		if (project == null || currentScope == null) {
+			return units;
+		}
+		for (ICompilationUnit unit : currentScope) {
+			if (unit != null && unit.exists() && project.equals(unit.getJavaProject())) {
+				units.add(unit.getPrimary());
+			}
+		return units;
 	}
 
 	private static boolean isSyntacticRuleName(String name) {

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnitScopeCandidateDetector.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnitScopeCandidateDetector.java
@@ -59,23 +59,24 @@ public final class JUnitScopeCandidateDetector {
 
 	/**
 	 * Finds source resource types referenced by selected declarations or Rule fields.
-	 * Candidate recognition deliberately runs first without binding resolution. The
-	 * second pass refines that structural result into exact Java elements. Missing
-	 * bindings therefore produce an incomplete candidate and conservative fallback,
-	 * never a false negative that suppresses scope expansion entirely.
+	 * Syntactic recognition and binding refinement deliberately happen in the same
+	 * AST pass. Eclipse working copies can still expose their source structure when
+	 * individual bindings are missing or recovered. Such candidates are marked
+	 * incomplete so callers retain the conservative complete-policy fallback instead
+	 * of silently suppressing scope expansion.
 	 */
 	public static SearchSeeds findSearchSeeds(IJavaProject project, Collection<ICompilationUnit> currentScope,
 			IProgressMonitor monitor) {
 		Set<ICompilationUnit> units= normalize(project, currentScope);
-		if (units.isEmpty() || !containsStructuralCandidate(project, units, monitor)) {
+		if (units.isEmpty()) {
 			return new SearchSeeds(false, true, List.of());
 		}
 
 		checkCanceled(monitor);
-		boolean[] resolvedCandidate= { false };
+		boolean[] candidateFound= { false };
 		boolean[] complete= { true };
 		Set<IJavaElement> elements= new LinkedHashSet<>();
-		ASTParser parser= newParser(project, true);
+		ASTParser parser= newParser(project);
 		parser.createASTs(units.toArray(ICompilationUnit[]::new), new String[0], new ASTRequestor() {
 			@Override
 			public void acceptAST(ICompilationUnit source, CompilationUnit ast) {
@@ -86,14 +87,15 @@ public final class JUnitScopeCandidateDetector {
 						ITypeBinding superclass= binding == null ? null : binding.getSuperclass();
 						if (superclass != null && ORG_JUNIT_RULES_EXTERNAL_RESOURCE.equals(
 								superclass.getErasure().getQualifiedName())) {
-							resolvedCandidate[0]= true;
+							candidateFound[0]= true;
 							complete[0]&= addJavaElement(binding, elements);
 							return false;
 						}
 						if (node.getSuperclassType() != null
 								&& "ExternalResource".equals(simpleName(node.getSuperclassType().toString()))) { //$NON-NLS-1$
-							resolvedCandidate[0]= true;
+							candidateFound[0]= true;
 							complete[0]= false;
+							return false;
 						}
 						return true;
 					}
@@ -101,7 +103,7 @@ public final class JUnitScopeCandidateDetector {
 					@Override
 					public boolean visit(FieldDeclaration node) {
 						boolean ruleField= false;
-						boolean unresolvedRuleAnnotation= false;
+						boolean incompleteRuleAnnotation= false;
 						for (Object modifier : node.modifiers()) {
 							if (!(modifier instanceof Annotation annotation)) {
 								continue;
@@ -109,18 +111,21 @@ public final class JUnitScopeCandidateDetector {
 							ITypeBinding annotationBinding= annotation.resolveTypeBinding();
 							if (annotationBinding != null) {
 								String qualifiedName= annotationBinding.getQualifiedName();
-								ruleField|= ORG_JUNIT_RULE.equals(qualifiedName)
-										|| ORG_JUNIT_CLASS_RULE.equals(qualifiedName);
-							} else if (isSyntacticRuleName(annotation.getTypeName().getFullyQualifiedName())) {
+								if (ORG_JUNIT_RULE.equals(qualifiedName) || ORG_JUNIT_CLASS_RULE.equals(qualifiedName)) {
+									ruleField= true;
+									continue;
+								}
+							}
+							if (isSyntacticRuleName(annotation.getTypeName().getFullyQualifiedName())) {
 								ruleField= true;
-								unresolvedRuleAnnotation= true;
+								incompleteRuleAnnotation= true;
 							}
 						}
 						if (!ruleField) {
 							return true;
 						}
-						resolvedCandidate[0]= true;
-						if (unresolvedRuleAnnotation) {
+						candidateFound[0]= true;
+						if (incompleteRuleAnnotation) {
 							complete[0]= false;
 						}
 						ITypeBinding fieldType= node.getType().resolveBinding();
@@ -131,54 +136,14 @@ public final class JUnitScopeCandidateDetector {
 			}
 		}, monitor);
 		checkCanceled(monitor);
-		return new SearchSeeds(true, complete[0] && resolvedCandidate[0], new ArrayList<>(elements));
+		return new SearchSeeds(candidateFound[0], complete[0], new ArrayList<>(elements));
 	}
 
-	private static boolean containsStructuralCandidate(IJavaProject project, Set<ICompilationUnit> units,
-			IProgressMonitor monitor) {
-		checkCanceled(monitor);
-		boolean[] candidate= { false };
-		ASTParser parser= newParser(project, false);
-		parser.createASTs(units.toArray(ICompilationUnit[]::new), new String[0], new ASTRequestor() {
-			@Override
-			public void acceptAST(ICompilationUnit source, CompilationUnit ast) {
-				if (candidate[0]) {
-					return;
-				}
-				ast.accept(new ASTVisitor() {
-					@Override
-					public boolean visit(TypeDeclaration node) {
-						if (node.getSuperclassType() != null
-								&& "ExternalResource".equals(simpleName(node.getSuperclassType().toString()))) { //$NON-NLS-1$
-							candidate[0]= true;
-							return false;
-						}
-						return true;
-					}
-
-					@Override
-					public boolean visit(FieldDeclaration node) {
-						for (Object modifier : node.modifiers()) {
-							if (modifier instanceof Annotation annotation
-									&& isSyntacticRuleName(annotation.getTypeName().getFullyQualifiedName())) {
-								candidate[0]= true;
-								break;
-							}
-						}
-						return !candidate[0];
-					}
-				});
-			}
-		}, monitor);
-		checkCanceled(monitor);
-		return candidate[0];
-	}
-
-	private static ASTParser newParser(IJavaProject project, boolean resolveBindings) {
+	private static ASTParser newParser(IJavaProject project) {
 		ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
 		parser.setProject(project);
-		parser.setResolveBindings(resolveBindings);
-		parser.setBindingsRecovery(resolveBindings && IASTSharedValues.SHARED_BINDING_RECOVERY);
+		parser.setResolveBindings(true);
+		parser.setBindingsRecovery(IASTSharedValues.SHARED_BINDING_RECOVERY);
 		parser.setStatementsRecovery(IASTSharedValues.SHARED_AST_STATEMENT_RECOVERY);
 		parser.setCompilerOptions(RefactoringASTParser.getCompilerOptions(project));
 		return parser;
@@ -192,7 +157,10 @@ public final class JUnitScopeCandidateDetector {
 		}
 		for (ICompilationUnit unit : currentScope) {
 			if (unit != null && unit.exists() && project.equals(unit.getJavaProject())) {
-				units.add(unit.getPrimary());
+				ICompilationUnit primary= unit.getPrimary();
+				if (primary != null) {
+					units.add(primary);
+				}
 			}
 		}
 		return units;

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnitScopeCandidateDetector.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnitScopeCandidateDetector.java
@@ -194,6 +194,7 @@ public final class JUnitScopeCandidateDetector {
 			if (unit != null && unit.exists() && project.equals(unit.getJavaProject())) {
 				units.add(unit.getPrimary());
 			}
+		}
 		return units;
 	}
 

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnitScopeCandidateDetector.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnitScopeCandidateDetector.java
@@ -26,6 +26,7 @@ import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.ASTParser;
 import org.eclipse.jdt.core.dom.ASTRequestor;
 import org.eclipse.jdt.core.dom.ASTVisitor;
@@ -59,11 +60,12 @@ public final class JUnitScopeCandidateDetector {
 
 	/**
 	 * Finds source resource types referenced by selected declarations or Rule fields.
-	 * Syntactic recognition and binding refinement deliberately happen in the same
-	 * AST pass. Eclipse working copies can still expose their source structure when
-	 * individual bindings are missing or recovered. Such candidates are marked
-	 * incomplete so callers retain the conservative complete-policy fallback instead
-	 * of silently suppressing scope expansion.
+	 * The normal binding-aware batch parse provides exact Java elements. Some PDE
+	 * working-copy lifecycles can return an empty or recovered batch AST even though
+	 * the compilation unit source is available. A source-backed syntax parse is then
+	 * used only as a fail-closed gate: it retains {@code candidateFound=true}, marks
+	 * the result incomplete and lets the caller use the conservative source-policy
+	 * fallback rather than silently suppressing coordinated migration.
 	 */
 	public static SearchSeeds findSearchSeeds(IJavaProject project, Collection<ICompilationUnit> currentScope,
 			IProgressMonitor monitor) {
@@ -76,70 +78,129 @@ public final class JUnitScopeCandidateDetector {
 		boolean[] candidateFound= { false };
 		boolean[] complete= { true };
 		Set<IJavaElement> elements= new LinkedHashSet<>();
-		ASTParser parser= newParser(project);
+		ASTParser parser= newBindingParser(project);
 		parser.createASTs(units.toArray(ICompilationUnit[]::new), new String[0], new ASTRequestor() {
 			@Override
 			public void acceptAST(ICompilationUnit source, CompilationUnit ast) {
-				ast.accept(new ASTVisitor() {
-					@Override
-					public boolean visit(TypeDeclaration node) {
-						ITypeBinding binding= node.resolveBinding();
-						ITypeBinding superclass= binding == null ? null : binding.getSuperclass();
-						if (superclass != null && ORG_JUNIT_RULES_EXTERNAL_RESOURCE.equals(
-								superclass.getErasure().getQualifiedName())) {
-							candidateFound[0]= true;
-							complete[0]&= addJavaElement(binding, elements);
-							return false;
-						}
-						if (node.getSuperclassType() != null
-								&& "ExternalResource".equals(simpleName(node.getSuperclassType().toString()))) { //$NON-NLS-1$
-							candidateFound[0]= true;
-							complete[0]= false;
-							return false;
-						}
-						return true;
-					}
-
-					@Override
-					public boolean visit(FieldDeclaration node) {
-						boolean ruleField= false;
-						boolean incompleteRuleAnnotation= false;
-						for (Object modifier : node.modifiers()) {
-							if (!(modifier instanceof Annotation annotation)) {
-								continue;
-							}
-							ITypeBinding annotationBinding= annotation.resolveTypeBinding();
-							if (annotationBinding != null) {
-								String qualifiedName= annotationBinding.getQualifiedName();
-								if (ORG_JUNIT_RULE.equals(qualifiedName) || ORG_JUNIT_CLASS_RULE.equals(qualifiedName)) {
-									ruleField= true;
-									continue;
-								}
-							}
-							if (isSyntacticRuleName(annotation.getTypeName().getFullyQualifiedName())) {
-								ruleField= true;
-								incompleteRuleAnnotation= true;
-							}
-						}
-						if (!ruleField) {
-							return true;
-						}
-						candidateFound[0]= true;
-						if (incompleteRuleAnnotation) {
-							complete[0]= false;
-						}
-						ITypeBinding fieldType= node.getType().resolveBinding();
-						complete[0]&= addJavaElement(fieldType, elements);
-						return true;
-					}
-				});
+				inspectBindingAwareAst(ast, candidateFound, complete, elements);
 			}
 		}, monitor);
 		checkCanceled(monitor);
+
+		if (!candidateFound[0] && containsSourceBackedSyntacticCandidate(project, units, monitor)) {
+			candidateFound[0]= true;
+			complete[0]= false;
+		}
 		return new SearchSeeds(candidateFound[0], complete[0], new ArrayList<>(elements));
 	}
 
-	private static ASTParser newParser(IJavaProject project) {
+	private static void inspectBindingAwareAst(CompilationUnit ast, boolean[] candidateFound,
+			boolean[] complete, Set<IJavaElement> elements) {
+		ast.accept(new ASTVisitor() {
+			@Override
+			public boolean visit(TypeDeclaration node) {
+				ITypeBinding binding= node.resolveBinding();
+				ITypeBinding superclass= binding == null ? null : binding.getSuperclass();
+				if (superclass != null && ORG_JUNIT_RULES_EXTERNAL_RESOURCE.equals(
+						superclass.getErasure().getQualifiedName())) {
+					candidateFound[0]= true;
+					complete[0]&= addJavaElement(binding, elements);
+					return false;
+				}
+				if (isSyntacticExternalResource(node)) {
+					candidateFound[0]= true;
+					complete[0]= false;
+					return false;
+				}
+				return true;
+			}
+
+			@Override
+			public boolean visit(FieldDeclaration node) {
+				boolean ruleField= false;
+				boolean incompleteRuleAnnotation= false;
+				for (Object modifier : node.modifiers()) {
+					if (!(modifier instanceof Annotation annotation)) {
+						continue;
+					}
+					ITypeBinding annotationBinding= annotation.resolveTypeBinding();
+					if (annotationBinding != null) {
+						String qualifiedName= annotationBinding.getQualifiedName();
+						if (ORG_JUNIT_RULE.equals(qualifiedName) || ORG_JUNIT_CLASS_RULE.equals(qualifiedName)) {
+							ruleField= true;
+							continue;
+						}
+					}
+					if (isSyntacticRuleName(annotation.getTypeName().getFullyQualifiedName())) {
+						ruleField= true;
+						incompleteRuleAnnotation= true;
+					}
+				}
+				if (!ruleField) {
+					return true;
+				}
+				candidateFound[0]= true;
+				if (incompleteRuleAnnotation) {
+					complete[0]= false;
+				}
+				ITypeBinding fieldType= node.getType().resolveBinding();
+				complete[0]&= addJavaElement(fieldType, elements);
+				return true;
+			}
+		});
+	}
+
+	private static boolean containsSourceBackedSyntacticCandidate(IJavaProject project,
+			Set<ICompilationUnit> units, IProgressMonitor monitor) {
+		for (ICompilationUnit unit : units) {
+			checkCanceled(monitor);
+			String source;
+			try {
+				source= unit.getSource();
+			} catch (JavaModelException e) {
+				continue;
+			}
+			if (source == null || source.isBlank()) {
+				continue;
+			}
+			ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
+			parser.setKind(ASTParser.K_COMPILATION_UNIT);
+			parser.setSource(source.toCharArray());
+			parser.setUnitName(unit.getElementName());
+			parser.setStatementsRecovery(IASTSharedValues.SHARED_AST_STATEMENT_RECOVERY);
+			parser.setCompilerOptions(RefactoringASTParser.getCompilerOptions(project));
+			CompilationUnit ast= (CompilationUnit) parser.createAST(monitor);
+			boolean[] candidate= { false };
+			ast.accept(new ASTVisitor() {
+				@Override
+				public boolean visit(TypeDeclaration node) {
+					if (isSyntacticExternalResource(node)) {
+						candidate[0]= true;
+						return false;
+					}
+					return true;
+				}
+
+				@Override
+				public boolean visit(FieldDeclaration node) {
+					for (Object modifier : node.modifiers()) {
+						if (modifier instanceof Annotation annotation
+								&& isSyntacticRuleName(annotation.getTypeName().getFullyQualifiedName())) {
+							candidate[0]= true;
+							break;
+						}
+					}
+					return !candidate[0];
+				}
+			});
+			if (candidate[0]) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static ASTParser newBindingParser(IJavaProject project) {
 		ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
 		parser.setProject(project);
 		parser.setResolveBindings(true);
@@ -164,6 +225,11 @@ public final class JUnitScopeCandidateDetector {
 			}
 		}
 		return units;
+	}
+
+	private static boolean isSyntacticExternalResource(TypeDeclaration node) {
+		return node.getSuperclassType() != null
+				&& "ExternalResource".equals(simpleName(node.getSuperclassType().toString())); //$NON-NLS-1$
 	}
 
 	private static boolean isSyntacticRuleName(String name) {


### PR DESCRIPTION
## Summary

Fixes the six reactor regressions introduced when coordinated cleanup scope discovery was changed to depend on binding-resolving candidate detection.

## Root cause

The candidate gate treated incomplete/recovered bindings as proof that no selected structural candidate existed. Scope expansion then returned an empty collection instead of either an exact related-unit closure or the conservative source-policy fallback. Int-to-Enum and JUnit `ExternalResource` plans consequently never ran.

A separate non-binding JUnit pre-pass was also tested, but PDE working-copy parsing did not reproduce the selected resource syntax reliably. The final implementation therefore uses the parsing strategy that is reliable for each cleanup while preserving the same fail-closed contract.

## Fix

- Int-to-Enum uses a binding-independent structural first pass followed by binding refinement;
- JUnit performs syntactic recognition and binding refinement in one binding-aware AST pass, with syntax accepted independently of whether individual bindings resolve;
- both detectors retain `candidateFound=true` when exact search seeds are unavailable;
- incomplete results use the existing conservative project/source-root fallback;
- complete binding-derived results retain the narrower related-unit closure;
- normalization is null-safe and both detectors compile correctly.

## Regressions covered

- Int-to-Enum fixed-point fallback;
- Int-to-Enum selected-candidate project fallback;
- owner-only coordinated Int-to-Enum migration;
- JUnit fixed-point fallback;
- JUnit selected-resource project fallback;
- resource-only `ExternalResource` lifecycle migration.

This restores the fail-closed contract intended by #1212 without returning to unconditional project parsing.