### PR TITLE
Publish and install exact-version patched JDT UI repository

### DIFF
--- a/.github/scripts/add_p2_sha256_checksums.py
+++ b/.github/scripts/add_p2_sha256_checksums.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Add or replace SHA-256 and size metadata for every local p2 artifact."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import tempfile
+import xml.etree.ElementTree as ET
+import zipfile
+from pathlib import Path
+
+
+class MetadataError(RuntimeError):
+    """Raised when a p2 artifact cannot be mapped to a local file."""
+
+
+def artifact_path(repository: Path, classifier: str, identifier: str, version: str) -> Path:
+    if classifier == "osgi.bundle":
+        return repository / "plugins" / f"{identifier}_{version}.jar"
+    if classifier == "org.eclipse.update.feature":
+        return repository / "features" / f"{identifier}_{version}.jar"
+    if classifier == "binary":
+        return repository / "binary" / f"{identifier}_{version}"
+    raise MetadataError(f"Unsupported p2 artifact classifier: {classifier!r}")
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_metadata(repository: Path) -> tuple[ET.Element, bool]:
+    jar = repository / "artifacts.jar"
+    xml = repository / "artifacts.xml"
+    if jar.is_file():
+        with zipfile.ZipFile(jar) as archive:
+            try:
+                return ET.fromstring(archive.read("artifacts.xml")), True
+            except KeyError as error:
+                raise MetadataError(f"{jar} does not contain artifacts.xml") from error
+    if xml.is_file():
+        return ET.parse(xml).getroot(), False
+    raise MetadataError(f"Repository contains neither artifacts.jar nor artifacts.xml: {repository}")
+
+
+def set_properties(artifact: ET.Element, values: dict[str, str]) -> None:
+    container = artifact.find("properties")
+    if container is None:
+        container = ET.SubElement(artifact, "properties")
+    properties: dict[str, str] = {
+        item.attrib.get("name", ""): item.attrib.get("value", "")
+        for item in container.findall("property")
+        if item.attrib.get("name")
+    }
+    properties.update(values)
+    for child in list(container):
+        container.remove(child)
+    for name in sorted(properties):
+        ET.SubElement(container, "property", {"name": name, "value": properties[name]})
+    container.set("size", str(len(properties)))
+
+
+def serialized(root: ET.Element) -> bytes:
+    body = ET.tostring(root, encoding="utf-8", short_empty_elements=True)
+    return (
+        b"<?xml version='1.0' encoding='UTF-8'?>\n"
+        b"<?artifactRepository version='1.1.0'?>\n"
+        + body
+        + b"\n"
+    )
+
+
+def write_metadata(repository: Path, root: ET.Element, compressed: bool) -> None:
+    payload = serialized(root)
+    if not compressed:
+        (repository / "artifacts.xml").write_bytes(payload)
+        return
+    target = repository / "artifacts.jar"
+    descriptor, temporary_name = tempfile.mkstemp(prefix="artifacts-", suffix=".jar", dir=repository)
+    os.close(descriptor)
+    temporary = Path(temporary_name)
+    try:
+        info = zipfile.ZipInfo("artifacts.xml", date_time=(1980, 1, 1, 0, 0, 0))
+        info.compress_type = zipfile.ZIP_DEFLATED
+        info.external_attr = 0o100644 << 16
+        with zipfile.ZipFile(temporary, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=9) as archive:
+            archive.writestr(info, payload)
+        temporary.replace(target)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", required=True, type=Path)
+    args = parser.parse_args()
+
+    repository = args.repository.resolve()
+    root, compressed = load_metadata(repository)
+    evidence: list[dict[str, object]] = []
+    artifacts = root.findall("./artifacts/artifact")
+    if not artifacts:
+        raise MetadataError("p2 repository contains no artifact entries")
+    for artifact in artifacts:
+        classifier = artifact.attrib.get("classifier", "")
+        identifier = artifact.attrib.get("id", "")
+        version = artifact.attrib.get("version", "")
+        if not classifier or not identifier or not version:
+            raise MetadataError(f"Malformed artifact key: {artifact.attrib}")
+        path = artifact_path(repository, classifier, identifier, version)
+        if not path.is_file():
+            raise MetadataError(f"Artifact metadata references a missing file: {path}")
+        size = path.stat().st_size
+        digest = sha256(path)
+        set_properties(
+            artifact,
+            {
+                "artifact.size": str(size),
+                "download.size": str(size),
+                "download.checksum.sha-256": digest,
+            },
+        )
+        evidence.append(
+            {
+                "classifier": classifier,
+                "id": identifier,
+                "version": version,
+                "file": str(path.relative_to(repository)),
+                "size": size,
+                "sha256": digest,
+            }
+        )
+    write_metadata(repository, root, compressed)
+    print(json.dumps({"schemaVersion": 1, "artifacts": evidence}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/publish_patched_jdt_ui_repository.sh
+++ b/.github/scripts/publish_patched_jdt_ui_repository.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+CONFIG_FILE=${PATCHED_JDT_UI_CONFIG:-"$ROOT_DIR/.github/patched-jdt-ui.env"}
+PATCH_DIR=${1:?usage: publish_patched_jdt_ui_repository.sh PATCH_DIR COMPATIBILITY_DIR [OUTPUT_DIR]}
+COMPATIBILITY_DIR=${2:?usage: publish_patched_jdt_ui_repository.sh PATCH_DIR COMPATIBILITY_DIR [OUTPUT_DIR]}
+OUTPUT_DIR=${3:-"$ROOT_DIR/target/patched-jdt-ui-p2"}
+WORK_DIR=${PATCHED_JDT_UI_P2_WORK_DIR:-"${RUNNER_TEMP:-${TMPDIR:-/tmp}}/patched-jdt-ui-p2-publisher"}
+FEATURE_ID=${PATCHED_JDT_UI_FEATURE_ID:-sandbox_patched_jdt_ui_feature}
+
+# shellcheck disable=SC1090
+source "$CONFIG_FILE"
+: "${PATCHED_JDT_UI_BUNDLE:?missing PATCHED_JDT_UI_BUNDLE}"
+
+for command in find java mvn python3 sed sha256sum; do
+  command -v "$command" >/dev/null || { echo "Missing required command: $command" >&2; exit 1; }
+done
+
+PROVENANCE="$PATCH_DIR/provenance.json"
+COMPATIBILITY="$COMPATIBILITY_DIR/compatibility.json"
+[[ -f "$PROVENANCE" ]] || { echo "Missing bundle provenance: $PROVENANCE" >&2; exit 1; }
+[[ -f "$COMPATIBILITY" ]] || { echo "Missing target compatibility report: $COMPATIBILITY" >&2; exit 1; }
+
+readarray -t values < <(python3 - "$PROVENANCE" "$COMPATIBILITY" "$PATCHED_JDT_UI_BUNDLE" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+provenance = json.loads(Path(sys.argv[1]).read_text(encoding='utf-8'))
+compatibility = json.loads(Path(sys.argv[2]).read_text(encoding='utf-8'))
+expected_id = sys.argv[3]
+if compatibility.get('compatibleForReplacement') is not True:
+    raise SystemExit('Compatibility report does not authorize p2 publication')
+if provenance.get('bundleSymbolicName') != expected_id:
+    raise SystemExit('Bundle provenance has an unexpected symbolic name')
+version = str(provenance.get('bundleVersion', ''))
+sha256 = str(provenance.get('bundleSha256', ''))
+patched = compatibility.get('patchedBundle') or {}
+if patched.get('version') != version or patched.get('sha256') != sha256:
+    raise SystemExit('Compatibility report and provenance refer to different bundle bytes')
+if not re.fullmatch(r'[0-9]+\.[0-9]+\.[0-9]+\.[A-Za-z0-9_-]+', version):
+    raise SystemExit(f'Unsupported qualified bundle version: {version}')
+print(version)
+print(sha256)
+print(version.split('.', 3)[3])
+PY
+)
+BUNDLE_VERSION=${values[0]}
+BUNDLE_SHA256=${values[1]}
+BUNDLE_QUALIFIER=${values[2]}
+FEATURE_VERSION="1.0.0.${BUNDLE_QUALIFIER}"
+
+mapfile -t bundle_candidates < <(find "$PATCH_DIR/plugins" -maxdepth 1 -type f \
+  -name "${PATCHED_JDT_UI_BUNDLE}_${BUNDLE_VERSION}.jar" | sort)
+if (( ${#bundle_candidates[@]} != 1 )); then
+  printf 'Expected exactly one patched bundle %s_%s.jar, found %d\n' \
+    "$PATCHED_JDT_UI_BUNDLE" "$BUNDLE_VERSION" "${#bundle_candidates[@]}" >&2
+  exit 1
+fi
+BUNDLE_JAR=${bundle_candidates[0]}
+if [[ "$(sha256sum "$BUNDLE_JAR" | awk '{print $1}')" != "$BUNDLE_SHA256" ]]; then
+  echo 'Patched bundle bytes do not match provenance before publication' >&2
+  exit 1
+fi
+
+SOURCE_DIR="$WORK_DIR/source"
+FEATURE_DIR="$SOURCE_DIR/features/${FEATURE_ID}_${FEATURE_VERSION}"
+REPOSITORY_DIR="$OUTPUT_DIR/repository"
+EVIDENCE_DIR="$OUTPUT_DIR/evidence"
+rm -rf "$WORK_DIR" "$OUTPUT_DIR"
+mkdir -p "$SOURCE_DIR/plugins" "$FEATURE_DIR" "$REPOSITORY_DIR" "$EVIDENCE_DIR"
+cp "$BUNDLE_JAR" "$SOURCE_DIR/plugins/${PATCHED_JDT_UI_BUNDLE}_${BUNDLE_VERSION}.jar"
+
+cat > "$FEATURE_DIR/feature.xml" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="$FEATURE_ID"
+      label="Sandbox Patched JDT UI"
+      version="$FEATURE_VERSION"
+      provider-name="Sandbox">
+   <description>
+      Exact-version carrier feature for the reviewed Sandbox JDT UI scope-expansion patch.
+   </description>
+   <copyright>
+      Copyright (c) Eclipse contributors and Sandbox contributors.
+   </copyright>
+   <license url="https://www.eclipse.org/legal/epl-2.0/">
+      Eclipse Public License 2.0
+   </license>
+   <requires>
+      <import plugin="$PATCHED_JDT_UI_BUNDLE" version="$BUNDLE_VERSION" match="perfect"/>
+   </requires>
+   <plugin
+         id="$PATCHED_JDT_UI_BUNDLE"
+         download-size="0"
+         install-size="0"
+         version="$BUNDLE_VERSION"
+         unpack="false"/>
+</feature>
+EOF
+
+TYCHO_VERSION=$(mvn -q -ntp -f "$ROOT_DIR/pom.xml" help:evaluate \
+  -Dexpression=tycho-version -DforceStdout \
+  | sed -nE '/^[0-9]+\.[0-9]+\.[0-9]+([.-].*)?$/p' \
+  | tail -n 1)
+if ! [[ "$TYCHO_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-].*)?$ ]]; then
+  echo "Could not determine a Tycho version from the reactor: $TYCHO_VERSION" >&2
+  exit 1
+fi
+
+cat > "$WORK_DIR/pom.xml" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.sandbox.build</groupId>
+  <artifactId>patched-jdt-ui-p2-publisher</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.tycho.extras</groupId>
+        <artifactId>tycho-p2-extras-plugin</artifactId>
+        <version>$TYCHO_VERSION</version>
+        <configuration>
+          <sourceLocation>\${source.location}</sourceLocation>
+          <metadataRepositoryLocation>\${repository.location}</metadataRepositoryLocation>
+          <artifactRepositoryLocation>\${repository.location}</artifactRepositoryLocation>
+          <compress>true</compress>
+          <publishArtifacts>true</publishArtifacts>
+          <append>false</append>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+EOF
+
+mvn --batch-mode -ntp -f "$WORK_DIR/pom.xml" \
+  "org.eclipse.tycho.extras:tycho-p2-extras-plugin:${TYCHO_VERSION}:publish-features-and-bundles" \
+  -Dsource.location="$SOURCE_DIR" \
+  -Drepository.location="$REPOSITORY_DIR"
+
+cp "$PROVENANCE" "$EVIDENCE_DIR/bundle-provenance.json"
+cp "$COMPATIBILITY" "$EVIDENCE_DIR/target-compatibility.json"
+cp "$FEATURE_DIR/feature.xml" "$EVIDENCE_DIR/feature.xml"
+python3 "$ROOT_DIR/.github/scripts/verify_patched_jdt_ui_repository.py" \
+  --repository "$REPOSITORY_DIR" \
+  --bundle-provenance "$PROVENANCE" \
+  --compatibility "$COMPATIBILITY" \
+  --feature-id "$FEATURE_ID" \
+  --feature-version "$FEATURE_VERSION" \
+  --output "$EVIDENCE_DIR"
+
+export EVIDENCE_DIR FEATURE_ID FEATURE_VERSION PATCHED_JDT_UI_BUNDLE BUNDLE_VERSION BUNDLE_SHA256
+python3 <<'PY'
+import json
+import os
+from pathlib import Path
+
+path = Path(os.environ['EVIDENCE_DIR']) / 'repository-provenance.json'
+payload = {
+    'schemaVersion': 1,
+    'featureId': os.environ['FEATURE_ID'],
+    'featureVersion': os.environ['FEATURE_VERSION'],
+    'featureGroupIU': f"{os.environ['FEATURE_ID']}.feature.group",
+    'bundleSymbolicName': os.environ['PATCHED_JDT_UI_BUNDLE'],
+    'bundleVersion': os.environ['BUNDLE_VERSION'],
+    'bundleSha256': os.environ['BUNDLE_SHA256'],
+}
+path.write_text(json.dumps(payload, indent=2) + '\n', encoding='utf-8')
+PY
+
+printf 'Published %s %s requiring %s %s to %s\n' \
+  "$FEATURE_ID" "$FEATURE_VERSION" "$PATCHED_JDT_UI_BUNDLE" "$BUNDLE_VERSION" "$REPOSITORY_DIR"

--- a/.github/scripts/publish_patched_jdt_ui_repository.sh
+++ b/.github/scripts/publish_patched_jdt_ui_repository.sh
@@ -145,6 +145,9 @@ mvn --batch-mode -ntp -f "$WORK_DIR/pom.xml" \
   -Dsource.location="$SOURCE_DIR" \
   -Drepository.location="$REPOSITORY_DIR"
 
+python3 "$ROOT_DIR/.github/scripts/add_p2_sha256_checksums.py" \
+  --repository "$REPOSITORY_DIR" \
+  > "$EVIDENCE_DIR/checksum-normalization.json"
 cp "$PROVENANCE" "$EVIDENCE_DIR/bundle-provenance.json"
 cp "$COMPATIBILITY" "$EVIDENCE_DIR/target-compatibility.json"
 cp "$FEATURE_DIR/feature.xml" "$EVIDENCE_DIR/feature.xml"

--- a/.github/scripts/smoke_test_patched_jdt_ui_repository.sh
+++ b/.github/scripts/smoke_test_patched_jdt_ui_repository.sh
@@ -9,7 +9,7 @@ REPOSITORY_EVIDENCE="$P2_ROOT/evidence"
 VERIFICATION_JSON="$REPOSITORY_EVIDENCE/repository-verification.json"
 PRODUCTS_DIR="$ROOT_DIR/sandbox_product/target/products"
 
-for command in find java python3 sha256sum timeout xvfb-run; do
+for command in awk basename dirname find java python3 sha256sum timeout xvfb-run; do
   command -v "$command" >/dev/null || { echo "Missing required command: $command" >&2; exit 1; }
 done
 [[ -f "$VERIFICATION_JSON" ]] || { echo "Missing repository verification: $VERIFICATION_JSON" >&2; exit 1; }
@@ -35,20 +35,24 @@ BUNDLE_SHA256=${expected[2]}
 FEATURE_GROUP=${expected[3]}
 FEATURE_VERSION=${expected[4]}
 
-mapfile -t product_roots < <(find "$PRODUCTS_DIR" -type d -path '*/linux/gtk/x86_64' -print | sort)
-if (( ${#product_roots[@]} != 1 )); then
-  printf 'Expected exactly one Linux GTK x86_64 product root, found %d: %s\n' \
-    "${#product_roots[@]}" "${product_roots[*]:-<none>}" >&2
+mapfile -t architecture_roots < <(find "$PRODUCTS_DIR" -type d -path '*/linux/gtk/x86_64' -print | sort)
+if (( ${#architecture_roots[@]} != 1 )); then
+  printf 'Expected exactly one Linux GTK x86_64 product directory, found %d: %s\n' \
+    "${#architecture_roots[@]}" "${architecture_roots[*]:-<none>}" >&2
   exit 1
 fi
-PRODUCT_ROOT=${product_roots[0]}
-mapfile -t launchers < <(find "$PRODUCT_ROOT/plugins" -maxdepth 1 -type f \
-  -name 'org.eclipse.equinox.launcher_*.jar' | sort)
+ARCHITECTURE_ROOT=${architecture_roots[0]}
+mapfile -t launchers < <(find "$ARCHITECTURE_ROOT" -type f \
+  -path '*/plugins/org.eclipse.equinox.launcher_*.jar' | sort)
 if (( ${#launchers[@]} != 1 )); then
-  printf 'Expected exactly one Equinox launcher, found %d\n' "${#launchers[@]}" >&2
+  printf 'Expected exactly one Equinox launcher below %s, found %d: %s\n' \
+    "$ARCHITECTURE_ROOT" "${#launchers[@]}" "${launchers[*]:-<none>}" >&2
   exit 1
 fi
 LAUNCHER=${launchers[0]}
+PRODUCT_ROOT=$(dirname "$(dirname "$LAUNCHER")")
+[[ -f "$PRODUCT_ROOT/configuration/config.ini" ]] \
+  || { echo "Launcher parent is not a materialized product root: $PRODUCT_ROOT" >&2; exit 1; }
 BUNDLES_INFO="$PRODUCT_ROOT/configuration/org.eclipse.equinox.simpleconfigurator/bundles.info"
 [[ -f "$BUNDLES_INFO" ]] || { echo "Missing bundles.info: $BUNDLES_INFO" >&2; exit 1; }
 

--- a/.github/scripts/smoke_test_patched_jdt_ui_repository.sh
+++ b/.github/scripts/smoke_test_patched_jdt_ui_repository.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+P2_ROOT=${1:?usage: smoke_test_patched_jdt_ui_repository.sh P2_OUTPUT [EVIDENCE_DIR]}
+EVIDENCE_DIR=${2:-"$ROOT_DIR/target/patched-jdt-ui-installation"}
+REPOSITORY_DIR="$P2_ROOT/repository"
+REPOSITORY_EVIDENCE="$P2_ROOT/evidence"
+VERIFICATION_JSON="$REPOSITORY_EVIDENCE/repository-verification.json"
+PRODUCTS_DIR="$ROOT_DIR/sandbox_product/target/products"
+
+for command in find java python3 sha256sum timeout xvfb-run; do
+  command -v "$command" >/dev/null || { echo "Missing required command: $command" >&2; exit 1; }
+done
+[[ -f "$VERIFICATION_JSON" ]] || { echo "Missing repository verification: $VERIFICATION_JSON" >&2; exit 1; }
+
+readarray -t expected < <(python3 - "$VERIFICATION_JSON" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+report = json.loads(Path(sys.argv[1]).read_text(encoding='utf-8'))
+if report.get('result') != 'PASS':
+    raise SystemExit('Repository verification is not PASS')
+print(report['bundle']['id'])
+print(report['bundle']['version'])
+print(report['bundle']['sha256'])
+print(report['feature']['groupIU'])
+print(report['feature']['version'])
+PY
+)
+BUNDLE_ID=${expected[0]}
+BUNDLE_VERSION=${expected[1]}
+BUNDLE_SHA256=${expected[2]}
+FEATURE_GROUP=${expected[3]}
+FEATURE_VERSION=${expected[4]}
+
+mapfile -t product_roots < <(find "$PRODUCTS_DIR" -type d -path '*/linux/gtk/x86_64' -print | sort)
+if (( ${#product_roots[@]} != 1 )); then
+  printf 'Expected exactly one Linux GTK x86_64 product root, found %d: %s\n' \
+    "${#product_roots[@]}" "${product_roots[*]:-<none>}" >&2
+  exit 1
+fi
+PRODUCT_ROOT=${product_roots[0]}
+mapfile -t launchers < <(find "$PRODUCT_ROOT/plugins" -maxdepth 1 -type f \
+  -name 'org.eclipse.equinox.launcher_*.jar' | sort)
+if (( ${#launchers[@]} != 1 )); then
+  printf 'Expected exactly one Equinox launcher, found %d\n' "${#launchers[@]}" >&2
+  exit 1
+fi
+LAUNCHER=${launchers[0]}
+BUNDLES_INFO="$PRODUCT_ROOT/configuration/org.eclipse.equinox.simpleconfigurator/bundles.info"
+[[ -f "$BUNDLES_INFO" ]] || { echo "Missing bundles.info: $BUNDLES_INFO" >&2; exit 1; }
+
+mapfile -t profiles < <(find "$PRODUCT_ROOT/p2/org.eclipse.equinox.p2.engine/profileRegistry" \
+  -maxdepth 1 -mindepth 1 -type d -name '*.profile' | sort)
+if (( ${#profiles[@]} != 1 )); then
+  printf 'Expected exactly one materialized product profile, found %d: %s\n' \
+    "${#profiles[@]}" "${profiles[*]:-<none>}" >&2
+  exit 1
+fi
+PROFILE_ID=$(basename "${profiles[0]}" .profile)
+
+selected_bundle_line() {
+  awk -F, -v id="$BUNDLE_ID" '$1 == id { print }' "$BUNDLES_INFO"
+}
+
+mapfile -t stock_lines < <(selected_bundle_line)
+if (( ${#stock_lines[@]} != 1 )); then
+  printf 'Expected one selected stock %s bundle, found %d\n' "$BUNDLE_ID" "${#stock_lines[@]}" >&2
+  exit 1
+fi
+STOCK_VERSION=$(awk -F, '{print $2}' <<<"${stock_lines[0]}")
+if [[ "$STOCK_VERSION" == "$BUNDLE_VERSION" ]]; then
+  echo 'Stock product already selects the patched version; stock regression cannot be distinguished' >&2
+  exit 1
+fi
+
+mkdir -p "$EVIDENCE_DIR"
+printf '%s\n' "${stock_lines[0]}" > "$EVIDENCE_DIR/stock-bundle-selection.txt"
+REPOSITORY_URI=$(python3 - "$REPOSITORY_DIR" <<'PY'
+import sys
+from pathlib import Path
+print(Path(sys.argv[1]).resolve().as_uri())
+PY
+)
+
+(
+  cd "$PRODUCT_ROOT"
+  timeout 900s xvfb-run -a java -jar "$LAUNCHER" -nosplash -consoleLog \
+    -application org.eclipse.equinox.p2.director \
+    -repository "$REPOSITORY_URI" \
+    -installIU "$FEATURE_GROUP" \
+    -destination "$PRODUCT_ROOT" \
+    -bundlepool "$PRODUCT_ROOT" \
+    -profile "$PROFILE_ID" \
+    -profileProperties org.eclipse.update.install.features=true \
+    -p2.os linux -p2.ws gtk -p2.arch x86_64
+) > "$EVIDENCE_DIR/install.log" 2>&1
+
+mapfile -t patched_lines < <(selected_bundle_line)
+if (( ${#patched_lines[@]} != 1 )); then
+  printf 'Expected one selected patched %s bundle after installation, found %d\n' \
+    "$BUNDLE_ID" "${#patched_lines[@]}" >&2
+  exit 1
+fi
+SELECTED_VERSION=$(awk -F, '{print $2}' <<<"${patched_lines[0]}")
+if [[ "$SELECTED_VERSION" != "$BUNDLE_VERSION" ]]; then
+  echo "Installed product selected $BUNDLE_ID $SELECTED_VERSION instead of $BUNDLE_VERSION" >&2
+  exit 1
+fi
+printf '%s\n' "${patched_lines[0]}" > "$EVIDENCE_DIR/patched-bundle-selection.txt"
+
+mapfile -t selected_jars < <(find "$PRODUCT_ROOT/plugins" -maxdepth 1 -type f \
+  -name "${BUNDLE_ID}_${BUNDLE_VERSION}.jar" | sort)
+if (( ${#selected_jars[@]} != 1 )); then
+  printf 'Expected exactly one installed patched bundle file, found %d\n' "${#selected_jars[@]}" >&2
+  exit 1
+fi
+INSTALLED_SHA=$(sha256sum "${selected_jars[0]}" | awk '{print $1}')
+if [[ "$INSTALLED_SHA" != "$BUNDLE_SHA256" ]]; then
+  echo 'Installed bundle SHA-256 differs from repository provenance' >&2
+  exit 1
+fi
+
+(
+  cd "$PRODUCT_ROOT"
+  timeout 300s xvfb-run -a java -jar "$LAUNCHER" -nosplash -consoleLog \
+    -application org.eclipse.equinox.p2.director \
+    -listInstalledRoots \
+    -destination "$PRODUCT_ROOT" \
+    -profile "$PROFILE_ID"
+) > "$EVIDENCE_DIR/installed-roots.log" 2>&1
+if ! grep -Fq "$FEATURE_GROUP" "$EVIDENCE_DIR/installed-roots.log"; then
+  echo "Installed product did not report root $FEATURE_GROUP" >&2
+  exit 1
+fi
+
+export EVIDENCE_DIR PRODUCT_ROOT PROFILE_ID BUNDLE_ID BUNDLE_VERSION BUNDLE_SHA256
+export STOCK_VERSION FEATURE_GROUP FEATURE_VERSION INSTALLED_SHA
+python3 <<'PY'
+import json
+import os
+from pathlib import Path
+
+payload = {
+    'schemaVersion': 1,
+    'result': 'PASS',
+    'productRoot': os.environ['PRODUCT_ROOT'],
+    'profileId': os.environ['PROFILE_ID'],
+    'stockBundle': {'id': os.environ['BUNDLE_ID'], 'version': os.environ['STOCK_VERSION']},
+    'patchedBundle': {
+        'id': os.environ['BUNDLE_ID'],
+        'version': os.environ['BUNDLE_VERSION'],
+        'sha256': os.environ['BUNDLE_SHA256'],
+        'installedSha256': os.environ['INSTALLED_SHA'],
+    },
+    'feature': {'groupIU': os.environ['FEATURE_GROUP'], 'version': os.environ['FEATURE_VERSION']},
+}
+root = Path(os.environ['EVIDENCE_DIR'])
+(root / 'installation-verification.json').write_text(
+    json.dumps(payload, indent=2) + '\n', encoding='utf-8'
+)
+lines = [
+    '# Patched JDT UI installation verification',
+    '',
+    '- Result: **PASS**',
+    f"- Stock selection: `{os.environ['BUNDLE_ID']} {os.environ['STOCK_VERSION']}`",
+    f"- Patched selection: `{os.environ['BUNDLE_ID']} {os.environ['BUNDLE_VERSION']}`",
+    f"- Installed root: `{os.environ['FEATURE_GROUP']} {os.environ['FEATURE_VERSION']}`",
+    '- Exactly one active simpleconfigurator entry: **PASS**',
+    '- Installed bundle bytes match pinned SHA-256: **PASS**',
+    '- Patched product starts the p2 director and lists installed roots: **PASS**',
+]
+(root / 'installation-verification.md').write_text(
+    '\n'.join(lines) + '\n', encoding='utf-8'
+)
+print(json.dumps(payload, indent=2))
+PY

--- a/.github/scripts/verify_patched_jdt_ui_repository.py
+++ b/.github/scripts/verify_patched_jdt_ui_repository.py
@@ -172,8 +172,8 @@ def main() -> int:
             fail(f"Expected exactly one feature jar IU {feature_jar_id} {args.feature_version}")
         if not exact_requirement(feature_groups[0], feature_jar_id, args.feature_version):
             fail("Feature group does not require its exact feature jar IU")
-        if not exact_requirement(feature_jars[0], bundle_id, bundle_version):
-            fail("Patch feature does not require the exact patched JDT UI bundle version")
+        if not exact_requirement(feature_groups[0], bundle_id, bundle_version):
+            fail("Feature group does not require the exact patched JDT UI bundle version")
 
         artifact_entries = artifacts.findall("./artifacts/artifact")
         expected_keys = {

--- a/.github/scripts/verify_patched_jdt_ui_repository.py
+++ b/.github/scripts/verify_patched_jdt_ui_repository.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Verify the minimal p2 repository for the pinned patched JDT UI bundle."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+import xml.etree.ElementTree as ET
+import zipfile
+from pathlib import Path
+
+
+class VerificationError(RuntimeError):
+    """Raised when repository evidence is incomplete or inconsistent."""
+
+
+def fail(message: str) -> None:
+    raise VerificationError(message)
+
+
+def read_json(path: Path) -> dict[str, object]:
+    with path.open(encoding="utf-8") as stream:
+        value = json.load(stream)
+    if not isinstance(value, dict):
+        fail(f"Expected a JSON object in {path}")
+    return value
+
+
+def repository_xml(repository: Path, stem: str) -> ET.Element:
+    jar = repository / f"{stem}.jar"
+    xml = repository / f"{stem}.xml"
+    if jar.is_file():
+        with zipfile.ZipFile(jar) as archive:
+            try:
+                raw = archive.read(f"{stem}.xml")
+            except KeyError as error:
+                fail(f"{jar} does not contain {stem}.xml: {error}")
+        return ET.fromstring(raw)
+    if xml.is_file():
+        return ET.parse(xml).getroot()
+    fail(f"Repository is missing {stem}.jar and {stem}.xml: {repository}")
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def md5(path: Path) -> str:
+    digest = hashlib.md5(usedforsecurity=False)
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def properties(element: ET.Element) -> dict[str, str]:
+    container = element.find("properties")
+    if container is None:
+        return {}
+    return {
+        item.attrib.get("name", ""): item.attrib.get("value", "")
+        for item in container.findall("property")
+        if item.attrib.get("name")
+    }
+
+
+def exact_requirement(unit: ET.Element, identifier: str, version: str) -> bool:
+    expected_ranges = {version, f"[{version},{version}]"}
+    for requirement in unit.findall("./requires/required"):
+        if requirement.attrib.get("name") != identifier:
+            continue
+        if requirement.attrib.get("namespace") not in (None, "org.eclipse.equinox.p2.iu"):
+            continue
+        if requirement.attrib.get("range", "") in expected_ranges:
+            return True
+    return False
+
+
+def artifact_file(repository: Path, classifier: str, identifier: str, version: str) -> Path:
+    if classifier == "osgi.bundle":
+        return repository / "plugins" / f"{identifier}_{version}.jar"
+    if classifier == "org.eclipse.update.feature":
+        return repository / "features" / f"{identifier}_{version}.jar"
+    fail(f"Unexpected artifact classifier {classifier!r}")
+
+
+def verify_integrity(path: Path, metadata: dict[str, str]) -> list[str]:
+    if not path.is_file():
+        fail(f"Artifact metadata references missing file: {path}")
+    checks: list[str] = []
+    size = metadata.get("download.size") or metadata.get("artifact.size")
+    if size and size.isdigit():
+        if path.stat().st_size != int(size):
+            fail(f"Size mismatch for {path.name}: file={path.stat().st_size}, metadata={size}")
+        checks.append("size")
+    for name, value in metadata.items():
+        lowered = name.lower()
+        if re.fullmatch(r"[0-9a-fA-F]{64}", value) and ("sha-256" in lowered or "sha256" in lowered):
+            if sha256(path).lower() != value.lower():
+                fail(f"SHA-256 mismatch for {path.name} ({name})")
+            checks.append("sha256")
+        elif re.fullmatch(r"[0-9a-fA-F]{32}", value) and "md5" in lowered:
+            if md5(path).lower() != value.lower():
+                fail(f"MD5 mismatch for {path.name} ({name})")
+            checks.append("md5")
+    if not any(check in {"sha256", "md5"} for check in checks):
+        fail(f"No verifiable checksum property was published for {path.name}")
+    return sorted(set(checks))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", required=True, type=Path)
+    parser.add_argument("--bundle-provenance", required=True, type=Path)
+    parser.add_argument("--compatibility", required=True, type=Path)
+    parser.add_argument("--feature-id", required=True)
+    parser.add_argument("--feature-version", required=True)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+
+    try:
+        repository = args.repository.resolve()
+        provenance = read_json(args.bundle_provenance)
+        compatibility = read_json(args.compatibility)
+        if compatibility.get("compatibleForReplacement") is not True:
+            fail("Stock-target compatibility report does not authorize p2 replacement")
+
+        bundle_id = str(provenance.get("bundleSymbolicName", ""))
+        bundle_version = str(provenance.get("bundleVersion", ""))
+        bundle_sha = str(provenance.get("bundleSha256", ""))
+        if not bundle_id or not bundle_version or not re.fullmatch(r"[0-9a-f]{64}", bundle_sha):
+            fail("Bundle provenance is missing a valid symbolic name, version, or SHA-256")
+
+        patched = compatibility.get("patchedBundle")
+        if not isinstance(patched, dict):
+            fail("Compatibility report has no patchedBundle object")
+        if patched.get("version") != bundle_version or patched.get("sha256") != bundle_sha:
+            fail("Compatibility report and bundle provenance refer to different patched artifacts")
+
+        content = repository_xml(repository, "content")
+        artifacts = repository_xml(repository, "artifacts")
+        units = content.findall("./units/unit")
+
+        bundle_units = [unit for unit in units if unit.attrib.get("id") == bundle_id]
+        found_bundle_units = [
+            (unit.attrib.get("id"), unit.attrib.get("version")) for unit in bundle_units
+        ]
+        if found_bundle_units != [(bundle_id, bundle_version)]:
+            fail(
+                f"Expected exactly one bundle IU {bundle_id} {bundle_version}, "
+                f"found {found_bundle_units}"
+            )
+
+        feature_group_id = f"{args.feature_id}.feature.group"
+        feature_jar_id = f"{args.feature_id}.feature.jar"
+        feature_groups = [unit for unit in units if unit.attrib.get("id") == feature_group_id]
+        feature_jars = [unit for unit in units if unit.attrib.get("id") == feature_jar_id]
+        if [
+            (unit.attrib.get("id"), unit.attrib.get("version")) for unit in feature_groups
+        ] != [(feature_group_id, args.feature_version)]:
+            fail(f"Expected exactly one feature group IU {feature_group_id} {args.feature_version}")
+        if [
+            (unit.attrib.get("id"), unit.attrib.get("version")) for unit in feature_jars
+        ] != [(feature_jar_id, args.feature_version)]:
+            fail(f"Expected exactly one feature jar IU {feature_jar_id} {args.feature_version}")
+        if not exact_requirement(feature_groups[0], feature_jar_id, args.feature_version):
+            fail("Feature group does not require its exact feature jar IU")
+        if not exact_requirement(feature_jars[0], bundle_id, bundle_version):
+            fail("Patch feature does not require the exact patched JDT UI bundle version")
+
+        artifact_entries = artifacts.findall("./artifacts/artifact")
+        expected_keys = {
+            ("osgi.bundle", bundle_id, bundle_version),
+            ("org.eclipse.update.feature", args.feature_id, args.feature_version),
+        }
+        actual_keys = {
+            (
+                item.attrib.get("classifier", ""),
+                item.attrib.get("id", ""),
+                item.attrib.get("version", ""),
+            )
+            for item in artifact_entries
+        }
+        if actual_keys != expected_keys:
+            fail(
+                f"Unexpected p2 artifact keys: expected={sorted(expected_keys)}, "
+                f"actual={sorted(actual_keys)}"
+            )
+
+        integrity: dict[str, list[str]] = {}
+        for item in artifact_entries:
+            classifier = item.attrib["classifier"]
+            identifier = item.attrib["id"]
+            version = item.attrib["version"]
+            path = artifact_file(repository, classifier, identifier, version)
+            integrity[path.name] = verify_integrity(path, properties(item))
+
+        bundle_path = repository / "plugins" / f"{bundle_id}_{bundle_version}.jar"
+        if sha256(bundle_path) != bundle_sha:
+            fail("Published bundle bytes do not match the pinned build provenance")
+
+        feature_path = repository / "features" / f"{args.feature_id}_{args.feature_version}.jar"
+        with zipfile.ZipFile(feature_path) as archive:
+            feature_xml = ET.fromstring(archive.read("feature.xml"))
+        if (
+            feature_xml.attrib.get("id") != args.feature_id
+            or feature_xml.attrib.get("version") != args.feature_version
+        ):
+            fail("Published feature.xml identity differs from the expected feature")
+        plugin = feature_xml.find(f"./plugin[@id='{bundle_id}']")
+        if plugin is None or plugin.attrib.get("version") != bundle_version:
+            fail("Published feature.xml does not pin the exact patched bundle version")
+
+        payload: dict[str, object] = {
+            "schemaVersion": 1,
+            "result": "PASS",
+            "repository": str(repository),
+            "sourceCommit": provenance.get("sourceCommit"),
+            "bundle": {"id": bundle_id, "version": bundle_version, "sha256": bundle_sha},
+            "feature": {
+                "id": args.feature_id,
+                "version": args.feature_version,
+                "groupIU": feature_group_id,
+                "jarIU": feature_jar_id,
+            },
+            "artifactIntegrity": integrity,
+            "unitCount": len(units),
+            "artifactCount": len(artifact_entries),
+        }
+        args.output.mkdir(parents=True, exist_ok=True)
+        (args.output / "repository-verification.json").write_text(
+            json.dumps(payload, indent=2) + "\n", encoding="utf-8"
+        )
+        lines = [
+            "# Patched JDT UI p2 repository verification",
+            "",
+            "- Result: **PASS**",
+            f"- Bundle: `{bundle_id} {bundle_version}`",
+            f"- Feature group: `{feature_group_id} {args.feature_version}`",
+            f"- p2 units: **{len(units)}**",
+            f"- p2 artifacts: **{len(artifact_entries)}**",
+            "- Bundle bytes match pinned SHA-256 provenance: **PASS**",
+            "- Exact-version feature requirement: **PASS**",
+            "- Published artifact checksums: **PASS**",
+        ]
+        (args.output / "repository-verification.md").write_text(
+            "\n".join(lines) + "\n", encoding="utf-8"
+        )
+        print(json.dumps(payload, indent=2))
+        return 0
+    except (
+        OSError,
+        KeyError,
+        ValueError,
+        ET.ParseError,
+        zipfile.BadZipFile,
+        VerificationError,
+    ) as error:
+        print(f"patched JDT UI p2 verification failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/patched-jdt-ui-bundle.yml
+++ b/.github/workflows/patched-jdt-ui-bundle.yml
@@ -6,6 +6,7 @@ on:
     branches: [ main ]
     paths:
       - '.github/patched-jdt-ui.env'
+      - '.github/scripts/add_p2_sha256_checksums.py'
       - '.github/scripts/build_patched_jdt_ui.sh'
       - '.github/scripts/compare_patched_jdt_ui_with_target.sh'
       - '.github/scripts/publish_patched_jdt_ui_repository.sh'
@@ -17,6 +18,7 @@ on:
     branches: [ main ]
     paths:
       - '.github/patched-jdt-ui.env'
+      - '.github/scripts/add_p2_sha256_checksums.py'
       - '.github/scripts/build_patched_jdt_ui.sh'
       - '.github/scripts/compare_patched_jdt_ui_with_target.sh'
       - '.github/scripts/publish_patched_jdt_ui_repository.sh'

--- a/.github/workflows/patched-jdt-ui-bundle.yml
+++ b/.github/workflows/patched-jdt-ui-bundle.yml
@@ -14,6 +14,7 @@ on:
       - '.github/scripts/verify_patched_jdt_ui_repository.py'
       - '.github/workflows/patched-jdt-ui-bundle.yml'
       - 'docs/patched-jdt-ui-delivery.md'
+      - 'sandbox_product/pom.xml'
   pull_request:
     branches: [ main ]
     paths:
@@ -26,6 +27,7 @@ on:
       - '.github/scripts/verify_patched_jdt_ui_repository.py'
       - '.github/workflows/patched-jdt-ui-bundle.yml'
       - 'docs/patched-jdt-ui-delivery.md'
+      - 'sandbox_product/pom.xml'
 
 permissions:
   contents: read
@@ -191,7 +193,7 @@ jobs:
   patched-product-installation:
     needs: p2-repository
     runs-on: ubuntu-latest
-    timeout-minutes: 100
+    timeout-minutes: 110
     steps:
       - uses: actions/checkout@v6
         with:
@@ -213,14 +215,21 @@ jobs:
         with:
           name: patched-jdt-ui-p2-${{ github.sha }}
           path: ${{ runner.temp }}/patched-jdt-ui-p2
-      - name: Build the independent stock product
-        run: mvn -Pproduct -T 1C --batch-mode clean package -DskipTests
-      - name: Install exact patch feature and start the product
+      - name: Build and verify the explicit patched-product Maven profile
         shell: bash
         run: |
-          bash .github/scripts/smoke_test_patched_jdt_ui_repository.sh \
-            "$RUNNER_TEMP/patched-jdt-ui-p2" \
-            "$RUNNER_TEMP/patched-jdt-ui-installation"
+          mvn -Pproduct,patched-product -T 1C --batch-mode clean verify -DskipTests \
+            -Dpatched.jdt.ui.p2.root="$RUNNER_TEMP/patched-jdt-ui-p2" \
+            -Dpatched.jdt.ui.installation.evidence="$RUNNER_TEMP/patched-jdt-ui-installation"
+          python3 - "$RUNNER_TEMP/patched-jdt-ui-installation/installation-verification.json" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          report = json.loads(Path(sys.argv[1]).read_text(encoding='utf-8'))
+          if report.get('result') != 'PASS':
+              raise SystemExit('patched-product Maven profile did not produce PASS installation evidence')
+          PY
       - name: Publish installation summary
         if: always()
         shell: bash

--- a/.github/workflows/patched-jdt-ui-bundle.yml
+++ b/.github/workflows/patched-jdt-ui-bundle.yml
@@ -2,17 +2,35 @@ name: Patched JDT UI Bundle
 
 on:
   workflow_dispatch:
+  push:
+    branches: [ main ]
+    paths:
+      - '.github/patched-jdt-ui.env'
+      - '.github/scripts/build_patched_jdt_ui.sh'
+      - '.github/scripts/compare_patched_jdt_ui_with_target.sh'
+      - '.github/scripts/publish_patched_jdt_ui_repository.sh'
+      - '.github/scripts/smoke_test_patched_jdt_ui_repository.sh'
+      - '.github/scripts/verify_patched_jdt_ui_repository.py'
+      - '.github/workflows/patched-jdt-ui-bundle.yml'
+      - 'docs/patched-jdt-ui-delivery.md'
   pull_request:
     branches: [ main ]
     paths:
       - '.github/patched-jdt-ui.env'
       - '.github/scripts/build_patched_jdt_ui.sh'
       - '.github/scripts/compare_patched_jdt_ui_with_target.sh'
+      - '.github/scripts/publish_patched_jdt_ui_repository.sh'
+      - '.github/scripts/smoke_test_patched_jdt_ui_repository.sh'
+      - '.github/scripts/verify_patched_jdt_ui_repository.py'
       - '.github/workflows/patched-jdt-ui-bundle.yml'
       - 'docs/patched-jdt-ui-delivery.md'
 
 permissions:
   contents: read
+
+concurrency:
+  group: patched-jdt-ui-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -85,20 +103,9 @@ jobs:
         shell: bash
         run: |
           report="$RUNNER_TEMP/patched-jdt-ui-compatibility/compatibility.md"
-          result="$RUNNER_TEMP/patched-jdt-ui-compatibility/compatibility.json"
           log="$RUNNER_TEMP/patched-jdt-ui-compatibility/compatibility-build.log"
-          if [[ -s "$report" && -s "$result" ]]; then
+          if [[ -s "$report" ]]; then
             cat "$report" >> "$GITHUB_STEP_SUMMARY"
-            if ! python3 - "$result" <<'PY'
-          import json
-          import sys
-          with open(sys.argv[1], encoding='utf-8') as stream:
-              compatible = json.load(stream)['compatibleForReplacement']
-          raise SystemExit(0 if compatible else 1)
-          PY
-            then
-              echo '::warning::The pinned bundle is not yet eligible for p2 replacement. The report records the exact stock-target incompatibility; publication remains disabled.'
-            fi
           else
             {
               echo '### Patched JDT UI target compatibility'
@@ -110,11 +117,121 @@ jobs:
               echo '```'
             } >> "$GITHUB_STEP_SUMMARY"
           fi
+      - name: Enforce stock-target replacement gate
+        shell: bash
+        run: |
+          python3 - "$RUNNER_TEMP/patched-jdt-ui-compatibility/compatibility.json" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          report = json.loads(Path(sys.argv[1]).read_text(encoding='utf-8'))
+          if report.get('compatibleForReplacement') is not True:
+              raise SystemExit('Pinned JDT UI bundle is not compatible with the stock target')
+          PY
       - name: Upload stock-target compatibility report
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: patched-jdt-ui-target-compatibility-${{ github.sha }}
           path: ${{ runner.temp }}/patched-jdt-ui-compatibility/
+          retention-days: 14
+          if-no-files-found: warn
+
+  p2-repository:
+    needs: [ build, target-compatibility ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+      - uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1
+        with:
+          maven-version: 3.9.14
+      - name: Download verified replacement bundle
+        uses: actions/download-artifact@v7
+        with:
+          name: patched-jdt-ui-${{ github.sha }}
+          path: ${{ runner.temp }}/patched-jdt-ui
+      - name: Download stock-target compatibility evidence
+        uses: actions/download-artifact@v7
+        with:
+          name: patched-jdt-ui-target-compatibility-${{ github.sha }}
+          path: ${{ runner.temp }}/patched-jdt-ui-compatibility
+      - name: Publish and verify exact-version p2 repository
+        shell: bash
+        run: |
+          bash .github/scripts/publish_patched_jdt_ui_repository.sh \
+            "$RUNNER_TEMP/patched-jdt-ui" \
+            "$RUNNER_TEMP/patched-jdt-ui-compatibility" \
+            "$RUNNER_TEMP/patched-jdt-ui-p2"
+      - name: Publish p2 repository summary
+        if: always()
+        shell: bash
+        run: |
+          report="$RUNNER_TEMP/patched-jdt-ui-p2/evidence/repository-verification.md"
+          if [[ -s "$report" ]]; then
+            cat "$report" >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - name: Upload verified p2 repository
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: patched-jdt-ui-p2-${{ github.sha }}
+          path: ${{ runner.temp }}/patched-jdt-ui-p2/
+          retention-days: 14
+          if-no-files-found: warn
+
+  patched-product-installation:
+    needs: p2-repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 100
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+      - uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1
+        with:
+          maven-version: 3.9.14
+      - name: Install Linux product runtime libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends xvfb libgtk-3-0
+      - name: Download verified patch repository
+        uses: actions/download-artifact@v7
+        with:
+          name: patched-jdt-ui-p2-${{ github.sha }}
+          path: ${{ runner.temp }}/patched-jdt-ui-p2
+      - name: Build the independent stock product
+        run: mvn -Pproduct -T 1C --batch-mode clean package -DskipTests
+      - name: Install exact patch feature and start the product
+        shell: bash
+        run: |
+          bash .github/scripts/smoke_test_patched_jdt_ui_repository.sh \
+            "$RUNNER_TEMP/patched-jdt-ui-p2" \
+            "$RUNNER_TEMP/patched-jdt-ui-installation"
+      - name: Publish installation summary
+        if: always()
+        shell: bash
+        run: |
+          report="$RUNNER_TEMP/patched-jdt-ui-installation/installation-verification.md"
+          if [[ -s "$report" ]]; then
+            cat "$report" >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - name: Upload patched-product installation evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: patched-jdt-ui-installation-${{ github.sha }}
+          path: ${{ runner.temp }}/patched-jdt-ui-installation/
           retention-days: 14
           if-no-files-found: warn

--- a/docs/patched-jdt-ui-delivery.md
+++ b/docs/patched-jdt-ui-delivery.md
@@ -81,15 +81,15 @@ The publisher creates a temporary source layout and invokes Tycho's Features and
 - `sandbox_patched_jdt_ui_feature_<derived-version>.jar`;
 - compressed p2 metadata and artifact indexes.
 
-The carrier feature pins the replacement through both its feature plug-in entry and a `match="perfect"` requirement. Its qualifier is derived from the reviewed bundle version, so rebuilding the same pinned source produces the same feature identity.
+The carrier feature pins the replacement through both its feature plug-in entry and a `match="perfect"` requirement. Tycho materializes those dependencies on the feature-group IU and keeps the feature-jar IU as the feature artifact carrier. Its qualifier is derived from the reviewed bundle version, so rebuilding the same pinned source produces the same feature identity.
 
-`.github/scripts/verify_patched_jdt_ui_repository.py` then requires:
+After publication, `.github/scripts/add_p2_sha256_checksums.py` recomputes the local artifact bytes and writes size plus SHA-256 metadata for every bundle and feature artifact. `.github/scripts/verify_patched_jdt_ui_repository.py` then requires:
 
 - exactly one bundle IU with the provenance-bound version;
 - exactly one feature-group IU and feature-jar IU;
-- an exact feature-jar-to-bundle requirement;
+- exact feature-group requirements for both the feature-jar IU and patched bundle IU;
 - exactly one bundle artifact and one feature artifact;
-- referenced files, declared sizes and at least one verifiable checksum per artifact;
+- referenced files, declared sizes and a verifiable checksum for every artifact;
 - byte equality between the published bundle and the original SHA-256 provenance;
 - a packaged `feature.xml` with the expected IDs and exact version.
 

--- a/docs/patched-jdt-ui-delivery.md
+++ b/docs/patched-jdt-ui-delivery.md
@@ -4,7 +4,14 @@
 
 The normal Sandbox target and cleanup test reactor use the stock Eclipse JDT UI bundle. Automatic multi-file cleanup scope expansion is an optional product capability that requires a reviewed replacement of the singleton `org.eclipse.jdt.ui` bundle.
 
-This document covers the reproducible source-bundle and stock-target compatibility stages. Minimal p2 publication, exact-IU product resolution, product startup and stock-versus-patched runtime smoke tests remain tracked in #1209 and #1215.
+The delivery pipeline has four fail-closed stages:
+
+1. reproducible source-bundle build from an immutable fork commit;
+2. strict comparison with the exact stock bundle selected by the checked-in Eclipse 2025-12 target;
+3. publication of a minimal p2 repository containing the replacement and an exact-version carrier feature;
+4. installation into an independently materialized stock Linux product, followed by singleton-selection and startup checks.
+
+Runtime apply/undo coverage for a real multi-file cleanup and publication to a persistent public channel remain tracked in #1209.
 
 ## Pinned source
 
@@ -17,7 +24,7 @@ The immutable coordinates are stored in `.github/patched-jdt-ui.env`:
 
 The commit is the merged result of `carstenartur/eclipse.jdt.ui#95`. Its fork synchronization manifest preserves both the modified `CleanUpRefactoring.java` source and `MultiFileCleanUpScopeExpansionTest.java`.
 
-## Local rebuild
+## Reproducible bundle build
 
 Requirements are Git, Java 21, Maven 3.9.x, JDK tools, Python 3 and access to the pinned fork plus Eclipse build repositories.
 
@@ -48,21 +55,85 @@ bash .github/scripts/compare_patched_jdt_ui_with_target.sh \
   target/patched-jdt-ui-compatibility
 ```
 
-The comparison removes only cached `org.eclipse.jdt.ui` artifacts, resolves `sandbox_target/eclipse.target` through the normal Tycho build and identifies the single stock JDT UI bundle selected from Eclipse 2025-12. It then records:
+The comparison uses an isolated Maven repository, resolves `sandbox_target/eclipse.target` through the normal Tycho build and identifies the single stock JDT UI bundle selected from Eclipse 2025-12. It records:
 
 - the exact stock and patched OSGi versions and SHA-256 checksums;
 - whether the patched version is strictly newer, as required for singleton replacement;
 - normalized differences in `Bundle-RequiredExecutionEnvironment`, `Require-Bundle` and `Import-Package`;
 - whether every stock `Export-Package` remains present in the patched bundle.
 
-Results are written to `compatibility.json` and `compatibility.md` and uploaded as a workflow artifact. A blocked result is emitted as an Actions warning and prevents the next p2-publication stage from being introduced. The source-bundle job may still remain green because it proves a different property: reproducibility of the pinned source build.
+Results are written to `compatibility.json` and `compatibility.md`. The p2 stage cannot run unless `compatibleForReplacement` is exactly `true`.
 
-The comparison is deliberately strict. A manifest difference is treated as unresolved compatibility work rather than assumed safe. Once the report passes, the next stage can publish a minimal p2 repository and prove exact IU selection in a patched product.
+## Minimal exact-version p2 repository
 
-## Trust boundary
+The repository is generated from the already verified bundle and compatibility evidence:
 
-Passing the source-bundle stage proves the source revision, patch paths, singleton identity, compiled capability marker and artifact checksum. Passing the compatibility stage additionally proves that the resolved 2025-12 stock bundle can be replaced without changing its declared execution environment, imports, required bundles or exported package surface under the current strict policy.
+```bash
+bash .github/scripts/publish_patched_jdt_ui_repository.sh \
+  target/patched-jdt-ui \
+  target/patched-jdt-ui-compatibility \
+  target/patched-jdt-ui-p2
+```
 
-Neither stage proves p2 installation, product startup, runtime cleanup expansion, apply/undo behavior or rollback. Those checks belong to the p2/product stages before an installation channel is published.
+The publisher creates a temporary source layout and invokes Tycho's Features and Bundles Publisher. The repository contains only:
 
-The stock target remains the default and has no dependency on this optional bundle artifact.
+- `org.eclipse.jdt.ui_<qualified-version>.jar`;
+- `sandbox_patched_jdt_ui_feature_<derived-version>.jar`;
+- compressed p2 metadata and artifact indexes.
+
+The carrier feature pins the replacement through both its feature plug-in entry and a `match="perfect"` requirement. Its qualifier is derived from the reviewed bundle version, so rebuilding the same pinned source produces the same feature identity.
+
+`.github/scripts/verify_patched_jdt_ui_repository.py` then requires:
+
+- exactly one bundle IU with the provenance-bound version;
+- exactly one feature-group IU and feature-jar IU;
+- an exact feature-jar-to-bundle requirement;
+- exactly one bundle artifact and one feature artifact;
+- referenced files, declared sizes and at least one verifiable checksum per artifact;
+- byte equality between the published bundle and the original SHA-256 provenance;
+- a packaged `feature.xml` with the expected IDs and exact version.
+
+The resulting repository and JSON/Markdown evidence are uploaded as a workflow artifact. This is an installable CI artifact, not yet a permanent public update-site channel.
+
+## Stock-to-patched installation smoke test
+
+The final workflow job builds the normal stock Linux GTK x86_64 product without consuming the patch repository. It records the stock `org.eclipse.jdt.ui` entry from `configuration/org.eclipse.equinox.simpleconfigurator/bundles.info`, then installs the exact patch feature into that materialized profile with the p2 director.
+
+```bash
+bash .github/scripts/smoke_test_patched_jdt_ui_repository.sh \
+  target/patched-jdt-ui-p2 \
+  target/patched-jdt-ui-installation
+```
+
+The smoke test requires:
+
+- one and only one stock JDT UI selection before installation;
+- a different, exact patched version after installation;
+- one active simpleconfigurator entry for `org.eclipse.jdt.ui`;
+- installed bundle bytes matching the pinned SHA-256;
+- the patch feature reported as an installed root;
+- successful startup of the modified product through the p2 director application.
+
+Because the stock product is built before the patch repository is introduced, the same workflow also proves that the ordinary target remains independently materializable.
+
+## Workflow evidence
+
+`.github/workflows/patched-jdt-ui-bundle.yml` runs for matching pull requests, matching pushes to `main`, and manual dispatch. It publishes bounded-retention artifacts for:
+
+- source-bundle build diagnostics;
+- verified bundle and source provenance;
+- stock-target compatibility;
+- exact-version p2 repository and repository verification;
+- stock-versus-patched installation and startup evidence.
+
+Cached Maven data may accelerate resolution, but every trust decision is recomputed from pinned source, an isolated target-resolution repository or artifact checksums.
+
+## Rollback and upgrade boundary
+
+The patch is not added to the normal target, normal update site or default product definition. Omitting the optional patch repository and feature therefore rebuilds the stock product. Before advancing the Eclipse target or pinned fork revision, the complete bundle, compatibility, p2 and installation pipeline must pass again; a changed bundle qualifier produces a new feature identity rather than overwriting prior evidence.
+
+No generated JAR is committed. A persistent public patch channel must add immutable versioned publication, public URL verification and retention/rollback policy before promotion.
+
+## Remaining #1209 work
+
+The current stages prove source provenance, manifest compatibility, p2 metadata, exact singleton selection and product startup. They do not yet prove that a running patched product invokes scope expansion for a real cleanup, previews the related compilation unit, applies the complete change and undoes it. That behavioral product test, plus persistent release-channel publication and rollback, remains required before #1209 can close.

--- a/docs/patched-jdt-ui-delivery.md
+++ b/docs/patched-jdt-ui-delivery.md
@@ -95,9 +95,17 @@ After publication, `.github/scripts/add_p2_sha256_checksums.py` recomputes the l
 
 The resulting repository and JSON/Markdown evidence are uploaded as a workflow artifact. This is an installable CI artifact, not yet a permanent public update-site channel.
 
-## Stock-to-patched installation smoke test
+## Patched-product profile and installation smoke test
 
-The final workflow job builds the normal stock Linux GTK x86_64 product without consuming the patch repository. It records the stock `org.eclipse.jdt.ui` entry from `configuration/org.eclipse.equinox.simpleconfigurator/bundles.info`, then installs the exact patch feature into that materialized profile with the p2 director.
+The normal `product` profile remains unchanged. The opt-in `patched-product` profile in `sandbox_product/pom.xml` overlays the generated repository only after Tycho has materialized the ordinary stock product. It requires an absolute path to the verified p2 output and runs the same repository-owned smoke script during the product module's `verify` phase.
+
+```bash
+mvn -Pproduct,patched-product -T 1C --batch-mode clean verify -DskipTests \
+  -Dpatched.jdt.ui.p2.root="$PWD/target/patched-jdt-ui-p2" \
+  -Dpatched.jdt.ui.installation.evidence="$PWD/target/patched-jdt-ui-installation"
+```
+
+The profile first records the stock `org.eclipse.jdt.ui` entry from `configuration/org.eclipse.equinox.simpleconfigurator/bundles.info`, then installs the exact patch feature into that materialized Linux GTK x86_64 profile with the p2 director. The underlying checkout-runnable command is:
 
 ```bash
 bash .github/scripts/smoke_test_patched_jdt_ui_repository.sh \
@@ -114,7 +122,7 @@ The smoke test requires:
 - the patch feature reported as an installed root;
 - successful startup of the modified product through the p2 director application.
 
-Because the stock product is built before the patch repository is introduced, the same workflow also proves that the ordinary target remains independently materializable.
+Because the stock product is built before the patch repository is introduced, the same profile proves that the ordinary target remains independently materializable. Omitting `patched-product` and the p2 path produces the original stock product without consulting the fork repository.
 
 ## Workflow evidence
 
@@ -124,16 +132,16 @@ Because the stock product is built before the patch repository is introduced, th
 - verified bundle and source provenance;
 - stock-target compatibility;
 - exact-version p2 repository and repository verification;
-- stock-versus-patched installation and startup evidence.
+- patched-product profile installation and startup evidence.
 
 Cached Maven data may accelerate resolution, but every trust decision is recomputed from pinned source, an isolated target-resolution repository or artifact checksums.
 
 ## Rollback and upgrade boundary
 
-The patch is not added to the normal target, normal update site or default product definition. Omitting the optional patch repository and feature therefore rebuilds the stock product. Before advancing the Eclipse target or pinned fork revision, the complete bundle, compatibility, p2 and installation pipeline must pass again; a changed bundle qualifier produces a new feature identity rather than overwriting prior evidence.
+The patch is not added to the normal target, normal update site or default product definition. Omitting the optional `patched-product` profile, patch repository and carrier feature therefore rebuilds the stock product. Before advancing the Eclipse target or pinned fork revision, the complete bundle, compatibility, p2 and installation pipeline must pass again; a changed bundle qualifier produces a new feature identity rather than overwriting prior evidence.
 
 No generated JAR is committed. A persistent public patch channel must add immutable versioned publication, public URL verification and retention/rollback policy before promotion.
 
 ## Remaining #1209 work
 
-The current stages prove source provenance, manifest compatibility, p2 metadata, exact singleton selection and product startup. They do not yet prove that a running patched product invokes scope expansion for a real cleanup, previews the related compilation unit, applies the complete change and undoes it. That behavioral product test, plus persistent release-channel publication and rollback, remains required before #1209 can close.
+The current stages prove source provenance, manifest compatibility, p2 metadata, an explicit patched-product profile, exact singleton selection and product startup. They do not yet prove that a running patched product invokes scope expansion for a real cleanup, previews the related compilation unit, applies the complete change and undoes it. That behavioral product test remains the final #1209 acceptance stage.

--- a/sandbox_product/pom.xml
+++ b/sandbox_product/pom.xml
@@ -108,4 +108,69 @@
 			</plugin>
 		</plugins>
 	</build>
+	<profiles>
+		<!--
+			Opt-in overlay for the provenance-bound JDT UI replacement repository.
+			Activate together with the root product profile:
+			-Pproduct,patched-product -Dpatched.jdt.ui.p2.root=/absolute/path/to/p2-output
+		-->
+		<profile>
+			<id>patched-product</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+			<properties>
+				<patched.jdt.ui.installation.evidence>${project.build.directory}/patched-jdt-ui-installation</patched.jdt.ui.installation.evidence>
+			</properties>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-enforcer-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>require-patched-jdt-ui-p2-root</id>
+								<phase>validate</phase>
+								<goals>
+									<goal>enforce</goal>
+								</goals>
+								<configuration>
+									<rules>
+										<requireProperty>
+											<property>patched.jdt.ui.p2.root</property>
+											<message>The patched-product profile requires -Dpatched.jdt.ui.p2.root=/absolute/path/to/the/generated-p2-output.</message>
+											<regex>.+</regex>
+										</requireProperty>
+									</rules>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.codehaus.mojo</groupId>
+						<artifactId>exec-maven-plugin</artifactId>
+						<version>3.6.3</version>
+						<executions>
+							<execution>
+								<id>install-and-start-patched-jdt-ui-product</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>exec</goal>
+								</goals>
+								<configuration>
+									<executable>bash</executable>
+									<workingDirectory>${maven.multiModuleProjectDirectory}</workingDirectory>
+									<arguments>
+										<argument>.github/scripts/smoke_test_patched_jdt_ui_repository.sh</argument>
+										<argument>${patched.jdt.ui.p2.root}</argument>
+										<argument>${patched.jdt.ui.installation.evidence}</argument>
+									</arguments>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>


### PR DESCRIPTION
## Summary

Advances #1209 from reproducible bundle construction and stock-target compatibility into an installable, provenance-bound p2 stage.

## Exact-version p2 repository

- consumes only the bundle artifact and SHA-256 provenance produced by the pinned source build;
- requires the strict stock-target compatibility report to authorize replacement;
- derives a deterministic carrier-feature version from the reviewed bundle qualifier;
- publishes the replacement bundle and `sandbox_patched_jdt_ui_feature` with Tycho's Features and Bundles Publisher;
- pins `org.eclipse.jdt.ui` through both the feature plug-in entry and a `match="perfect"` requirement;
- validates the bundle IU, feature-group IU, feature-jar IU, exact requirements, artifact keys, files, sizes and checksums;
- rejects any mismatch between source provenance, compatibility evidence and published bytes.

## Stock-to-patched installation smoke test

- builds the ordinary Linux GTK x86_64 product without the patch repository;
- records the single stock `org.eclipse.jdt.ui` selection;
- installs the exact patch feature into the materialized profile through the p2 director;
- requires exactly one active simpleconfigurator entry with the patched version;
- verifies the installed JAR against the pinned SHA-256;
- starts the modified product through the p2 director and requires the patch feature as an installed root.

## Workflow and evidence

- runs on relevant pull requests, matching pushes to `main`, and manual dispatch;
- makes target compatibility a hard gate before p2 publication;
- uploads the repository, source/compatibility inputs, repository verification and installation evidence as bounded-retention artifacts;
- keeps the normal target, update site and product definition independent of the optional patch.

## Scope boundary

This PR proves p2 metadata, exact singleton selection and product startup. It does not yet exercise a real multi-file cleanup through preview, scope expansion, apply and undo, and it does not publish a persistent public patch channel. Those remain the final #1209 stages.

Refs #1209.
Refs #1215.