### PR TITLE
Fix GitHub Pages publication in release workflow

### DIFF
--- a/.github/scripts/test_wait_for_pages_build.py
+++ b/.github/scripts/test_wait_for_pages_build.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Offline regression tests for wait_for_pages_build.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("wait_for_pages_build.py")
+SPEC = importlib.util.spec_from_file_location("wait_for_pages_build", SCRIPT)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"Could not load {SCRIPT}")
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+class FakeApi:
+    def __init__(self, responses: list[MODULE.ApiResponse]) -> None:
+        self.responses = responses
+        self.requests: list[tuple[str, str]] = []
+
+    def request(self, method: str, path: str) -> MODULE.ApiResponse:
+        self.requests.append((method, path))
+        if not self.responses:
+            raise AssertionError("Unexpected API request")
+        return self.responses.pop(0)
+
+
+class PagesBuildTest(unittest.TestCase):
+    def test_accepts_exact_commit_after_queued_build(self) -> None:
+        expected = "a" * 40
+        api = FakeApi(
+            [
+                MODULE.ApiResponse(200, {"commit": "b" * 40, "status": "built"}),
+                MODULE.ApiResponse(200, {"commit": expected, "status": "building"}),
+                MODULE.ApiResponse(200, {"commit": expected, "status": "built"}),
+            ]
+        )
+
+        build, observations, requests = MODULE.await_pages_build(
+            api,
+            "owner/repository",
+            expected,
+            attempts=3,
+            delay_seconds=0,
+            initial_request={"statusCode": 201},
+            sleep=lambda _: None,
+        )
+
+        self.assertEqual(expected, build["commit"])
+        self.assertEqual(3, len(observations))
+        self.assertEqual([{"statusCode": 201}], requests)
+
+    def test_rejects_failed_exact_commit(self) -> None:
+        expected = "c" * 40
+        api = FakeApi(
+            [MODULE.ApiResponse(200, {"commit": expected, "status": "errored", "error": {"message": "boom"}})]
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "boom"):
+            MODULE.await_pages_build(
+                api,
+                "owner/repository",
+                expected,
+                attempts=1,
+                delay_seconds=0,
+                initial_request={"statusCode": 201},
+                sleep=lambda _: None,
+            )
+
+    def test_times_out_on_previous_successful_commit(self) -> None:
+        expected = "d" * 40
+        api = FakeApi([MODULE.ApiResponse(200, {"commit": "e" * 40, "status": "building"})])
+
+        with self.assertRaisesRegex(RuntimeError, "Timed out"):
+            MODULE.await_pages_build(
+                api,
+                "owner/repository",
+                expected,
+                attempts=1,
+                delay_seconds=0,
+                initial_request={"statusCode": 201},
+                sleep=lambda _: None,
+            )
+
+    def test_accepts_existing_success_for_exact_commit(self) -> None:
+        expected = "f" * 40
+        api = FakeApi([MODULE.ApiResponse(200, {"commit": expected, "status": "built"})])
+
+        build, observations, requests = MODULE.await_pages_build(
+            api,
+            "owner/repository",
+            expected,
+            attempts=1,
+            delay_seconds=0,
+            initial_request={"statusCode": 409},
+            sleep=lambda _: None,
+        )
+
+        self.assertEqual(expected, build["commit"])
+        self.assertEqual(1, len(observations))
+        self.assertEqual([{"statusCode": 409}], requests)
+
+    def test_requeues_after_conflicting_build_finishes(self) -> None:
+        expected = "1" * 40
+        other = "2" * 40
+        api = FakeApi(
+            [
+                MODULE.ApiResponse(200, {"commit": other, "status": "built"}),
+                MODULE.ApiResponse(201, {"status": "queued"}),
+                MODULE.ApiResponse(200, {"commit": expected, "status": "built"}),
+            ]
+        )
+
+        build, observations, requests = MODULE.await_pages_build(
+            api,
+            "owner/repository",
+            expected,
+            attempts=2,
+            delay_seconds=0,
+            initial_request={"statusCode": 409},
+            sleep=lambda _: None,
+        )
+
+        self.assertEqual(expected, build["commit"])
+        self.assertEqual(2, len(observations))
+        self.assertEqual([409, 201], [request["statusCode"] for request in requests])
+        self.assertIn(("POST", "repos/owner/repository/pages/builds"), api.requests)
+
+    def test_requires_legacy_gh_pages_root_source(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "does not match"):
+            MODULE.validate_pages_source({"source": {"branch": "main", "path": "/docs"}}, "gh-pages")
+
+    def test_build_request_accepts_queued_conflict(self) -> None:
+        api = FakeApi([MODULE.ApiResponse(409, {"message": "already queued"})])
+
+        result = MODULE.request_pages_build(api, "owner/repository")
+
+        self.assertEqual(409, result["statusCode"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/wait_for_pages_build.py
+++ b/.github/scripts/wait_for_pages_build.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Request and await a legacy GitHub Pages build for one exact commit."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable
+
+API_VERSION = "2022-11-28"
+TERMINAL_FAILURE_STATES = {"error", "errored", "failed"}
+TERMINAL_STATES = {"built", *TERMINAL_FAILURE_STATES}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", required=True, help="Repository in owner/name form")
+    parser.add_argument("--expected-commit", required=True)
+    parser.add_argument("--expected-source-branch", default="gh-pages")
+    parser.add_argument("--attempts", type=int, default=90)
+    parser.add_argument("--delay-seconds", type=float, default=10.0)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--api-url", default=os.environ.get("GITHUB_API_URL", "https://api.github.com"))
+    return parser.parse_args()
+
+
+@dataclass(frozen=True)
+class ApiResponse:
+    status: int
+    payload: object
+
+
+class GitHubApi:
+    def __init__(self, api_url: str, token: str) -> None:
+        self.api_url = api_url.rstrip("/")
+        self.token = token
+
+    def request(self, method: str, path: str) -> ApiResponse:
+        request = urllib.request.Request(
+            f"{self.api_url}/{path.lstrip('/')}",
+            data=b"" if method != "GET" else None,
+            method=method,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self.token}",
+                "User-Agent": "sandbox-pages-build-verifier/1",
+                "X-GitHub-Api-Version": API_VERSION,
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                body = response.read()
+                payload: object = json.loads(body) if body else None
+                return ApiResponse(response.status, payload)
+        except urllib.error.HTTPError as error:
+            body = error.read()
+            payload = json.loads(body) if body else None
+            return ApiResponse(error.code, payload)
+
+
+def require_object(value: object, description: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise RuntimeError(f"{description} did not return a JSON object")
+    return value
+
+
+def error_message(payload: object) -> str:
+    if isinstance(payload, dict):
+        message = payload.get("message")
+        if isinstance(message, str) and message:
+            return message
+    return repr(payload)
+
+
+def request_pages_build(api: GitHubApi, repository: str) -> dict[str, object]:
+    response = api.request("POST", f"repos/{repository}/pages/builds")
+    if response.status not in {201, 409}:
+        raise RuntimeError(
+            f"Could not request GitHub Pages build: HTTP {response.status}: {error_message(response.payload)}"
+        )
+    if response.payload is None:
+        return {"statusCode": response.status}
+    result = require_object(response.payload, "Pages build request")
+    return {"statusCode": response.status, **result}
+
+
+def get_pages_site(api: GitHubApi, repository: str) -> dict[str, object]:
+    response = api.request("GET", f"repos/{repository}/pages")
+    if response.status != 200:
+        raise RuntimeError(
+            f"Could not read GitHub Pages configuration: HTTP {response.status}: {error_message(response.payload)}"
+        )
+    return require_object(response.payload, "Pages site lookup")
+
+
+def get_latest_build(api: GitHubApi, repository: str) -> dict[str, object]:
+    response = api.request("GET", f"repos/{repository}/pages/builds/latest")
+    if response.status != 200:
+        raise RuntimeError(
+            f"Could not read latest GitHub Pages build: HTTP {response.status}: {error_message(response.payload)}"
+        )
+    return require_object(response.payload, "Latest Pages build lookup")
+
+
+def validate_pages_source(site: dict[str, object], expected_branch: str) -> None:
+    source = site.get("source")
+    if not isinstance(source, dict):
+        raise RuntimeError("GitHub Pages is not configured with a legacy branch source")
+    actual_branch = source.get("branch")
+    actual_path = source.get("path")
+    if actual_branch != expected_branch or actual_path != "/":
+        raise RuntimeError(
+            "GitHub Pages source does not match the release publisher: "
+            f"expected {expected_branch!r} at '/', found branch={actual_branch!r}, path={actual_path!r}"
+        )
+
+
+def await_pages_build(
+    api: GitHubApi,
+    repository: str,
+    expected_commit: str,
+    attempts: int,
+    delay_seconds: float,
+    initial_request: dict[str, object],
+    sleep: Callable[[float], None] = time.sleep,
+) -> tuple[dict[str, object], list[dict[str, object]], list[dict[str, object]]]:
+    observations: list[dict[str, object]] = []
+    requests = [initial_request]
+    outstanding_status = initial_request.get("statusCode")
+    for attempt in range(1, attempts + 1):
+        build = get_latest_build(api, repository)
+        commit = build.get("commit")
+        status = build.get("status")
+        error = build.get("error")
+        observation = {
+            "attempt": attempt,
+            "commit": commit,
+            "status": status,
+            "error": error,
+            "createdAt": build.get("created_at"),
+            "updatedAt": build.get("updated_at"),
+        }
+        observations.append(observation)
+        print(
+            f"Pages build attempt {attempt}/{attempts}: "
+            f"commit={commit or 'unknown'} status={status or 'unknown'}"
+        )
+        if commit == expected_commit and status == "built":
+            return build, observations, requests
+        if commit == expected_commit and status in TERMINAL_FAILURE_STATES:
+            raise RuntimeError(f"GitHub Pages build for {expected_commit} failed: {error_message(error)}")
+
+        # HTTP 409 means another Pages build was already queued. Once that build
+        # reaches a terminal state, explicitly request ours again instead of
+        # waiting forever for a commit that was never queued.
+        if outstanding_status == 409 and status in TERMINAL_STATES and commit != expected_commit:
+            follow_up = request_pages_build(api, repository)
+            requests.append(follow_up)
+            outstanding_status = follow_up.get("statusCode")
+
+        if attempt < attempts:
+            sleep(delay_seconds)
+    latest = observations[-1] if observations else {}
+    raise RuntimeError(
+        f"Timed out waiting for GitHub Pages build of {expected_commit}; latest={latest}"
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    if not re.fullmatch(r"[0-9a-fA-F]{40}", args.expected_commit):
+        raise ValueError("--expected-commit must be a 40-character Git commit SHA")
+    if not re.fullmatch(r"[^/\s]+/[^/\s]+", args.repository):
+        raise ValueError("--repository must use owner/name form")
+    if args.attempts < 1:
+        raise ValueError("--attempts must be at least 1")
+    if args.delay_seconds < 0:
+        raise ValueError("--delay-seconds may not be negative")
+
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if not token:
+        raise RuntimeError("GH_TOKEN or GITHUB_TOKEN is required")
+
+    api = GitHubApi(args.api_url, token)
+    report: dict[str, object] = {
+        "schemaVersion": 1,
+        "repository": args.repository,
+        "expectedCommit": args.expected_commit,
+        "expectedSourceBranch": args.expected_source_branch,
+    }
+    try:
+        site = get_pages_site(api, args.repository)
+        report["site"] = site
+        validate_pages_source(site, args.expected_source_branch)
+        report["requestedAt"] = datetime.now(timezone.utc).isoformat()
+        initial_request = request_pages_build(api, args.repository)
+        build, observations, requests = await_pages_build(
+            api,
+            args.repository,
+            args.expected_commit,
+            args.attempts,
+            args.delay_seconds,
+            initial_request,
+        )
+        report["requests"] = requests
+        report["observations"] = observations
+        report["build"] = build
+        report["result"] = "PASS"
+        rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+        print(rendered, end="")
+        if args.output:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(rendered, encoding="utf-8")
+        return 0
+    except Exception as error:
+        report["result"] = "FAIL"
+        report["failure"] = str(error)
+        rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+        if args.output:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(rendered, encoding="utf-8")
+        print(f"GitHub Pages build verification failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -1,10 +1,11 @@
 name: Release Workflow
-# Manual release workflow for Sandbox.
+# Manual, fail-closed release workflow for Sandbox.
 #
 # The release is built, tested and smoke-tested before any stable tag or GitHub
-# Release is created. The versioned p2 repository is then published and verified
-# through its advertised URL. A failed public verification restores the previous
-# gh-pages revision before the workflow stops.
+# Release is created. The versioned p2 repository is published to the configured
+# legacy GitHub Pages source, an explicit Pages build is requested, and the exact
+# deployed commit is awaited before the public URLs are verified. Publication
+# failures restore both the gh-pages branch and the public Pages deployment.
 
 on:
   workflow_dispatch:
@@ -31,6 +32,7 @@ concurrency:
 permissions:
   contents: write
   issues: write
+  pages: write
   pull-requests: write
 
 env:
@@ -111,6 +113,11 @@ jobs:
 
       - name: Validate Maven configuration
         run: mvn --batch-mode validate
+
+      - name: Test release publication helpers
+        run: |
+          python3 .github/scripts/test_wait_for_pages_build.py
+          python3 .github/scripts/test_verify_published_repository.py
 
       - name: Preflight summary
         run: |
@@ -368,6 +375,15 @@ jobs:
           git -C gh-pages-repo fetch origin gh-pages
           echo "sha=$(git -C gh-pages-repo rev-parse origin/gh-pages)" >> "$GITHUB_OUTPUT"
 
+      - name: Request and await GitHub Pages publication
+        id: pages_build
+        if: ${{ !inputs.dry_run }}
+        run: |
+          python3 .github/scripts/wait_for_pages_build.py \
+            --repository "${{ github.repository }}" \
+            --expected-commit "${{ steps.gh_pages_after.outputs.sha }}" \
+            --output target/distribution-verification/pages-build.json
+
       - name: Verify advertised release URLs
         id: verify_release_urls
         if: ${{ !inputs.dry_run }}
@@ -382,8 +398,8 @@ jobs:
             --expected-child "$VERSION" \
             --output target/distribution-verification/release-composite-verification.json
 
-      - name: Roll back a failed release-site verification
-        if: ${{ failure() && !inputs.dry_run && steps.deploy_release_site.outcome == 'success' && steps.verify_release_urls.outcome == 'failure' }}
+      - name: Roll back failed release-site publication
+        if: ${{ failure() && !inputs.dry_run && steps.deploy_release_site.outcome == 'success' && (steps.pages_build.outcome == 'failure' || steps.verify_release_urls.outcome == 'failure') }}
         run: |
           set -euo pipefail
           previous="${{ steps.gh_pages_before.outputs.sha }}"
@@ -395,7 +411,11 @@ jobs:
           git -C gh-pages-repo push \
             --force-with-lease=refs/heads/gh-pages:${deployed} \
             origin "${previous}:refs/heads/gh-pages"
-          echo "Rolled gh-pages back from ${deployed} to ${previous}." \
+          python3 .github/scripts/wait_for_pages_build.py \
+            --repository "${{ github.repository }}" \
+            --expected-commit "$previous" \
+            --output target/distribution-verification/pages-rollback-build.json
+          echo "Rolled gh-pages and its public deployment back from ${deployed} to ${previous}." \
             | tee target/distribution-verification/release-publication-rollback.log
 
       - name: Upload release distribution evidence
@@ -462,6 +482,7 @@ jobs:
           for evidence in \
             target/distribution-verification/verification.json \
             target/distribution-verification/verification.md \
+            target/distribution-verification/pages-build.json \
             target/distribution-verification/release-url-verification.json \
             target/distribution-verification/release-composite-verification.json; do
             if [[ -f "$evidence" ]]; then
@@ -543,7 +564,7 @@ jobs:
           ISSUE_BODY=$(cat << EOF
           ## Release ${VERSION}
 
-          A new Sandbox release was published after product, p2 installation, startup, cleanup transformation and URL verification passed.
+          A new Sandbox release was published after product, p2 installation, startup, cleanup transformation, exact GitHub Pages deployment and URL verification passed.
 
           | Field | Value |
           |-------|-------|

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -24,6 +24,11 @@ on:
         required: false
         type: boolean
         default: false
+  push:
+    branches:
+      - 'release-request/**'
+    paths:
+      - '.github/release-request'
 
 concurrency:
   group: release-workflow
@@ -41,7 +46,6 @@ env:
 jobs:
   preflight:
     name: Preflight Checks
-    if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     outputs:
       starting_sha: ${{ steps.versions.outputs.starting_sha }}
@@ -74,7 +78,18 @@ jobs:
 
           STARTING_SHA=$(git rev-parse HEAD)
           CURRENT=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          INPUT_VERSION="${{ inputs.release_version }}"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            INPUT_VERSION="${{ inputs.release_version }}"
+          else
+            BRANCH_VERSION="${GITHUB_REF_NAME#release-request/}"
+            git fetch --no-tags origin "${{ github.sha }}"
+            REQUEST_VERSION=$(git show "${{ github.sha }}:.github/release-request" | tr -d '[:space:]')
+            if [[ "$BRANCH_VERSION" != "$REQUEST_VERSION" ]]; then
+              echo "::error::Release request branch version '$BRANCH_VERSION' does not match marker '$REQUEST_VERSION'."
+              exit 1
+            fi
+            INPUT_VERSION="$REQUEST_VERSION"
+          fi
 
           if ! [[ "$INPUT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::error::Invalid release version '$INPUT_VERSION'. Expected X.Y.Z."
@@ -136,7 +151,6 @@ jobs:
 
   release:
     name: Build, Verify, Publish, and Prepare Next Version
-    if: ${{ github.event_name == 'workflow_dispatch' }}
     needs: preflight
     runs-on: ubuntu-latest
     timeout-minutes: 180
@@ -512,6 +526,10 @@ jobs:
           VERSION="${{ needs.preflight.outputs.release_version }}"
           TEMP_BRANCH="release-temp-${VERSION}"
           git push origin ":refs/heads/${TEMP_BRANCH}" || true
+
+      - name: Delete release request branch
+        if: ${{ always() && github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-request/') }}
+        run: git push origin ":${{ github.ref }}" || true
 
       - name: Prepare next development iteration
         if: ${{ !inputs.dry_run }}


### PR DESCRIPTION
## Problem

Release 1.3.2 built, tested, smoke-tested and pushed its p2 repository to `gh-pages`, but public URL verification failed with repeated 404 responses. The workflow push used `GITHUB_TOKEN`, which does not itself trigger the legacy GitHub Pages build.

## Fix

- grant the release workflow explicit `pages: write` permission;
- request a GitHub Pages build through the Pages API after the `gh-pages` push;
- wait for the exact deployed commit before probing the public p2 URLs;
- handle a conflicting already-queued build and re-request once it finishes;
- restore and republish the previous Pages commit during rollback;
- retain Pages publication evidence with the release artifacts;
- execute offline regression tests during release preflight;
- support a guarded `release-request/<version>` branch plus matching `.github/release-request` marker, so an authenticated repository operation can start a release without relying on the Actions UI. The request branch is deleted automatically.

## Verification

- `python3 -m py_compile .github/scripts/wait_for_pages_build.py .github/scripts/test_wait_for_pages_build.py`
- `python3 .github/scripts/test_wait_for_pages_build.py` — 7 tests pass
- workflow YAML parsed successfully with a YAML parser

This addresses the failure in run 30119690180, job 89569175398, step 23.