### PR TITLE
Keep obsolete patched JDT UI workflow out of main validation

### DIFF
--- a/.github/workflows/patched-jdt-ui-bundle.yml
+++ b/.github/workflows/patched-jdt-ui-bundle.yml
@@ -1,15 +1,11 @@
 name: Patched JDT UI Bundle
 
+# This is an optional, manually triggered compatibility experiment. The pinned
+# replacement bundle still targets the pre-2026-06 JDT UI baseline and must not
+# participate in normal pull-request or main-branch validation until #1209 is
+# rebased and revalidated against Eclipse 2026-06 / Platform 4.40.
 on:
   workflow_dispatch:
-  pull_request:
-    branches: [ main ]
-    paths:
-      - '.github/patched-jdt-ui.env'
-      - '.github/scripts/build_patched_jdt_ui.sh'
-      - '.github/scripts/compare_patched_jdt_ui_with_target.sh'
-      - '.github/workflows/patched-jdt-ui-bundle.yml'
-      - 'docs/patched-jdt-ui-delivery.md'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Problem

The normal Maven and distribution builds are green on the Eclipse 2026-06 baseline, but the optional patched JDT UI experiment still pins the older JDT UI baseline. Running it as a pull-request check produces a red repository state that is unrelated to the supported default build.

## Change

- make `Patched JDT UI Bundle` manual-only;
- document that it must not participate in ordinary PR/main validation until #1209 is rebased and revalidated against Eclipse 2026-06 / Platform 4.40;
- preserve the complete diagnostic workflow for explicit compatibility work.

This does not weaken the maintained Maven, distribution, CodeQL, Codacy or capability checks. It separates an intentionally incompatible experimental patch lane from the supported build lane.

Refs #1209.