### PR TITLE
Promote verified boolean conditional simplification

### DIFF
--- a/sandbox_common_core/src/main/resources/org/sandbox/jdt/triggerpattern/internal/misc.sandbox-hint
+++ b/sandbox_common_core/src/main/resources/org/sandbox/jdt/triggerpattern/internal/misc.sandbox-hint
@@ -37,6 +37,13 @@ $x.toString()
 => !$a || !$b
 ;;
 
+@id: logical.simplification.boolean-conditional
+@severity: info
+"Simplify condition ? true : false to condition.":
+$condition ? true : false
+=> $condition
+;;
+
 $threadLocalVar.set(null) :: instanceof($threadLocalVar, "java.lang.ThreadLocal")
 => $threadLocalVar.remove()
 ;;

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/BooleanConditionalSimplificationHintTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/BooleanConditionalSimplificationHintTest.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.sandbox.jdt.triggerpattern.api.HintFile;
+
+/** Behavior tests for the promoted boolean conditional simplification. */
+class BooleanConditionalSimplificationHintTest extends HintRuleTestSupport {
+
+	private HintFile hintFile;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		registerBuiltInGuards();
+		hintFile = loadBundledHint("misc.sandbox-hint"); //$NON-NLS-1$
+	}
+
+	@Test
+	void simplifiesConditionalWithLiteralBooleanBranches() {
+		String before = "class Test { boolean m(int value) { return value > 10 ? true : false; } }"; //$NON-NLS-1$
+		String expected = "class Test { boolean m(int value) { return value > 10; } }"; //$NON-NLS-1$
+
+		assertFullReplacement(hintFile, before, expected);
+		assertEquals("logical.simplification.boolean-conditional", //$NON-NLS-1$
+				process(hintFile, before).get(0).rule().getRuleId());
+	}
+
+	@Test
+	void doesNotRewriteNegatedConditionalOrNonLiteralBranches() {
+		assertNoMatch(hintFile,
+				"class Test { boolean m(boolean value) { return value ? false : true; } }"); //$NON-NLS-1$
+		assertNoMatch(hintFile,
+				"class Test { boolean m(boolean value, boolean fallback) { return value ? true : fallback; } }"); //$NON-NLS-1$
+	}
+}


### PR DESCRIPTION
## Summary

Promotes the verified mining candidate from #1284 into the bundled TriggerPattern rule set.

## Change

- adds the stable rule `logical.simplification.boolean-conditional` to `misc.sandbox-hint`;
- rewrites only `$condition ? true : false` to `$condition`;
- adds permanent full-source behavior coverage;
- verifies the stable rule ID;
- keeps `condition ? false : true` and conditionals with non-literal branches unchanged.

The rule is local, side-effect neutral and valid since Java 8. It does not duplicate the existing De Morgan or length-comparison simplifications.

Closes #1284.