### PR TITLE
Reject generated-name collisions across coordinated cleanup scope

### DIFF
--- a/sandbox_common/src/org/sandbox/jdt/cleanup/multifile/GeneratedNameCollisionPolicy.java
+++ b/sandbox_common/src/org/sandbox/jdt/cleanup/multifile/GeneratedNameCollisionPolicy.java
@@ -1,0 +1,226 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.cleanup.multifile;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.FieldDeclaration;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.ImportDeclaration;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.core.dom.TypeParameter;
+import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+
+/**
+ * Conservative, deterministic generated-name collision policy shared by
+ * coordinated cleanups.
+ *
+ * <p>Domain type names are rejected rather than silently suffixed. The caller
+ * must run this assessment against every affected compilation unit immediately
+ * before creating changes so imports, local types and stale working-copy edits
+ * participate in the decision.</p>
+ */
+public final class GeneratedNameCollisionPolicy {
+
+	/** Namespace in which a prospective name is already occupied. */
+	public enum Namespace {
+		TYPE_DECLARATION,
+		INHERITED_TYPE,
+		IMPORT,
+		MEMBER,
+		TYPE_PARAMETER
+	}
+
+	/** One deterministic collision finding. */
+	public record Collision(Namespace namespace, String compilationUnit, String description) {
+		public Collision {
+			namespace= Objects.requireNonNull(namespace);
+			compilationUnit= Objects.requireNonNull(compilationUnit);
+			description= Objects.requireNonNull(description);
+		}
+	}
+
+	/** Complete assessment for one prospective generated name in one source unit. */
+	public record Assessment(String generatedName, List<Collision> collisions) {
+		public Assessment {
+			generatedName= Objects.requireNonNull(generatedName);
+			List<Collision> normalized= new ArrayList<>(collisions == null ? List.of() : collisions);
+			normalized.sort(Comparator.comparing((Collision collision) -> collision.namespace().name())
+					.thenComparing(Collision::compilationUnit).thenComparing(Collision::description));
+			collisions= List.copyOf(normalized);
+		}
+
+		/** Whether the name remains available in this compilation unit. */
+		public boolean available() {
+			return collisions.isEmpty();
+		}
+
+		/** Stable explanation suitable for preview and stale-plan diagnostics. */
+		public String explanation() {
+			if (available()) {
+				return "Generated name " + generatedName + " is available."; //$NON-NLS-1$ //$NON-NLS-2$
+			}
+			return collisions.stream()
+					.map(collision -> collision.namespace() + " in " + collision.compilationUnit() //$NON-NLS-1$
+							+ ": " + collision.description()) //$NON-NLS-1$
+					.collect(java.util.stream.Collectors.joining("; ")); //$NON-NLS-1$
+		}
+	}
+
+	private GeneratedNameCollisionPolicy() {
+	}
+
+	/**
+	 * Assesses one fresh compilation-unit AST against a planned generated name.
+	 *
+	 * @param root fresh AST used to create the current local fix
+	 * @param ownerTypeBindingKey binding key of the type that will own the artifact
+	 * @param ownerTypeQualifiedName qualified source name of the owning type
+	 * @param generatedName prospective simple name
+	 * @return deterministic collision assessment
+	 */
+	public static Assessment assess(CompilationUnit root, String ownerTypeBindingKey,
+			String ownerTypeQualifiedName, String generatedName) {
+		Objects.requireNonNull(root);
+		Objects.requireNonNull(ownerTypeQualifiedName);
+		Objects.requireNonNull(generatedName);
+		String unitName= compilationUnitName(root);
+		List<Collision> collisions= new ArrayList<>();
+		Set<String> identities= new HashSet<>();
+
+		for (Object importObject : root.imports()) {
+			ImportDeclaration declaration= (ImportDeclaration) importObject;
+			if (!declaration.isOnDemand()
+					&& generatedName.equals(declaration.getName().getFullyQualifiedName()
+							.substring(declaration.getName().getFullyQualifiedName().lastIndexOf('.') + 1))) {
+				add(collisions, identities, Namespace.IMPORT, unitName,
+						"explicit import " + declaration.getName().getFullyQualifiedName()); //$NON-NLS-1$
+			}
+		}
+
+		root.accept(new ASTVisitor() {
+			@Override
+			public void preVisit(ASTNode node) {
+				if (node instanceof AbstractTypeDeclaration declaration) {
+					SimpleName name= declaration.getName();
+					if (name != null && generatedName.equals(name.getIdentifier())) {
+						add(collisions, identities, Namespace.TYPE_DECLARATION, unitName,
+								"type declaration " + name.getIdentifier()); //$NON-NLS-1$
+					}
+					if (isOwner(declaration, ownerTypeBindingKey, ownerTypeQualifiedName, root)) {
+						assessOwnerMembers(declaration, generatedName, unitName, collisions, identities);
+						assessInheritedTypes(declaration.resolveBinding(), generatedName, unitName,
+								collisions, identities, new HashSet<>());
+					}
+				} else if (node instanceof TypeParameter parameter
+						&& generatedName.equals(parameter.getName().getIdentifier())) {
+					add(collisions, identities, Namespace.TYPE_PARAMETER, unitName,
+							"type parameter " + parameter.getName().getIdentifier()); //$NON-NLS-1$
+				}
+			}
+		});
+		return new Assessment(generatedName, collisions);
+	}
+
+	private static void assessOwnerMembers(AbstractTypeDeclaration owner, String generatedName,
+			String unitName, List<Collision> collisions, Set<String> identities) {
+		for (Object bodyObject : owner.bodyDeclarations()) {
+			if (bodyObject instanceof FieldDeclaration field) {
+				for (Object fragmentObject : field.fragments()) {
+					VariableDeclarationFragment fragment= (VariableDeclarationFragment) fragmentObject;
+					if (generatedName.equals(fragment.getName().getIdentifier())) {
+						add(collisions, identities, Namespace.MEMBER, unitName,
+								"field " + fragment.getName().getIdentifier()); //$NON-NLS-1$
+					}
+				}
+			} else if (bodyObject instanceof MethodDeclaration method
+					&& generatedName.equals(method.getName().getIdentifier())) {
+				add(collisions, identities, Namespace.MEMBER, unitName,
+						"method " + method.getName().getIdentifier()); //$NON-NLS-1$
+			}
+		}
+		if (owner instanceof TypeDeclaration type) {
+			for (Object parameterObject : type.typeParameters()) {
+				TypeParameter parameter= (TypeParameter) parameterObject;
+				if (generatedName.equals(parameter.getName().getIdentifier())) {
+					add(collisions, identities, Namespace.TYPE_PARAMETER, unitName,
+							"owner type parameter " + parameter.getName().getIdentifier()); //$NON-NLS-1$
+				}
+			}
+		}
+	}
+
+	private static void assessInheritedTypes(ITypeBinding binding, String generatedName, String unitName,
+			List<Collision> collisions, Set<String> identities, Set<String> visited) {
+		if (binding == null) {
+			return;
+		}
+		String key= binding.getTypeDeclaration().getKey();
+		if (key != null && !visited.add(key)) {
+			return;
+		}
+		for (ITypeBinding nested : binding.getDeclaredTypes()) {
+			if (generatedName.equals(nested.getName())) {
+				add(collisions, identities, Namespace.INHERITED_TYPE, unitName,
+						"nested type inherited from " + binding.getQualifiedName()); //$NON-NLS-1$
+			}
+		}
+		assessInheritedTypes(binding.getSuperclass(), generatedName, unitName, collisions, identities, visited);
+		for (ITypeBinding interfaceBinding : binding.getInterfaces()) {
+			assessInheritedTypes(interfaceBinding, generatedName, unitName, collisions, identities, visited);
+		}
+	}
+
+	private static boolean isOwner(AbstractTypeDeclaration declaration, String ownerTypeBindingKey,
+			String ownerTypeQualifiedName, CompilationUnit root) {
+		ITypeBinding binding= declaration.resolveBinding();
+		if (binding != null && ownerTypeBindingKey != null
+				&& ownerTypeBindingKey.equals(binding.getTypeDeclaration().getKey())) {
+			return true;
+		}
+		if (!(declaration.getParent() instanceof CompilationUnit)) {
+			return false;
+		}
+		String packageName= root.getPackage() == null ? "" //$NON-NLS-1$
+				: root.getPackage().getName().getFullyQualifiedName();
+		String qualifiedName= packageName.isEmpty() ? declaration.getName().getIdentifier()
+				: packageName + '.' + declaration.getName().getIdentifier();
+		return ownerTypeQualifiedName.equals(qualifiedName);
+	}
+
+	private static String compilationUnitName(CompilationUnit root) {
+		if (root.getJavaElement() instanceof ICompilationUnit unit) {
+			return unit.getElementName();
+		}
+		return "<unknown compilation unit>"; //$NON-NLS-1$
+	}
+
+	private static void add(List<Collision> collisions, Set<String> identities, Namespace namespace,
+			String unitName, String description) {
+		String identity= namespace + "\u0000" + unitName + "\u0000" + description; //$NON-NLS-1$ //$NON-NLS-2$
+		if (identities.add(identity)) {
+			collisions.add(new Collision(namespace, unitName, description));
+		}
+	}
+}

--- a/sandbox_common_test/src/org/sandbox/jdt/cleanup/multifile/GeneratedNameCollisionPolicyTest.java
+++ b/sandbox_common_test/src/org/sandbox/jdt/cleanup/multifile/GeneratedNameCollisionPolicyTest.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.cleanup.multifile;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+
+import org.sandbox.jdt.cleanup.multifile.GeneratedNameCollisionPolicy.Assessment;
+import org.sandbox.jdt.cleanup.multifile.GeneratedNameCollisionPolicy.Namespace;
+
+class GeneratedNameCollisionPolicyTest {
+
+	@Test
+	void acceptsUnusedGeneratedName() {
+		Assessment assessment= assess("""
+				package test;
+				class Owner {
+					int value;
+					void process() {}
+				}
+				""");
+
+		assertTrue(assessment.available());
+		assertTrue(assessment.collisions().isEmpty());
+	}
+
+	@Test
+	void rejectsTypeMemberImportAndTypeParameterNamespaces() {
+		Assessment assessment= assess("""
+				package test;
+				import other.Status;
+				class Owner<Status> {
+					int Status;
+					void Status() {}
+					class Status {}
+					void local() {
+						class Status {}
+					}
+				}
+				""");
+
+		assertFalse(assessment.available());
+		assertTrue(namespaces(assessment).containsAll(List.of(Namespace.IMPORT, Namespace.MEMBER,
+				Namespace.TYPE_DECLARATION, Namespace.TYPE_PARAMETER)));
+		assertTrue(assessment.explanation().contains("Status")); //$NON-NLS-1$
+	}
+
+	@Test
+	void rejectsConflictingTypeInAnotherAffectedCompilationUnit() {
+		CompilationUnit caller= parse("""
+				package test;
+				class Caller {
+					class Status {}
+				}
+				""");
+
+		Assessment assessment= GeneratedNameCollisionPolicy.assess(caller, "owner-key", "test.Owner", "Status"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
+		assertFalse(assessment.available());
+		assertEquals(List.of(Namespace.TYPE_DECLARATION), namespaces(assessment).stream().distinct().toList());
+	}
+
+	@Test
+	void collisionOrderingIsDeterministic() {
+		Assessment assessment= assess("""
+				package test;
+				import z.Status;
+				class Owner {
+					void Status() {}
+					int Status;
+				}
+				""");
+
+		assertEquals(List.of(Namespace.IMPORT, Namespace.MEMBER, Namespace.MEMBER), namespaces(assessment));
+	}
+
+	private static Assessment assess(String source) {
+		return GeneratedNameCollisionPolicy.assess(parse(source), "owner-key", "test.Owner", "Status"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+	}
+
+	private static List<Namespace> namespaces(Assessment assessment) {
+		return assessment.collisions().stream().map(GeneratedNameCollisionPolicy.Collision::namespace).toList();
+	}
+
+	private static CompilationUnit parse(String source) {
+		ASTParser parser= ASTParser.newParser(AST.getJLSLatest());
+		parser.setKind(ASTParser.K_COMPILATION_UNIT);
+		parser.setSource(source.toCharArray());
+		return (CompilationUnit) parser.createAST(null);
+	}
+}

--- a/sandbox_int_to_enum/src/org/sandbox/jdt/internal/corext/fix/multifile/IntEnumGeneratedNameValidator.java
+++ b/sandbox_int_to_enum/src/org/sandbox/jdt/internal/corext/fix/multifile/IntEnumGeneratedNameValidator.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.corext.fix.multifile;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.ASTRequestor;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
+import org.eclipse.jdt.internal.corext.refactoring.util.RefactoringASTParser;
+
+import org.sandbox.jdt.cleanup.multifile.GeneratedNameCollisionPolicy;
+import org.sandbox.jdt.cleanup.multifile.MultiFileCandidateDiagnostic;
+import org.sandbox.jdt.cleanup.multifile.MultiFileCleanUpDiagnostics;
+import org.sandbox.jdt.cleanup.multifile.MultiFileCleanUpPlanResult;
+import org.sandbox.jdt.cleanup.multifile.MultiFilePlanningBudget;
+
+/** Rejects prospective generated enum names against every fresh selected AST. */
+public final class IntEnumGeneratedNameValidator {
+
+	private static final String CLEANUP_ID= "int-to-enum"; //$NON-NLS-1$
+
+	private IntEnumGeneratedNameValidator() {
+	}
+
+	/**
+	 * Filters colliding candidates before preview changes are created.
+	 *
+	 * @param project current Java project
+	 * @param units complete selected source scope
+	 * @param result semantic planner result
+	 * @param monitor progress monitor
+	 * @return planner result containing only collision-free candidates
+	 * @throws CoreException if fresh AST creation fails
+	 */
+	public static MultiFileCleanUpPlanResult<IntEnumMigrationPlan> validate(IJavaProject project,
+			ICompilationUnit[] units, MultiFileCleanUpPlanResult<IntEnumMigrationPlan> result,
+			IProgressMonitor monitor) throws CoreException {
+		IntEnumMigrationPlan plan= result.plan();
+		if (plan == null || plan.candidates().isEmpty()) {
+			return result;
+		}
+		Map<String, CompilationUnit> roots= parse(project, units, monitor);
+		List<IntEnumCandidate> accepted= new ArrayList<>();
+		List<MultiFileCandidateDiagnostic> diagnostics= new ArrayList<>();
+		for (IntEnumCandidate candidate : plan.candidates()) {
+			MultiFilePlanningBudget.checkCanceled(monitor);
+			List<String> collisionExplanations= new ArrayList<>();
+			for (CompilationUnit root : roots.values()) {
+				GeneratedNameCollisionPolicy.Assessment assessment= GeneratedNameCollisionPolicy.assess(root,
+						candidate.ownerTypeBindingKey(), candidate.ownerTypeQualifiedName(), candidate.enumTypeName());
+				if (!assessment.available()) {
+					collisionExplanations.add(assessment.explanation());
+				}
+			}
+			String candidateId= candidateId(candidate);
+			List<String> relatedUnits= relatedUnits(candidate);
+			if (collisionExplanations.isEmpty()) {
+				accepted.add(candidate);
+				diagnostics.add(MultiFileCandidateDiagnostic.transformed(candidateId,
+						candidate.ownerCompilationUnitHandle(),
+						"Migrates the closed integer-state flow to nested enum " + candidate.enumTypeName() + '.', //$NON-NLS-1$
+						relatedUnits));
+			} else {
+				diagnostics.add(MultiFileCandidateDiagnostic.rejected(candidateId,
+						candidate.ownerCompilationUnitHandle(), "GENERATED_NAME_COLLISION", //$NON-NLS-1$
+						String.join("; ", collisionExplanations), relatedUnits)); //$NON-NLS-1$
+			}
+		}
+		IntEnumMigrationPlan validatedPlan= new IntEnumMigrationPlan(plan.selectedScope(), accepted);
+		MultiFileCleanUpDiagnostics validatedDiagnostics= new MultiFileCleanUpDiagnostics(CLEANUP_ID,
+				result.diagnostics().scope(), diagnostics);
+		return MultiFileCleanUpPlanResult.success(validatedPlan, result.status(),
+				result.metrics().withRetainedPlanEntries(accepted.size()), validatedDiagnostics);
+	}
+
+	private static Map<String, CompilationUnit> parse(IJavaProject project, ICompilationUnit[] units,
+			IProgressMonitor monitor) {
+		Map<String, CompilationUnit> roots= new LinkedHashMap<>();
+		ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
+		parser.setProject(project);
+		parser.setResolveBindings(true);
+		parser.setBindingsRecovery(IASTSharedValues.SHARED_BINDING_RECOVERY);
+		parser.setStatementsRecovery(IASTSharedValues.SHARED_AST_STATEMENT_RECOVERY);
+		parser.setCompilerOptions(RefactoringASTParser.getCompilerOptions(project));
+		parser.createASTs(units, new String[0], new ASTRequestor() {
+			@Override
+			public void acceptAST(ICompilationUnit source, CompilationUnit ast) {
+				roots.put(source.getPrimary().getHandleIdentifier(), ast);
+			}
+		}, monitor);
+		return roots;
+	}
+
+	private static String candidateId(IntEnumCandidate candidate) {
+		return candidate.ownerTypeQualifiedName() + '#' + candidate.enumTypeName() + ':' + candidate.parameterIndex();
+	}
+
+	private static List<String> relatedUnits(IntEnumCandidate candidate) {
+		Set<String> handles= new LinkedHashSet<>();
+		handles.add(candidate.ownerCompilationUnitHandle());
+		handles.addAll(candidate.expectedReferenceCountsByUnit().keySet());
+		handles.addAll(candidate.expectedCallCountsByUnit().keySet());
+		return List.copyOf(handles);
+	}
+}

--- a/sandbox_int_to_enum/src/org/sandbox/jdt/internal/corext/fix/multifile/IntEnumMigrationPlan.java
+++ b/sandbox_int_to_enum/src/org/sandbox/jdt/internal/corext/fix/multifile/IntEnumMigrationPlan.java
@@ -14,12 +14,16 @@ import java.util.List;
 import java.util.Set;
 
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
 
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 
+import org.sandbox.jdt.cleanup.multifile.GeneratedNameCollisionPolicy;
+import org.sandbox.jdt.cleanup.multifile.GeneratedNameCollisionPolicy.Assessment;
 import org.sandbox.jdt.cleanup.multifile.SelectedCompilationUnitPlan;
 
 /** Immutable plan containing all conservative package-scoped enum candidates. */
@@ -39,6 +43,14 @@ public record IntEnumMigrationPlan(SelectedCompilationUnitPlan selectedScope, Li
 	public void addOperationsFor(ICompilationUnit unit, CompilationUnit root,
 			Set<CompilationUnitRewriteOperationWithSourceRange> operations, Set<ASTNode> nodesProcessed)
 			throws CoreException {
+		for (IntEnumCandidate candidate : candidates) {
+			Assessment assessment= GeneratedNameCollisionPolicy.assess(root, candidate.ownerTypeBindingKey(),
+					candidate.ownerTypeQualifiedName(), candidate.enumTypeName());
+			if (!assessment.available()) {
+				throw generatedNameCollision(unit, candidate, assessment);
+			}
+		}
+
 		String handle= unit.getPrimary().getHandleIdentifier();
 		List<IntEnumCandidate> relevant= candidates.stream()
 				.filter(candidate -> handle.equals(candidate.ownerCompilationUnitHandle())
@@ -52,5 +64,12 @@ public record IntEnumMigrationPlan(SelectedCompilationUnitPlan selectedScope, Li
 				unit.getPrimary(), root, relevant);
 		nodesProcessed.addAll(resolved.processedNodes());
 		operations.add(new IntEnumMultiFileRewriteOperation(resolved));
+	}
+
+	private static CoreException generatedNameCollision(ICompilationUnit unit, IntEnumCandidate candidate,
+			Assessment assessment) {
+		String message= "The project-wide int-to-enum plan cannot generate " + candidate.enumTypeName() //$NON-NLS-1$
+				+ " while resolving " + unit.getElementName() + ": " + assessment.explanation(); //$NON-NLS-1$ //$NON-NLS-2$
+		return new CoreException(new Status(IStatus.ERROR, "sandbox_int_to_enum", message)); //$NON-NLS-1$
 	}
 }

--- a/sandbox_int_to_enum/src/org/sandbox/jdt/internal/ui/fix/IntToEnumCleanUpCore.java
+++ b/sandbox_int_to_enum/src/org/sandbox/jdt/internal/ui/fix/IntToEnumCleanUpCore.java
@@ -52,6 +52,7 @@ import org.sandbox.jdt.cleanup.multifile.RelatedCompilationUnitSearch;
 import org.sandbox.jdt.cleanup.multifile.SelectedCompilationUnitPlan;
 import org.sandbox.jdt.cleanup.multifile.SourceRootPolicy;
 import org.sandbox.jdt.internal.corext.fix.IntToEnumFixCore;
+import org.sandbox.jdt.internal.corext.fix.multifile.IntEnumGeneratedNameValidator;
 import org.sandbox.jdt.internal.corext.fix.multifile.IntEnumMigrationPlan;
 import org.sandbox.jdt.internal.corext.fix.multifile.IntEnumMultiFilePlanner;
 import org.sandbox.jdt.internal.corext.fix.multifile.IntEnumScopeCandidateDetector;
@@ -93,9 +94,10 @@ public class IntToEnumCleanUpCore extends AbstractPlannedMultiFileCleanUp<IntEnu
 			return MultiFileCleanUpPlanResult.success(new IntEnumMigrationPlan(selectedScope, List.of()));
 		}
 		Boolean closedScope= consumeClosedScopeDecision(project, compilationUnits);
-		return closedScope == null
+		MultiFileCleanUpPlanResult<IntEnumMigrationPlan> result= closedScope == null
 				? IntEnumMultiFilePlanner.create(project, compilationUnits, monitor)
 				: IntEnumMultiFilePlanner.create(project, compilationUnits, closedScope.booleanValue(), monitor);
+		return IntEnumGeneratedNameValidator.validate(project, compilationUnits, result, monitor);
 	}
 
 	@Override

--- a/sandbox_int_to_enum_test/src/org/eclipse/jdt/ui/tests/quickfix/Java22/MultiFileIntToEnumCleanUpTest.java
+++ b/sandbox_int_to_enum_test/src/org/eclipse/jdt/ui/tests/quickfix/Java22/MultiFileIntToEnumCleanUpTest.java
@@ -155,4 +155,49 @@ public class MultiFileIntToEnumCleanUpTest {
 
 		context.assertRefactoringHasNoChange(new ICompilationUnit[] { processor, client });
 	}
+
+	@Test
+	public void abortsAtomicallyWhenAnotherSelectedUnitOccupiesGeneratedName() throws CoreException {
+		IPackageFragment pack= context.getSourceFolder().createPackageFragment("test", false, null); //$NON-NLS-1$
+		ICompilationUnit processor= pack.createCompilationUnit("OrderProcessor.java", //$NON-NLS-1$
+				"""
+				package test;
+
+				class OrderProcessor {
+					static final int STATUS_PENDING = 0;
+					static final int STATUS_APPROVED = 1;
+
+					void process(int status) {
+						if (status == STATUS_PENDING) {
+							System.out.println("pending");
+						} else if (status == STATUS_APPROVED) {
+							System.out.println("approved");
+						}
+					}
+				}
+				""", false, null);
+		ICompilationUnit client= pack.createCompilationUnit("OrderClient.java", //$NON-NLS-1$
+				"""
+				package test;
+
+				class OrderClient {
+					void run(OrderProcessor processor) {
+						processor.process(OrderProcessor.STATUS_PENDING);
+					}
+				}
+				""", false, null);
+		ICompilationUnit conflicting= pack.createCompilationUnit("Other.java", //$NON-NLS-1$
+				"""
+				package test;
+
+				class Other {
+					class Status {}
+				}
+				""", false, null);
+
+		context.enable(MYCleanUpConstants.INT_TO_ENUM_CLEANUP);
+		context.enable(IntToEnumCleanUpOptions.PROJECT_WIDE);
+
+		context.assertRefactoringHasNoChange(new ICompilationUnit[] { processor, client, conflicting });
+	}
 }


### PR DESCRIPTION
## Summary

Adds the reusable deterministic name-collision policy required by #1225 and applies it to package-scoped Int-to-Enum plans before preview changes are retained.

## Policy

The prospective domain type name is checked against every fresh AST in the complete selected scope, including:

- existing top-level, nested and local type declarations;
- explicit imports;
- owner fields and methods;
- owner and method type parameters;
- inherited nested types when bindings are available.

A domain type name is rejected with `GENERATED_NAME_COLLISION`; it is never silently changed to an opaque numeric suffix.

## Plan safety

- validation happens after semantic candidate discovery but before preview/fix creation;
- collision-free candidates remain in the immutable plan;
- rejected candidates receive deterministic structured diagnostics;
- retained-plan metrics are updated;
- every fresh per-unit AST is checked again during resolution so working-copy changes make the plan stale rather than generating ambiguous source;
- an integration test proves that a conflict in another selected compilation unit aborts the migration atomically.

This also provides the collision foundation needed for the qualification strategy in #1223; shortening generated references remains a separate style change.

Closes #1225.
Refs #1223.