### PR TITLE
Revalidate patched JDT UI against Eclipse 2026-06

### DIFF
--- a/.github/patched-jdt-ui.env
+++ b/.github/patched-jdt-ui.env
@@ -1,5 +1,8 @@
 # Reproducible source coordinates for the optional patched-product build.
+# This commit is the current fork master after synchronization with the
+# Eclipse 2026-06 / Platform 4.40 JDT UI baseline and still contains the
+# fixed-point cleanup scope expansion from carstenartur/eclipse.jdt.ui#94.
 PATCHED_JDT_UI_REPOSITORY=https://github.com/carstenartur/eclipse.jdt.ui.git
-PATCHED_JDT_UI_COMMIT=450bfd46089c99608dd60203e1257e1c329ad2c5
+PATCHED_JDT_UI_COMMIT=f5270e1eb9e35be435ac4ff7d4e942ac3c1dc219
 PATCHED_JDT_UI_BUNDLE=org.eclipse.jdt.ui
 PATCHED_JDT_UI_EXPECTED_BASE_VERSION=3.39.0

--- a/.github/workflows/patched-jdt-ui-bundle.yml
+++ b/.github/workflows/patched-jdt-ui-bundle.yml
@@ -1,11 +1,18 @@
 name: Patched JDT UI Bundle
 
-# This is an optional, manually triggered compatibility experiment. The pinned
-# replacement bundle still targets the pre-2026-06 JDT UI baseline and must not
-# participate in normal pull-request or main-branch validation until #1209 is
-# rebased and revalidated against Eclipse 2026-06 / Platform 4.40.
+# Optional compatibility lane for the pinned JDT UI replacement. It is not a
+# general main-branch check: pull requests trigger it only when the source pin,
+# build/compatibility scripts, workflow or delivery documentation changes.
 on:
   workflow_dispatch:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '.github/patched-jdt-ui.env'
+      - '.github/scripts/build_patched_jdt_ui.sh'
+      - '.github/scripts/compare_patched_jdt_ui_with_target.sh'
+      - '.github/workflows/patched-jdt-ui-bundle.yml'
+      - 'docs/patched-jdt-ui-delivery.md'
 
 permissions:
   contents: read
@@ -106,6 +113,22 @@ jobs:
               echo '```'
             } >> "$GITHUB_STEP_SUMMARY"
           fi
+      - name: Enforce 2026-06 stock-target replacement gate
+        shell: bash
+        run: |
+          result="$RUNNER_TEMP/patched-jdt-ui-compatibility/compatibility.json"
+          python3 - "$result" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          path = Path(sys.argv[1])
+          if not path.is_file():
+              raise SystemExit('Compatibility report is missing')
+          payload = json.loads(path.read_text(encoding='utf-8'))
+          if payload.get('compatibleForReplacement') is not True:
+              raise SystemExit('Pinned JDT UI bundle is not compatible with the Eclipse 2026-06 stock target')
+          PY
       - name: Upload stock-target compatibility report
         if: always()
         uses: actions/upload-artifact@v7

--- a/docs/patched-jdt-ui-delivery.md
+++ b/docs/patched-jdt-ui-delivery.md
@@ -4,18 +4,20 @@
 
 The normal Sandbox target and cleanup test reactor use the stock Eclipse JDT UI bundle. Automatic multi-file cleanup scope expansion is an optional product capability that requires a reviewed replacement of the singleton `org.eclipse.jdt.ui` bundle.
 
-This document covers the reproducible source-bundle and stock-target compatibility stages. Minimal p2 publication, exact-IU product resolution, product startup and stock-versus-patched runtime smoke tests remain tracked in #1209 and #1215.
+This document covers the reproducible source-bundle and Eclipse 2026-06 stock-target compatibility stages. Minimal p2 publication, exact-IU product resolution, product startup and stock-versus-patched runtime smoke tests remain tracked in #1209.
+
+The optional workflow is not a general repository build. It runs manually and on pull requests that change only the patch source pin, delivery scripts, workflow or this document.
 
 ## Pinned source
 
 The immutable coordinates are stored in `.github/patched-jdt-ui.env`:
 
 - repository: `https://github.com/carstenartur/eclipse.jdt.ui.git`;
-- commit: `450bfd46089c99608dd60203e1257e1c329ad2c5`;
+- commit: `f5270e1eb9e35be435ac4ff7d4e942ac3c1dc219`;
 - bundle: `org.eclipse.jdt.ui`;
 - expected base version: `3.39.0`.
 
-The commit is the merged result of `carstenartur/eclipse.jdt.ui#95`. Its fork synchronization manifest preserves both the modified `CleanUpRefactoring.java` source and `MultiFileCleanUpScopeExpansionTest.java`.
+The pinned commit is the synchronized fork master for the Eclipse 2026-06 / Platform 4.40 development line. It still contains the merged fixed-point cleanup scope expansion from `carstenartur/eclipse.jdt.ui#94`. The fork synchronization manifest preserves both the modified `CleanUpRefactoring.java` source and `MultiFileCleanUpScopeExpansionTest.java` while upstream JDT UI changes continue to be synchronized.
 
 ## Local rebuild
 
@@ -38,7 +40,7 @@ The script:
 
 Generated JARs are not committed. CI publishes the verified output as a short-lived artifact.
 
-## Stock-target compatibility gate
+## Eclipse 2026-06 stock-target compatibility gate
 
 After building the bundle, CI runs:
 
@@ -48,20 +50,20 @@ bash .github/scripts/compare_patched_jdt_ui_with_target.sh \
   target/patched-jdt-ui-compatibility
 ```
 
-The comparison removes only cached `org.eclipse.jdt.ui` artifacts, resolves `sandbox_target/eclipse.target` through the normal Tycho build and identifies the single stock JDT UI bundle selected from Eclipse 2025-12. It then records:
+The comparison removes only cached `org.eclipse.jdt.ui` artifacts, resolves `sandbox_target/eclipse.target` through the normal Tycho build and identifies the single stock JDT UI bundle selected from Eclipse 2026-06. It then records:
 
 - the exact stock and patched OSGi versions and SHA-256 checksums;
 - whether the patched version is strictly newer, as required for singleton replacement;
 - normalized differences in `Bundle-RequiredExecutionEnvironment`, `Require-Bundle` and `Import-Package`;
 - whether every stock `Export-Package` remains present in the patched bundle.
 
-Results are written to `compatibility.json` and `compatibility.md` and uploaded as a workflow artifact. A blocked result is emitted as an Actions warning and prevents the next p2-publication stage from being introduced. The source-bundle job may still remain green because it proves a different property: reproducibility of the pinned source build.
+Results are written to `compatibility.json` and `compatibility.md` and uploaded as a workflow artifact. Compatibility is a hard gate on patch-delivery pull requests: an incompatible replacement fails the workflow rather than marking an unrelated ordinary PR red.
 
 The comparison is deliberately strict. A manifest difference is treated as unresolved compatibility work rather than assumed safe. Once the report passes, the next stage can publish a minimal p2 repository and prove exact IU selection in a patched product.
 
 ## Trust boundary
 
-Passing the source-bundle stage proves the source revision, patch paths, singleton identity, compiled capability marker and artifact checksum. Passing the compatibility stage additionally proves that the resolved 2025-12 stock bundle can be replaced without changing its declared execution environment, imports, required bundles or exported package surface under the current strict policy.
+Passing the source-bundle stage proves the source revision, patch paths, singleton identity, compiled capability marker and artifact checksum. Passing the compatibility stage additionally proves that the resolved Eclipse 2026-06 stock bundle can be replaced without changing its declared execution environment, imports, required bundles or exported package surface under the current strict policy.
 
 Neither stage proves p2 installation, product startup, runtime cleanup expansion, apply/undo behavior or rollback. Those checks belong to the p2/product stages before an installation channel is published.
 


### PR DESCRIPTION
## Summary

Rebases the optional patched JDT UI delivery lane onto the synchronized Eclipse 2026-06 / Platform 4.40 fork revision.

## Change

- pins `carstenartur/eclipse.jdt.ui` commit `f5270e1eb9e35be435ac4ff7d4e942ac3c1dc219`;
- verifies that the current fork still contains the merged fixed-point scope expansion and its PDE tests;
- restores pull-request validation only when patch-delivery files change;
- keeps the workflow out of ordinary main and unrelated PR validation;
- makes strict Eclipse 2026-06 stock-target compatibility a hard gate;
- updates provenance and trust-boundary documentation.

## Boundary

A green result proves reproducible bundle construction and manifest compatibility with the current stock target. The remaining exact p2 installation, product startup and runtime apply/undo proof stay in #1209 and will build on the emitted bundle/provenance artifacts.

Refs #1209.