### PR TITLE
Deliver patched JDT UI scope expansion for Eclipse 2026-06

### DIFF
--- a/.github/patched-jdt-ui.env
+++ b/.github/patched-jdt-ui.env
@@ -1,5 +1,7 @@
 # Reproducible source coordinates for the optional patched-product build.
+# This commit is the synchronized Eclipse 2026-06 / Platform 4.40 fork master
+# and retains the fixed-point cleanup scope expansion from the reviewed patch.
 PATCHED_JDT_UI_REPOSITORY=https://github.com/carstenartur/eclipse.jdt.ui.git
-PATCHED_JDT_UI_COMMIT=450bfd46089c99608dd60203e1257e1c329ad2c5
+PATCHED_JDT_UI_COMMIT=f5270e1eb9e35be435ac4ff7d4e942ac3c1dc219
 PATCHED_JDT_UI_BUNDLE=org.eclipse.jdt.ui
 PATCHED_JDT_UI_EXPECTED_BASE_VERSION=3.39.0

--- a/.github/probes/patched-jdt-ui/META-INF/MANIFEST.MF
+++ b/.github/probes/patched-jdt-ui/META-INF/MANIFEST.MF
@@ -1,0 +1,16 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Sandbox Patched JDT UI Runtime Probe
+Bundle-SymbolicName: sandbox_patched_jdt_ui_runtime_probe;singleton:=true
+Bundle-Version: 1.0.0
+Bundle-Vendor: Sandbox
+Bundle-RequiredExecutionEnvironment: JavaSE-21
+Bundle-ActivationPolicy: lazy
+Require-Bundle: org.eclipse.core.runtime,
+ org.eclipse.core.resources,
+ org.eclipse.jdt.core,
+ org.eclipse.jdt.core.manipulation,
+ org.eclipse.jdt.ui,
+ org.eclipse.ltk.core.refactoring,
+ org.eclipse.text
+Import-Package: org.eclipse.equinox.app

--- a/.github/probes/patched-jdt-ui/plugin.xml
+++ b/.github/probes/patched-jdt-ui/plugin.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+   <extension
+         id="scopeProbe"
+         point="org.eclipse.core.runtime.applications">
+      <application>
+         <run class="org.sandbox.jdt.ui.probe.ScopeExpansionProbeApplication"/>
+      </application>
+   </extension>
+</plugin>

--- a/.github/probes/patched-jdt-ui/src/org/sandbox/jdt/ui/probe/ScopeExpansionProbeApplication.java
+++ b/.github/probes/patched-jdt-ui/src/org/sandbox/jdt/ui/probe/ScopeExpansionProbeApplication.java
@@ -1,0 +1,348 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.ui.probe;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
+
+import org.eclipse.equinox.app.IApplication;
+import org.eclipse.equinox.app.IApplicationContext;
+
+import org.eclipse.ltk.core.refactoring.Change;
+import org.eclipse.ltk.core.refactoring.CompositeChange;
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+import org.eclipse.ltk.core.refactoring.TextEditBasedChange;
+
+import org.eclipse.text.edits.InsertEdit;
+import org.eclipse.text.edits.MultiTextEdit;
+
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.refactoring.CompilationUnitChange;
+import org.eclipse.jdt.internal.corext.fix.CleanUpRefactoring;
+import org.eclipse.jdt.ui.cleanup.CleanUpContext;
+import org.eclipse.jdt.ui.cleanup.CleanUpOptions;
+import org.eclipse.jdt.ui.cleanup.CleanUpRequirements;
+import org.eclipse.jdt.ui.cleanup.ICleanUp;
+import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
+
+/** Executes the installed patched JDT UI scope-expansion path in a real product. */
+public final class ScopeExpansionProbeApplication implements IApplication {
+
+	private static final String PROJECT_NAME= "PatchedJdtUiScopeProbe"; //$NON-NLS-1$
+	private static final String PACKAGE_NAME= "probe"; //$NON-NLS-1$
+	private static final String MARKER= "// patched scope probe\n"; //$NON-NLS-1$
+	private static final String FIRST_SOURCE= "package probe;\npublic class First {}\n"; //$NON-NLS-1$
+	private static final String SECOND_SOURCE= "package probe;\npublic class Second {}\n"; //$NON-NLS-1$
+	private static final String PASS_MARKER= "PATCHED_JDT_UI_SCOPE_PROBE_PASS"; //$NON-NLS-1$
+	private static final String REPORT_ENV= "SANDBOX_PATCHED_JDT_UI_PROBE_REPORT"; //$NON-NLS-1$
+
+	private record ProbeResult(int targetCount, int plannedCount, int expansionInvocations,
+			int previewCount, int appliedCount, int restoredCount) {
+	}
+
+	@Override
+	public Object start(IApplicationContext context) throws Exception {
+		IProgressMonitor monitor= new NullProgressMonitor();
+		IProject project= ResourcesPlugin.getWorkspace().getRoot().getProject(PROJECT_NAME);
+		ProbeResult result= null;
+		Throwable failure= null;
+		try {
+			deleteIfPresent(project, monitor);
+			IJavaProject javaProject= createJavaProject(project, monitor);
+			IPackageFragment pack= javaProject.getPackageFragmentRoot(project.getFolder("src")) //$NON-NLS-1$
+					.createPackageFragment(PACKAGE_NAME, true, monitor);
+			ICompilationUnit first= pack.createCompilationUnit("First.java", FIRST_SOURCE, false, monitor); //$NON-NLS-1$
+			ICompilationUnit second= pack.createCompilationUnit("Second.java", SECOND_SOURCE, false, monitor); //$NON-NLS-1$
+
+			ScopeExpandingCleanUp cleanUp= new ScopeExpandingCleanUp(second);
+			cleanUp.setOptions(new CleanUpOptions());
+			CleanUpRefactoring refactoring= new CleanUpRefactoring("Patched JDT UI runtime scope probe"); //$NON-NLS-1$
+			refactoring.addCompilationUnit(first);
+			refactoring.addCleanUp(cleanUp);
+
+			RefactoringStatus conditions= refactoring.checkAllConditions(monitor);
+			require(!conditions.hasError(), "Cleanup conditions failed: " + conditions); //$NON-NLS-1$
+			int targetCount= refactoring.getCleanUpTargetsSize();
+			require(targetCount == 2, "Expected two cleanup targets after expansion, found " + targetCount); //$NON-NLS-1$
+
+			Set<String> plannedHandles= handles(cleanUp.plannedUnits());
+			Set<String> expectedHandles= handles(List.of(first, second));
+			require(plannedHandles.equals(expectedHandles),
+					"Preconditions did not receive the complete expanded scope: " + plannedHandles); //$NON-NLS-1$
+			require(cleanUp.expansionInvocations() >= 2,
+					"Scope expansion did not run to a fixed point: " + cleanUp.expansionInvocations()); //$NON-NLS-1$
+
+			Change change= refactoring.createChange(monitor);
+			require(change instanceof CompositeChange, "Expected a composite cleanup change"); //$NON-NLS-1$
+			CompositeChange composite= (CompositeChange) change;
+			Change[] children= composite.getChildren();
+			require(children.length == 2, "Expected two preview changes, found " + children.length); //$NON-NLS-1$
+			Set<String> previews= new LinkedHashSet<>();
+			for (Change child : children) {
+				require(child instanceof TextEditBasedChange,
+						"Expected a text-edit cleanup child, found " + child.getClass().getName()); //$NON-NLS-1$
+				previews.add(((TextEditBasedChange) child).getPreviewContent(monitor));
+			}
+			Set<String> expectedPreviews= Set.of(MARKER + FIRST_SOURCE, MARKER + SECOND_SOURCE);
+			require(previews.equals(expectedPreviews), "Preview did not cover both source files: " + previews); //$NON-NLS-1$
+
+			validateChange(change, monitor, "apply"); //$NON-NLS-1$
+			Change undo= change.perform(monitor);
+			require(undo != null, "Cleanup did not produce an undo change"); //$NON-NLS-1$
+			project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
+			int appliedCount= changedCount(first, second);
+			require(appliedCount == 2, "Cleanup did not modify both files: " + appliedCount); //$NON-NLS-1$
+
+			validateChange(undo, monitor, "undo"); //$NON-NLS-1$
+			Change redo= undo.perform(monitor);
+			require(redo != null, "Undo did not produce a redo change"); //$NON-NLS-1$
+			project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
+			int restoredCount= restoredCount(first, second);
+			require(restoredCount == 2, "Undo did not restore both original files: " + restoredCount); //$NON-NLS-1$
+
+			result= new ProbeResult(targetCount, plannedHandles.size(), cleanUp.expansionInvocations(),
+					previews.size(), appliedCount, restoredCount);
+			writeReport("PASS", result, ""); //$NON-NLS-1$ //$NON-NLS-2$
+			System.out.println(PASS_MARKER);
+			return IApplication.EXIT_OK;
+		} catch (Throwable throwable) {
+			failure= throwable;
+			try {
+				writeReport("FAIL", result, failureMessage(throwable)); //$NON-NLS-1$
+			} catch (Throwable reportingFailure) {
+				throwable.addSuppressed(reportingFailure);
+			}
+			if (throwable instanceof Exception exception) {
+				throw exception;
+			}
+			if (throwable instanceof Error error) {
+				throw error;
+			}
+			throw new IllegalStateException(throwable);
+		} finally {
+			try {
+				deleteIfPresent(project, monitor);
+			} catch (CoreException cleanupFailure) {
+				if (failure != null) {
+					failure.addSuppressed(cleanupFailure);
+				} else {
+					throw cleanupFailure;
+				}
+			}
+		}
+	}
+
+	@Override
+	public void stop() {
+		// The probe is synchronous and owns no background work.
+	}
+
+	private static IJavaProject createJavaProject(IProject project, IProgressMonitor monitor) throws CoreException {
+		project.create(monitor);
+		project.open(monitor);
+		IProjectDescription description= project.getDescription();
+		description.setNatureIds(new String[] { JavaCore.NATURE_ID });
+		project.setDescription(description, monitor);
+
+		IFolder source= project.getFolder("src"); //$NON-NLS-1$
+		IFolder output= project.getFolder("bin"); //$NON-NLS-1$
+		source.create(true, true, monitor);
+		output.create(true, true, monitor);
+		IJavaProject javaProject= JavaCore.create(project);
+		IClasspathEntry sourceEntry= JavaCore.newSourceEntry(source.getFullPath());
+		javaProject.setRawClasspath(new IClasspathEntry[] { sourceEntry }, output.getFullPath(), monitor);
+		return javaProject;
+	}
+
+	private static void validateChange(Change change, IProgressMonitor monitor, String phase) throws CoreException {
+		change.initializeValidationData(monitor);
+		RefactoringStatus validity= change.isValid(monitor);
+		require(!validity.hasError(), "Change is invalid before " + phase + ": " + validity); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	private static int changedCount(ICompilationUnit first, ICompilationUnit second) throws IOException {
+		int count= 0;
+		if ((MARKER + FIRST_SOURCE).equals(read(first))) {
+			count++;
+		}
+		if ((MARKER + SECOND_SOURCE).equals(read(second))) {
+			count++;
+		}
+		return count;
+	}
+
+	private static int restoredCount(ICompilationUnit first, ICompilationUnit second) throws IOException {
+		int count= 0;
+		if (FIRST_SOURCE.equals(read(first))) {
+			count++;
+		}
+		if (SECOND_SOURCE.equals(read(second))) {
+			count++;
+		}
+		return count;
+	}
+
+	private static String read(ICompilationUnit unit) throws IOException {
+		IResource resource= unit.getResource();
+		require(resource instanceof IFile, "Compilation unit has no file resource: " + unit.getElementName()); //$NON-NLS-1$
+		IFile file= (IFile) resource;
+		require(file.getLocation() != null, "Compilation-unit file has no local location: " + unit.getElementName()); //$NON-NLS-1$
+		return Files.readString(file.getLocation().toFile().toPath(), StandardCharsets.UTF_8);
+	}
+
+	private static Set<String> handles(Collection<ICompilationUnit> units) {
+		Set<String> result= new LinkedHashSet<>();
+		for (ICompilationUnit unit : units) {
+			result.add(unit.getPrimary().getHandleIdentifier());
+		}
+		return result;
+	}
+
+	private static void deleteIfPresent(IProject project, IProgressMonitor monitor) throws CoreException {
+		if (project.exists()) {
+			project.delete(true, true, monitor);
+		}
+	}
+
+	private static void require(boolean condition, String message) {
+		if (!condition) {
+			throw new IllegalStateException(message);
+		}
+	}
+
+	private static String failureMessage(Throwable failure) {
+		String message= failure.getMessage();
+		return failure.getClass().getName() + (message == null || message.isBlank() ? "" : ": " + message); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	private static void writeReport(String outcome, ProbeResult result, String message) throws IOException {
+		String reportPath= System.getenv(REPORT_ENV);
+		if (reportPath == null || reportPath.isBlank()) {
+			return;
+		}
+		Path path= Path.of(reportPath).toAbsolutePath().normalize();
+		Path parent= path.getParent();
+		if (parent != null) {
+			Files.createDirectories(parent);
+		}
+		int targetCount= result == null ? -1 : result.targetCount();
+		int plannedCount= result == null ? -1 : result.plannedCount();
+		int expansionInvocations= result == null ? -1 : result.expansionInvocations();
+		int previewCount= result == null ? -1 : result.previewCount();
+		int appliedCount= result == null ? -1 : result.appliedCount();
+		int restoredCount= result == null ? -1 : result.restoredCount();
+		String json= "{\n" //$NON-NLS-1$
+				+ "  \"schemaVersion\": 1,\n" //$NON-NLS-1$
+				+ "  \"result\": \"" + jsonEscape(outcome) + "\",\n" //$NON-NLS-1$ //$NON-NLS-2$
+				+ "  \"targetCount\": " + targetCount + ",\n" //$NON-NLS-1$ //$NON-NLS-2$
+				+ "  \"plannedCount\": " + plannedCount + ",\n" //$NON-NLS-1$ //$NON-NLS-2$
+				+ "  \"expansionInvocations\": " + expansionInvocations + ",\n" //$NON-NLS-1$ //$NON-NLS-2$
+				+ "  \"previewCount\": " + previewCount + ",\n" //$NON-NLS-1$ //$NON-NLS-2$
+				+ "  \"appliedCount\": " + appliedCount + ",\n" //$NON-NLS-1$ //$NON-NLS-2$
+				+ "  \"restoredCount\": " + restoredCount + ",\n" //$NON-NLS-1$ //$NON-NLS-2$
+				+ "  \"message\": \"" + jsonEscape(message) + "\"\n" //$NON-NLS-1$ //$NON-NLS-2$
+				+ "}\n"; //$NON-NLS-1$
+		Files.writeString(path, json, StandardCharsets.UTF_8);
+	}
+
+	private static String jsonEscape(String value) {
+		return value.replace("\\", "\\\\") //$NON-NLS-1$ //$NON-NLS-2$
+				.replace("\"", "\\\"") //$NON-NLS-1$ //$NON-NLS-2$
+				.replace("\n", "\\n") //$NON-NLS-1$ //$NON-NLS-2$
+				.replace("\r", "\\r") //$NON-NLS-1$ //$NON-NLS-2$
+				.replace("\t", "\\t"); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	/** Cleanup whose public optional method is discovered by the patched JDT UI. */
+	public static final class ScopeExpandingCleanUp implements ICleanUp {
+		private final ICompilationUnit relatedUnit;
+		private List<ICompilationUnit> plannedUnits= List.of();
+		private int expansionInvocations;
+
+		ScopeExpandingCleanUp(ICompilationUnit relatedUnit) {
+			this.relatedUnit= relatedUnit;
+		}
+
+		@Override
+		public void setOptions(CleanUpOptions options) {
+			// This deterministic probe has no configurable options.
+		}
+
+		@Override
+		public String[] getStepDescriptions() {
+			return new String[] { "Insert patched JDT UI runtime probe marker" }; //$NON-NLS-1$
+		}
+
+		@Override
+		public CleanUpRequirements getRequirements() {
+			return new CleanUpRequirements(false, false, false, null);
+		}
+
+		@Override
+		public RefactoringStatus checkPreConditions(IJavaProject project, ICompilationUnit[] compilationUnits,
+				IProgressMonitor monitor) {
+			plannedUnits= List.of(compilationUnits.clone());
+			return new RefactoringStatus();
+		}
+
+		@Override
+		public ICleanUpFix createFix(CleanUpContext context) {
+			return progressMonitor -> {
+				CompilationUnitChange change= new CompilationUnitChange("Patched JDT UI runtime probe", //$NON-NLS-1$
+						context.getCompilationUnit());
+				MultiTextEdit edit= new MultiTextEdit();
+				edit.addChild(new InsertEdit(0, MARKER));
+				change.setEdit(edit);
+				return change;
+			};
+		}
+
+		@Override
+		public RefactoringStatus checkPostConditions(IProgressMonitor monitor) {
+			return new RefactoringStatus();
+		}
+
+		/** Optional method intentionally discovered reflectively by the patched host. */
+		public Collection<ICompilationUnit> expandCleanUpScope(IJavaProject project,
+				Collection<ICompilationUnit> currentScope, IProgressMonitor monitor) {
+			expansionInvocations++;
+			return List.of(relatedUnit);
+		}
+
+		List<ICompilationUnit> plannedUnits() {
+			return plannedUnits;
+		}
+
+		int expansionInvocations() {
+			return expansionInvocations;
+		}
+	}
+}

--- a/.github/scripts/add_p2_sha256_checksums.py
+++ b/.github/scripts/add_p2_sha256_checksums.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Add or replace SHA-256 and size metadata for every local p2 artifact."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import tempfile
+import xml.etree.ElementTree as ET
+import zipfile
+from pathlib import Path
+
+
+class MetadataError(RuntimeError):
+    """Raised when a p2 artifact cannot be mapped to a local file."""
+
+
+def artifact_path(repository: Path, classifier: str, identifier: str, version: str) -> Path:
+    if classifier == "osgi.bundle":
+        return repository / "plugins" / f"{identifier}_{version}.jar"
+    if classifier == "org.eclipse.update.feature":
+        return repository / "features" / f"{identifier}_{version}.jar"
+    if classifier == "binary":
+        return repository / "binary" / f"{identifier}_{version}"
+    raise MetadataError(f"Unsupported p2 artifact classifier: {classifier!r}")
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_metadata(repository: Path) -> tuple[ET.Element, bool]:
+    jar = repository / "artifacts.jar"
+    xml = repository / "artifacts.xml"
+    if jar.is_file():
+        with zipfile.ZipFile(jar) as archive:
+            try:
+                return ET.fromstring(archive.read("artifacts.xml")), True
+            except KeyError as error:
+                raise MetadataError(f"{jar} does not contain artifacts.xml") from error
+    if xml.is_file():
+        return ET.parse(xml).getroot(), False
+    raise MetadataError(f"Repository contains neither artifacts.jar nor artifacts.xml: {repository}")
+
+
+def set_properties(artifact: ET.Element, values: dict[str, str]) -> None:
+    container = artifact.find("properties")
+    if container is None:
+        container = ET.SubElement(artifact, "properties")
+    properties: dict[str, str] = {
+        item.attrib.get("name", ""): item.attrib.get("value", "")
+        for item in container.findall("property")
+        if item.attrib.get("name")
+    }
+    properties.update(values)
+    for child in list(container):
+        container.remove(child)
+    for name in sorted(properties):
+        ET.SubElement(container, "property", {"name": name, "value": properties[name]})
+    container.set("size", str(len(properties)))
+
+
+def serialized(root: ET.Element) -> bytes:
+    body = ET.tostring(root, encoding="utf-8", short_empty_elements=True)
+    return (
+        b"<?xml version='1.0' encoding='UTF-8'?>\n"
+        b"<?artifactRepository version='1.1.0'?>\n"
+        + body
+        + b"\n"
+    )
+
+
+def write_metadata(repository: Path, root: ET.Element, compressed: bool) -> None:
+    payload = serialized(root)
+    if not compressed:
+        (repository / "artifacts.xml").write_bytes(payload)
+        return
+    target = repository / "artifacts.jar"
+    descriptor, temporary_name = tempfile.mkstemp(prefix="artifacts-", suffix=".jar", dir=repository)
+    os.close(descriptor)
+    temporary = Path(temporary_name)
+    try:
+        info = zipfile.ZipInfo("artifacts.xml", date_time=(1980, 1, 1, 0, 0, 0))
+        info.compress_type = zipfile.ZIP_DEFLATED
+        info.external_attr = 0o100644 << 16
+        with zipfile.ZipFile(temporary, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=9) as archive:
+            archive.writestr(info, payload)
+        temporary.replace(target)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", required=True, type=Path)
+    args = parser.parse_args()
+
+    repository = args.repository.resolve()
+    root, compressed = load_metadata(repository)
+    evidence: list[dict[str, object]] = []
+    artifacts = root.findall("./artifacts/artifact")
+    if not artifacts:
+        raise MetadataError("p2 repository contains no artifact entries")
+    for artifact in artifacts:
+        classifier = artifact.attrib.get("classifier", "")
+        identifier = artifact.attrib.get("id", "")
+        version = artifact.attrib.get("version", "")
+        if not classifier or not identifier or not version:
+            raise MetadataError(f"Malformed artifact key: {artifact.attrib}")
+        path = artifact_path(repository, classifier, identifier, version)
+        if not path.is_file():
+            raise MetadataError(f"Artifact metadata references a missing file: {path}")
+        size = path.stat().st_size
+        digest = sha256(path)
+        set_properties(
+            artifact,
+            {
+                "artifact.size": str(size),
+                "download.size": str(size),
+                "download.checksum.sha-256": digest,
+            },
+        )
+        evidence.append(
+            {
+                "classifier": classifier,
+                "id": identifier,
+                "version": version,
+                "file": str(path.relative_to(repository)),
+                "size": size,
+                "sha256": digest,
+            }
+        )
+    write_metadata(repository, root, compressed)
+    print(json.dumps({"schemaVersion": 1, "artifacts": evidence}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/publish_patched_jdt_ui_repository.sh
+++ b/.github/scripts/publish_patched_jdt_ui_repository.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+CONFIG_FILE=${PATCHED_JDT_UI_CONFIG:-"$ROOT_DIR/.github/patched-jdt-ui.env"}
+PATCH_DIR=${1:?usage: publish_patched_jdt_ui_repository.sh PATCH_DIR COMPATIBILITY_DIR [OUTPUT_DIR]}
+COMPATIBILITY_DIR=${2:?usage: publish_patched_jdt_ui_repository.sh PATCH_DIR COMPATIBILITY_DIR [OUTPUT_DIR]}
+OUTPUT_DIR=${3:-"$ROOT_DIR/target/patched-jdt-ui-p2"}
+WORK_DIR=${PATCHED_JDT_UI_P2_WORK_DIR:-"${RUNNER_TEMP:-${TMPDIR:-/tmp}}/patched-jdt-ui-p2-publisher"}
+FEATURE_ID=${PATCHED_JDT_UI_FEATURE_ID:-sandbox_patched_jdt_ui_feature}
+
+# shellcheck disable=SC1090
+source "$CONFIG_FILE"
+: "${PATCHED_JDT_UI_BUNDLE:?missing PATCHED_JDT_UI_BUNDLE}"
+
+for command in find java mvn python3 sed sha256sum; do
+  command -v "$command" >/dev/null || { echo "Missing required command: $command" >&2; exit 1; }
+done
+
+PROVENANCE="$PATCH_DIR/provenance.json"
+COMPATIBILITY="$COMPATIBILITY_DIR/compatibility.json"
+[[ -f "$PROVENANCE" ]] || { echo "Missing bundle provenance: $PROVENANCE" >&2; exit 1; }
+[[ -f "$COMPATIBILITY" ]] || { echo "Missing target compatibility report: $COMPATIBILITY" >&2; exit 1; }
+
+readarray -t values < <(python3 - "$PROVENANCE" "$COMPATIBILITY" "$PATCHED_JDT_UI_BUNDLE" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+provenance = json.loads(Path(sys.argv[1]).read_text(encoding='utf-8'))
+compatibility = json.loads(Path(sys.argv[2]).read_text(encoding='utf-8'))
+expected_id = sys.argv[3]
+if compatibility.get('compatibleForReplacement') is not True:
+    raise SystemExit('Compatibility report does not authorize p2 publication')
+if provenance.get('bundleSymbolicName') != expected_id:
+    raise SystemExit('Bundle provenance has an unexpected symbolic name')
+version = str(provenance.get('bundleVersion', ''))
+sha256 = str(provenance.get('bundleSha256', ''))
+patched = compatibility.get('patchedBundle') or {}
+if patched.get('version') != version or patched.get('sha256') != sha256:
+    raise SystemExit('Compatibility report and provenance refer to different bundle bytes')
+if not re.fullmatch(r'[0-9]+\.[0-9]+\.[0-9]+\.[A-Za-z0-9_-]+', version):
+    raise SystemExit(f'Unsupported qualified bundle version: {version}')
+print(version)
+print(sha256)
+print(version.split('.', 3)[3])
+PY
+)
+BUNDLE_VERSION=${values[0]}
+BUNDLE_SHA256=${values[1]}
+BUNDLE_QUALIFIER=${values[2]}
+FEATURE_VERSION="1.0.0.${BUNDLE_QUALIFIER}"
+
+mapfile -t bundle_candidates < <(find "$PATCH_DIR/plugins" -maxdepth 1 -type f \
+  -name "${PATCHED_JDT_UI_BUNDLE}_${BUNDLE_VERSION}.jar" | sort)
+if (( ${#bundle_candidates[@]} != 1 )); then
+  printf 'Expected exactly one patched bundle %s_%s.jar, found %d\n' \
+    "$PATCHED_JDT_UI_BUNDLE" "$BUNDLE_VERSION" "${#bundle_candidates[@]}" >&2
+  exit 1
+fi
+BUNDLE_JAR=${bundle_candidates[0]}
+if [[ "$(sha256sum "$BUNDLE_JAR" | awk '{print $1}')" != "$BUNDLE_SHA256" ]]; then
+  echo 'Patched bundle bytes do not match provenance before publication' >&2
+  exit 1
+fi
+
+SOURCE_DIR="$WORK_DIR/source"
+FEATURE_DIR="$SOURCE_DIR/features/${FEATURE_ID}_${FEATURE_VERSION}"
+REPOSITORY_DIR="$OUTPUT_DIR/repository"
+EVIDENCE_DIR="$OUTPUT_DIR/evidence"
+rm -rf "$WORK_DIR" "$OUTPUT_DIR"
+mkdir -p "$SOURCE_DIR/plugins" "$FEATURE_DIR" "$REPOSITORY_DIR" "$EVIDENCE_DIR"
+cp "$BUNDLE_JAR" "$SOURCE_DIR/plugins/${PATCHED_JDT_UI_BUNDLE}_${BUNDLE_VERSION}.jar"
+
+cat > "$FEATURE_DIR/feature.xml" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="$FEATURE_ID"
+      label="Sandbox Patched JDT UI"
+      version="$FEATURE_VERSION"
+      provider-name="Sandbox">
+   <description>
+      Exact-version carrier feature for the reviewed Sandbox JDT UI scope-expansion patch.
+   </description>
+   <copyright>
+      Copyright (c) Eclipse contributors and Sandbox contributors.
+   </copyright>
+   <license url="https://www.eclipse.org/legal/epl-2.0/">
+      Eclipse Public License 2.0
+   </license>
+   <requires>
+      <import plugin="$PATCHED_JDT_UI_BUNDLE" version="$BUNDLE_VERSION" match="perfect"/>
+   </requires>
+   <plugin
+         id="$PATCHED_JDT_UI_BUNDLE"
+         download-size="0"
+         install-size="0"
+         version="$BUNDLE_VERSION"
+         unpack="false"/>
+</feature>
+EOF
+
+TYCHO_VERSION=$(mvn -q -ntp -f "$ROOT_DIR/pom.xml" help:evaluate \
+  -Dexpression=tycho-version -DforceStdout \
+  | sed -nE '/^[0-9]+\.[0-9]+\.[0-9]+([.-].*)?$/p' \
+  | tail -n 1)
+if ! [[ "$TYCHO_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-].*)?$ ]]; then
+  echo "Could not determine a Tycho version from the reactor: $TYCHO_VERSION" >&2
+  exit 1
+fi
+
+cat > "$WORK_DIR/pom.xml" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.sandbox.build</groupId>
+  <artifactId>patched-jdt-ui-p2-publisher</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.tycho.extras</groupId>
+        <artifactId>tycho-p2-extras-plugin</artifactId>
+        <version>$TYCHO_VERSION</version>
+        <configuration>
+          <sourceLocation>\${source.location}</sourceLocation>
+          <metadataRepositoryLocation>\${repository.location}</metadataRepositoryLocation>
+          <artifactRepositoryLocation>\${repository.location}</artifactRepositoryLocation>
+          <compress>true</compress>
+          <publishArtifacts>true</publishArtifacts>
+          <append>false</append>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+EOF
+
+mvn --batch-mode -ntp -f "$WORK_DIR/pom.xml" \
+  "org.eclipse.tycho.extras:tycho-p2-extras-plugin:${TYCHO_VERSION}:publish-features-and-bundles" \
+  -Dsource.location="$SOURCE_DIR" \
+  -Drepository.location="$REPOSITORY_DIR"
+
+python3 "$ROOT_DIR/.github/scripts/add_p2_sha256_checksums.py" \
+  --repository "$REPOSITORY_DIR" \
+  > "$EVIDENCE_DIR/checksum-normalization.json"
+cp "$PROVENANCE" "$EVIDENCE_DIR/bundle-provenance.json"
+cp "$COMPATIBILITY" "$EVIDENCE_DIR/target-compatibility.json"
+cp "$FEATURE_DIR/feature.xml" "$EVIDENCE_DIR/feature.xml"
+python3 "$ROOT_DIR/.github/scripts/verify_patched_jdt_ui_repository.py" \
+  --repository "$REPOSITORY_DIR" \
+  --bundle-provenance "$PROVENANCE" \
+  --compatibility "$COMPATIBILITY" \
+  --feature-id "$FEATURE_ID" \
+  --feature-version "$FEATURE_VERSION" \
+  --output "$EVIDENCE_DIR"
+
+export EVIDENCE_DIR FEATURE_ID FEATURE_VERSION PATCHED_JDT_UI_BUNDLE BUNDLE_VERSION BUNDLE_SHA256
+python3 <<'PY'
+import json
+import os
+from pathlib import Path
+
+path = Path(os.environ['EVIDENCE_DIR']) / 'repository-provenance.json'
+payload = {
+    'schemaVersion': 1,
+    'featureId': os.environ['FEATURE_ID'],
+    'featureVersion': os.environ['FEATURE_VERSION'],
+    'featureGroupIU': f"{os.environ['FEATURE_ID']}.feature.group",
+    'bundleSymbolicName': os.environ['PATCHED_JDT_UI_BUNDLE'],
+    'bundleVersion': os.environ['BUNDLE_VERSION'],
+    'bundleSha256': os.environ['BUNDLE_SHA256'],
+}
+path.write_text(json.dumps(payload, indent=2) + '\n', encoding='utf-8')
+PY
+
+printf 'Published %s %s requiring %s %s to %s\n' \
+  "$FEATURE_ID" "$FEATURE_VERSION" "$PATCHED_JDT_UI_BUNDLE" "$BUNDLE_VERSION" "$REPOSITORY_DIR"

--- a/.github/scripts/run_patched_jdt_ui_scope_probe.sh
+++ b/.github/scripts/run_patched_jdt_ui_scope_probe.sh
@@ -1,0 +1,319 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+P2_ROOT=${1:?usage: run_patched_jdt_ui_scope_probe.sh P2_OUTPUT INSTALLATION_EVIDENCE [PROBE_EVIDENCE]}
+INSTALLATION_EVIDENCE=${2:?usage: run_patched_jdt_ui_scope_probe.sh P2_OUTPUT INSTALLATION_EVIDENCE [PROBE_EVIDENCE]}
+EVIDENCE_DIR=${3:-"$ROOT_DIR/target/patched-jdt-ui-runtime-probe"}
+PROBE_ROOT="$ROOT_DIR/.github/probes/patched-jdt-ui"
+WORK_DIR=${PATCHED_JDT_UI_PROBE_WORK_DIR:-"${RUNNER_TEMP:-${TMPDIR:-/tmp}}/patched-jdt-ui-runtime-probe"}
+PROBE_ID=sandbox_patched_jdt_ui_runtime_probe
+PROBE_VERSION=1.0.0
+PROBE_IU="$PROBE_ID/$PROBE_VERSION"
+PROBE_APPLICATION="$PROBE_ID.scopeProbe"
+INSTALLATION_JSON="$INSTALLATION_EVIDENCE/installation-verification.json"
+
+for command in find jar java javac mvn paste python3 sha256sum timeout xvfb-run; do
+  command -v "$command" >/dev/null || { echo "Missing required command: $command" >&2; exit 1; }
+done
+[[ -f "$INSTALLATION_JSON" ]] || { echo "Missing patched-product evidence: $INSTALLATION_JSON" >&2; exit 1; }
+[[ -f "$PROBE_ROOT/META-INF/MANIFEST.MF" ]] || { echo 'Missing runtime probe manifest' >&2; exit 1; }
+[[ -f "$PROBE_ROOT/plugin.xml" ]] || { echo 'Missing runtime probe extension declaration' >&2; exit 1; }
+
+readarray -t product_values < <(python3 - "$INSTALLATION_JSON" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+report = json.loads(Path(sys.argv[1]).read_text(encoding='utf-8'))
+if report.get('result') != 'PASS':
+    raise SystemExit('Patched-product installation evidence is not PASS')
+print(report['productRoot'])
+print(report['profileId'])
+print(report['patchedBundle']['id'])
+print(report['patchedBundle']['version'])
+PY
+)
+PRODUCT_ROOT=${product_values[0]}
+PROFILE_ID=${product_values[1]}
+PATCHED_BUNDLE_ID=${product_values[2]}
+PATCHED_BUNDLE_VERSION=${product_values[3]}
+[[ -d "$PRODUCT_ROOT" ]] || { echo "Product root does not exist: $PRODUCT_ROOT" >&2; exit 1; }
+
+mapfile -t launchers < <(find "$PRODUCT_ROOT/plugins" -maxdepth 1 -type f \
+  -name 'org.eclipse.equinox.launcher_*.jar' | sort)
+if (( ${#launchers[@]} != 1 )); then
+  printf 'Expected one Equinox launcher, found %d: %s\n' \
+    "${#launchers[@]}" "${launchers[*]:-<none>}" >&2
+  exit 1
+fi
+LAUNCHER=${launchers[0]}
+BUNDLES_INFO="$PRODUCT_ROOT/configuration/org.eclipse.equinox.simpleconfigurator/bundles.info"
+[[ -f "$BUNDLES_INFO" ]] || { echo "Missing bundles.info: $BUNDLES_INFO" >&2; exit 1; }
+mapfile -t patched_lines < <(awk -F, -v id="$PATCHED_BUNDLE_ID" '$1 == id { print }' "$BUNDLES_INFO")
+if (( ${#patched_lines[@]} != 1 )) || [[ "$(awk -F, '{print $2}' <<<"${patched_lines[0]:-}")" != "$PATCHED_BUNDLE_VERSION" ]]; then
+  echo "Runtime probe requires exactly one selected $PATCHED_BUNDLE_ID $PATCHED_BUNDLE_VERSION" >&2
+  exit 1
+fi
+
+rm -rf "$WORK_DIR" "$EVIDENCE_DIR"
+CLASSES_DIR="$WORK_DIR/classes"
+SOURCE_DIR="$WORK_DIR/source"
+REPOSITORY_DIR="$WORK_DIR/repository"
+mkdir -p "$CLASSES_DIR" "$SOURCE_DIR/plugins" "$REPOSITORY_DIR" "$EVIDENCE_DIR"
+
+mapfile -t product_jars < <(find "$PRODUCT_ROOT/plugins" -maxdepth 1 -type f -name '*.jar' | sort)
+if (( ${#product_jars[@]} == 0 )); then
+  echo "Materialized product contains no plug-in JARs: $PRODUCT_ROOT" >&2
+  exit 1
+fi
+PRODUCT_CLASSPATH=$(IFS=:; echo "${product_jars[*]}")
+mapfile -t probe_sources < <(find "$PROBE_ROOT/src" -type f -name '*.java' | sort)
+if (( ${#probe_sources[@]} == 0 )); then
+  echo 'Runtime probe contains no Java sources' >&2
+  exit 1
+fi
+
+javac --release 21 -encoding UTF-8 \
+  -classpath "$PRODUCT_CLASSPATH" \
+  -d "$CLASSES_DIR" \
+  "${probe_sources[@]}" \
+  2>&1 | tee "$EVIDENCE_DIR/compile.log"
+
+PROBE_JAR="$SOURCE_DIR/plugins/${PROBE_ID}_${PROBE_VERSION}.jar"
+jar --create \
+  --file "$PROBE_JAR" \
+  --manifest "$PROBE_ROOT/META-INF/MANIFEST.MF" \
+  -C "$CLASSES_DIR" . \
+  -C "$PROBE_ROOT" plugin.xml
+jar --list --file "$PROBE_JAR" > "$EVIDENCE_DIR/probe-jar-entries.txt"
+grep -Fq 'org/sandbox/jdt/ui/probe/ScopeExpansionProbeApplication.class' "$EVIDENCE_DIR/probe-jar-entries.txt"
+grep -Fq 'plugin.xml' "$EVIDENCE_DIR/probe-jar-entries.txt"
+PROBE_SHA256=$(sha256sum "$PROBE_JAR" | awk '{print $1}')
+
+TYCHO_VERSION=$(mvn -q -ntp -f "$ROOT_DIR/pom.xml" help:evaluate \
+  -Dexpression=tycho-version -DforceStdout \
+  | sed -nE '/^[0-9]+\.[0-9]+\.[0-9]+([.-].*)?$/p' \
+  | tail -n 1)
+if ! [[ "$TYCHO_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-].*)?$ ]]; then
+  echo "Could not determine Tycho version: $TYCHO_VERSION" >&2
+  exit 1
+fi
+
+cat > "$WORK_DIR/pom.xml" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.sandbox.build</groupId>
+  <artifactId>patched-jdt-ui-runtime-probe-publisher</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.tycho.extras</groupId>
+        <artifactId>tycho-p2-extras-plugin</artifactId>
+        <version>$TYCHO_VERSION</version>
+        <configuration>
+          <sourceLocation>\${source.location}</sourceLocation>
+          <metadataRepositoryLocation>\${repository.location}</metadataRepositoryLocation>
+          <artifactRepositoryLocation>\${repository.location}</artifactRepositoryLocation>
+          <compress>true</compress>
+          <publishArtifacts>true</publishArtifacts>
+          <append>false</append>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+EOF
+
+mvn --batch-mode -ntp -f "$WORK_DIR/pom.xml" \
+  "org.eclipse.tycho.extras:tycho-p2-extras-plugin:${TYCHO_VERSION}:publish-features-and-bundles" \
+  -Dsource.location="$SOURCE_DIR" \
+  -Drepository.location="$REPOSITORY_DIR" \
+  2>&1 | tee "$EVIDENCE_DIR/publisher.log"
+
+python3 "$ROOT_DIR/.github/scripts/add_p2_sha256_checksums.py" \
+  --repository "$REPOSITORY_DIR" \
+  > "$EVIDENCE_DIR/probe-checksum-normalization.json"
+python3 - "$REPOSITORY_DIR" "$PROBE_ID" "$PROBE_VERSION" "$PROBE_SHA256" "$EVIDENCE_DIR" <<'PY'
+import hashlib
+import json
+import re
+import sys
+import xml.etree.ElementTree as ET
+import zipfile
+from pathlib import Path
+
+repository = Path(sys.argv[1])
+probe_id = sys.argv[2]
+probe_version = sys.argv[3]
+expected_sha = sys.argv[4]
+evidence = Path(sys.argv[5])
+
+
+def repository_xml(stem: str) -> ET.Element:
+    jar = repository / f'{stem}.jar'
+    xml = repository / f'{stem}.xml'
+    if jar.is_file():
+        with zipfile.ZipFile(jar) as archive:
+            return ET.fromstring(archive.read(f'{stem}.xml'))
+    if xml.is_file():
+        return ET.parse(xml).getroot()
+    raise SystemExit(f'Probe repository is missing {stem}.jar and {stem}.xml')
+
+
+def sha256(path: Path) -> str:
+    value = hashlib.sha256()
+    with path.open('rb') as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b''):
+            value.update(chunk)
+    return value.hexdigest()
+
+
+content = repository_xml('content')
+artifacts = repository_xml('artifacts')
+matching_units = [
+    unit for unit in content.findall('./units/unit')
+    if unit.attrib.get('id') == probe_id and unit.attrib.get('version') == probe_version
+]
+if len(matching_units) != 1:
+    raise SystemExit(f'Expected one probe IU, found {len(matching_units)}')
+keys = {
+    (item.attrib.get('classifier'), item.attrib.get('id'), item.attrib.get('version'))
+    for item in artifacts.findall('./artifacts/artifact')
+}
+expected_key = ('osgi.bundle', probe_id, probe_version)
+if keys != {expected_key}:
+    raise SystemExit(f'Unexpected probe repository artifacts: {sorted(keys)}')
+artifact = artifacts.find(
+    f"./artifacts/artifact[@classifier='osgi.bundle'][@id='{probe_id}'][@version='{probe_version}']"
+)
+if artifact is None:
+    raise SystemExit('Probe artifact metadata is missing')
+properties = artifact.find('properties')
+metadata = {} if properties is None else {
+    item.attrib.get('name', ''): item.attrib.get('value', '')
+    for item in properties.findall('property')
+}
+path = repository / 'plugins' / f'{probe_id}_{probe_version}.jar'
+if not path.is_file():
+    raise SystemExit(f'Probe repository references a missing plug-in: {path}')
+if sha256(path) != expected_sha:
+    raise SystemExit('Published probe plug-in bytes differ from the compiled JAR')
+size = metadata.get('download.size') or metadata.get('artifact.size')
+if size and size.isdigit() and path.stat().st_size != int(size):
+    raise SystemExit('Published probe plug-in size differs from p2 metadata')
+checksums = [
+    name for name, value in metadata.items()
+    if (re.fullmatch(r'[0-9a-fA-F]{64}', value) and ('sha-256' in name.lower() or 'sha256' in name.lower()))
+    or (re.fullmatch(r'[0-9a-fA-F]{32}', value) and 'md5' in name.lower())
+]
+if not checksums:
+    raise SystemExit('Probe p2 metadata contains no verifiable checksum')
+payload = {
+    'schemaVersion': 1,
+    'result': 'PASS',
+    'iu': {'id': probe_id, 'version': probe_version},
+    'bundleSha256': expected_sha,
+    'checksumProperties': sorted(checksums),
+}
+(evidence / 'probe-repository.json').write_text(json.dumps(payload, indent=2) + '\n', encoding='utf-8')
+print(json.dumps(payload, indent=2))
+PY
+
+REPOSITORY_URI=$(python3 - "$REPOSITORY_DIR" <<'PY'
+import sys
+from pathlib import Path
+print(Path(sys.argv[1]).resolve().as_uri())
+PY
+)
+(
+  cd "$PRODUCT_ROOT"
+  timeout 600s xvfb-run -a java -jar "$LAUNCHER" -nosplash -consoleLog \
+    -application org.eclipse.equinox.p2.director \
+    -repository "$REPOSITORY_URI" \
+    -installIU "$PROBE_IU" \
+    -destination "$PRODUCT_ROOT" \
+    -bundlepool "$PRODUCT_ROOT" \
+    -profile "$PROFILE_ID" \
+    -p2.os linux -p2.ws gtk -p2.arch x86_64
+) > "$EVIDENCE_DIR/install-probe.log" 2>&1
+
+mapfile -t probe_lines < <(awk -F, -v id="$PROBE_ID" '$1 == id { print }' "$BUNDLES_INFO")
+if (( ${#probe_lines[@]} != 1 )) || [[ "$(awk -F, '{print $2}' <<<"${probe_lines[0]:-}")" != "$PROBE_VERSION" ]]; then
+  echo "Product did not select exactly one runtime probe bundle $PROBE_ID $PROBE_VERSION" >&2
+  exit 1
+fi
+printf '%s\n' "${probe_lines[0]}" > "$EVIDENCE_DIR/probe-bundle-selection.txt"
+
+WORKSPACE_DIR="$EVIDENCE_DIR/workspace"
+RESULT_JSON="$EVIDENCE_DIR/probe-result.json"
+rm -rf "$WORKSPACE_DIR"
+mkdir -p "$WORKSPACE_DIR"
+(
+  cd "$PRODUCT_ROOT"
+  SANDBOX_PATCHED_JDT_UI_PROBE_REPORT="$RESULT_JSON" \
+    timeout 300s xvfb-run -a java -jar "$LAUNCHER" -nosplash -consoleLog -clean \
+      -application "$PROBE_APPLICATION" \
+      -data "$WORKSPACE_DIR"
+) > "$EVIDENCE_DIR/runtime.log" 2>&1
+
+grep -Fq 'PATCHED_JDT_UI_SCOPE_PROBE_PASS' "$EVIDENCE_DIR/runtime.log"
+python3 - "$RESULT_JSON" "$EVIDENCE_DIR" "$PATCHED_BUNDLE_ID" "$PATCHED_BUNDLE_VERSION" \
+  "$PROBE_ID" "$PROBE_VERSION" "$PROBE_SHA256" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+result_path = Path(sys.argv[1])
+evidence = Path(sys.argv[2])
+patched_id = sys.argv[3]
+patched_version = sys.argv[4]
+probe_id = sys.argv[5]
+probe_version = sys.argv[6]
+probe_sha = sys.argv[7]
+result = json.loads(result_path.read_text(encoding='utf-8'))
+expected_exact = {
+    'result': 'PASS',
+    'targetCount': 2,
+    'plannedCount': 2,
+    'previewCount': 2,
+    'appliedCount': 2,
+    'restoredCount': 2,
+}
+for key, expected in expected_exact.items():
+    if result.get(key) != expected:
+        raise SystemExit(f'Unexpected runtime probe value {key}: {result.get(key)!r}, expected {expected!r}')
+if not isinstance(result.get('expansionInvocations'), int) or result['expansionInvocations'] < 2:
+    raise SystemExit(f"Scope expansion did not reach a fixed point: {result.get('expansionInvocations')!r}")
+payload = {
+    'schemaVersion': 1,
+    'result': 'PASS',
+    'patchedBundle': {'id': patched_id, 'version': patched_version},
+    'probeBundle': {'id': probe_id, 'version': probe_version, 'sha256': probe_sha},
+    'behavior': result,
+}
+(evidence / 'runtime-verification.json').write_text(
+    json.dumps(payload, indent=2) + '\n', encoding='utf-8'
+)
+lines = [
+    '# Patched JDT UI runtime behavior verification',
+    '',
+    '- Result: **PASS**',
+    f'- Patched bundle: `{patched_id} {patched_version}`',
+    f'- Probe bundle: `{probe_id} {probe_version}`',
+    '- One explicitly selected Java file expanded to two cleanup targets: **PASS**',
+    '- Both compilation units reached preconditions and preview: **PASS**',
+    '- Both source files changed through one composite cleanup: **PASS**',
+    '- Undo restored both files byte-for-byte: **PASS**',
+    f"- Scope-expansion invocations: **{result['expansionInvocations']}** (fixed point reached)",
+]
+(evidence / 'runtime-verification.md').write_text('\n'.join(lines) + '\n', encoding='utf-8')
+print(json.dumps(payload, indent=2))
+PY
+
+rm -rf "$WORKSPACE_DIR"

--- a/.github/scripts/smoke_test_patched_jdt_ui_repository.sh
+++ b/.github/scripts/smoke_test_patched_jdt_ui_repository.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+P2_ROOT=${1:?usage: smoke_test_patched_jdt_ui_repository.sh P2_OUTPUT [EVIDENCE_DIR]}
+EVIDENCE_DIR=${2:-"$ROOT_DIR/target/patched-jdt-ui-installation"}
+REPOSITORY_DIR="$P2_ROOT/repository"
+REPOSITORY_EVIDENCE="$P2_ROOT/evidence"
+VERIFICATION_JSON="$REPOSITORY_EVIDENCE/repository-verification.json"
+PRODUCTS_DIR="$ROOT_DIR/sandbox_product/target/products"
+
+for command in awk basename dirname find java python3 sha256sum timeout xvfb-run; do
+  command -v "$command" >/dev/null || { echo "Missing required command: $command" >&2; exit 1; }
+done
+[[ -f "$VERIFICATION_JSON" ]] || { echo "Missing repository verification: $VERIFICATION_JSON" >&2; exit 1; }
+
+readarray -t expected < <(python3 - "$VERIFICATION_JSON" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+report = json.loads(Path(sys.argv[1]).read_text(encoding='utf-8'))
+if report.get('result') != 'PASS':
+    raise SystemExit('Repository verification is not PASS')
+print(report['bundle']['id'])
+print(report['bundle']['version'])
+print(report['bundle']['sha256'])
+print(report['feature']['groupIU'])
+print(report['feature']['version'])
+PY
+)
+BUNDLE_ID=${expected[0]}
+BUNDLE_VERSION=${expected[1]}
+BUNDLE_SHA256=${expected[2]}
+FEATURE_GROUP=${expected[3]}
+FEATURE_VERSION=${expected[4]}
+
+mapfile -t architecture_roots < <(find "$PRODUCTS_DIR" -type d -path '*/linux/gtk/x86_64' -print | sort)
+if (( ${#architecture_roots[@]} != 1 )); then
+  printf 'Expected exactly one Linux GTK x86_64 product directory, found %d: %s\n' \
+    "${#architecture_roots[@]}" "${architecture_roots[*]:-<none>}" >&2
+  exit 1
+fi
+ARCHITECTURE_ROOT=${architecture_roots[0]}
+mapfile -t launchers < <(find "$ARCHITECTURE_ROOT" -type f \
+  -path '*/plugins/org.eclipse.equinox.launcher_*.jar' | sort)
+if (( ${#launchers[@]} != 1 )); then
+  printf 'Expected exactly one Equinox launcher below %s, found %d: %s\n' \
+    "$ARCHITECTURE_ROOT" "${#launchers[@]}" "${launchers[*]:-<none>}" >&2
+  exit 1
+fi
+LAUNCHER=${launchers[0]}
+PRODUCT_ROOT=$(dirname "$(dirname "$LAUNCHER")")
+[[ -f "$PRODUCT_ROOT/configuration/config.ini" ]] \
+  || { echo "Launcher parent is not a materialized product root: $PRODUCT_ROOT" >&2; exit 1; }
+BUNDLES_INFO="$PRODUCT_ROOT/configuration/org.eclipse.equinox.simpleconfigurator/bundles.info"
+[[ -f "$BUNDLES_INFO" ]] || { echo "Missing bundles.info: $BUNDLES_INFO" >&2; exit 1; }
+
+mapfile -t profiles < <(find "$PRODUCT_ROOT/p2/org.eclipse.equinox.p2.engine/profileRegistry" \
+  -maxdepth 1 -mindepth 1 -type d -name '*.profile' | sort)
+if (( ${#profiles[@]} != 1 )); then
+  printf 'Expected exactly one materialized product profile, found %d: %s\n' \
+    "${#profiles[@]}" "${profiles[*]:-<none>}" >&2
+  exit 1
+fi
+PROFILE_ID=$(basename "${profiles[0]}" .profile)
+
+selected_bundle_line() {
+  awk -F, -v id="$BUNDLE_ID" '$1 == id { print }' "$BUNDLES_INFO"
+}
+
+mapfile -t stock_lines < <(selected_bundle_line)
+if (( ${#stock_lines[@]} != 1 )); then
+  printf 'Expected one selected stock %s bundle, found %d\n' "$BUNDLE_ID" "${#stock_lines[@]}" >&2
+  exit 1
+fi
+STOCK_VERSION=$(awk -F, '{print $2}' <<<"${stock_lines[0]}")
+if [[ "$STOCK_VERSION" == "$BUNDLE_VERSION" ]]; then
+  echo 'Stock product already selects the patched version; stock regression cannot be distinguished' >&2
+  exit 1
+fi
+
+mkdir -p "$EVIDENCE_DIR"
+printf '%s\n' "${stock_lines[0]}" > "$EVIDENCE_DIR/stock-bundle-selection.txt"
+REPOSITORY_URI=$(python3 - "$REPOSITORY_DIR" <<'PY'
+import sys
+from pathlib import Path
+print(Path(sys.argv[1]).resolve().as_uri())
+PY
+)
+
+(
+  cd "$PRODUCT_ROOT"
+  timeout 900s xvfb-run -a java -jar "$LAUNCHER" -nosplash -consoleLog \
+    -application org.eclipse.equinox.p2.director \
+    -repository "$REPOSITORY_URI" \
+    -installIU "$FEATURE_GROUP" \
+    -destination "$PRODUCT_ROOT" \
+    -bundlepool "$PRODUCT_ROOT" \
+    -profile "$PROFILE_ID" \
+    -profileProperties org.eclipse.update.install.features=true \
+    -p2.os linux -p2.ws gtk -p2.arch x86_64
+) > "$EVIDENCE_DIR/install.log" 2>&1
+
+mapfile -t patched_lines < <(selected_bundle_line)
+if (( ${#patched_lines[@]} != 1 )); then
+  printf 'Expected one selected patched %s bundle after installation, found %d\n' \
+    "$BUNDLE_ID" "${#patched_lines[@]}" >&2
+  exit 1
+fi
+SELECTED_VERSION=$(awk -F, '{print $2}' <<<"${patched_lines[0]}")
+if [[ "$SELECTED_VERSION" != "$BUNDLE_VERSION" ]]; then
+  echo "Installed product selected $BUNDLE_ID $SELECTED_VERSION instead of $BUNDLE_VERSION" >&2
+  exit 1
+fi
+printf '%s\n' "${patched_lines[0]}" > "$EVIDENCE_DIR/patched-bundle-selection.txt"
+
+mapfile -t selected_jars < <(find "$PRODUCT_ROOT/plugins" -maxdepth 1 -type f \
+  -name "${BUNDLE_ID}_${BUNDLE_VERSION}.jar" | sort)
+if (( ${#selected_jars[@]} != 1 )); then
+  printf 'Expected exactly one installed patched bundle file, found %d\n' "${#selected_jars[@]}" >&2
+  exit 1
+fi
+INSTALLED_SHA=$(sha256sum "${selected_jars[0]}" | awk '{print $1}')
+if [[ "$INSTALLED_SHA" != "$BUNDLE_SHA256" ]]; then
+  echo 'Installed bundle SHA-256 differs from repository provenance' >&2
+  exit 1
+fi
+
+(
+  cd "$PRODUCT_ROOT"
+  timeout 300s xvfb-run -a java -jar "$LAUNCHER" -nosplash -consoleLog \
+    -application org.eclipse.equinox.p2.director \
+    -listInstalledRoots \
+    -destination "$PRODUCT_ROOT" \
+    -profile "$PROFILE_ID"
+) > "$EVIDENCE_DIR/installed-roots.log" 2>&1
+if ! grep -Fq "$FEATURE_GROUP" "$EVIDENCE_DIR/installed-roots.log"; then
+  echo "Installed product did not report root $FEATURE_GROUP" >&2
+  exit 1
+fi
+
+export EVIDENCE_DIR PRODUCT_ROOT PROFILE_ID BUNDLE_ID BUNDLE_VERSION BUNDLE_SHA256
+export STOCK_VERSION FEATURE_GROUP FEATURE_VERSION INSTALLED_SHA
+python3 <<'PY'
+import json
+import os
+from pathlib import Path
+
+payload = {
+    'schemaVersion': 1,
+    'result': 'PASS',
+    'productRoot': os.environ['PRODUCT_ROOT'],
+    'profileId': os.environ['PROFILE_ID'],
+    'stockBundle': {'id': os.environ['BUNDLE_ID'], 'version': os.environ['STOCK_VERSION']},
+    'patchedBundle': {
+        'id': os.environ['BUNDLE_ID'],
+        'version': os.environ['BUNDLE_VERSION'],
+        'sha256': os.environ['BUNDLE_SHA256'],
+        'installedSha256': os.environ['INSTALLED_SHA'],
+    },
+    'feature': {'groupIU': os.environ['FEATURE_GROUP'], 'version': os.environ['FEATURE_VERSION']},
+}
+root = Path(os.environ['EVIDENCE_DIR'])
+(root / 'installation-verification.json').write_text(
+    json.dumps(payload, indent=2) + '\n', encoding='utf-8'
+)
+lines = [
+    '# Patched JDT UI installation verification',
+    '',
+    '- Result: **PASS**',
+    f"- Stock selection: `{os.environ['BUNDLE_ID']} {os.environ['STOCK_VERSION']}`",
+    f"- Patched selection: `{os.environ['BUNDLE_ID']} {os.environ['BUNDLE_VERSION']}`",
+    f"- Installed root: `{os.environ['FEATURE_GROUP']} {os.environ['FEATURE_VERSION']}`",
+    '- Exactly one active simpleconfigurator entry: **PASS**',
+    '- Installed bundle bytes match pinned SHA-256: **PASS**',
+    '- Patched product starts the p2 director and lists installed roots: **PASS**',
+]
+(root / 'installation-verification.md').write_text(
+    '\n'.join(lines) + '\n', encoding='utf-8'
+)
+print(json.dumps(payload, indent=2))
+PY

--- a/.github/scripts/verify_patched_jdt_ui_repository.py
+++ b/.github/scripts/verify_patched_jdt_ui_repository.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Verify the minimal p2 repository for the pinned patched JDT UI bundle."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+import xml.etree.ElementTree as ET
+import zipfile
+from pathlib import Path
+
+
+class VerificationError(RuntimeError):
+    """Raised when repository evidence is incomplete or inconsistent."""
+
+
+def fail(message: str) -> None:
+    raise VerificationError(message)
+
+
+def read_json(path: Path) -> dict[str, object]:
+    with path.open(encoding="utf-8") as stream:
+        value = json.load(stream)
+    if not isinstance(value, dict):
+        fail(f"Expected a JSON object in {path}")
+    return value
+
+
+def repository_xml(repository: Path, stem: str) -> ET.Element:
+    jar = repository / f"{stem}.jar"
+    xml = repository / f"{stem}.xml"
+    if jar.is_file():
+        with zipfile.ZipFile(jar) as archive:
+            try:
+                raw = archive.read(f"{stem}.xml")
+            except KeyError as error:
+                fail(f"{jar} does not contain {stem}.xml: {error}")
+        return ET.fromstring(raw)
+    if xml.is_file():
+        return ET.parse(xml).getroot()
+    fail(f"Repository is missing {stem}.jar and {stem}.xml: {repository}")
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def md5(path: Path) -> str:
+    digest = hashlib.md5(usedforsecurity=False)
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def properties(element: ET.Element) -> dict[str, str]:
+    container = element.find("properties")
+    if container is None:
+        return {}
+    return {
+        item.attrib.get("name", ""): item.attrib.get("value", "")
+        for item in container.findall("property")
+        if item.attrib.get("name")
+    }
+
+
+def exact_requirement(unit: ET.Element, identifier: str, version: str) -> bool:
+    expected_ranges = {version, f"[{version},{version}]"}
+    for requirement in unit.findall("./requires/required"):
+        if requirement.attrib.get("name") != identifier:
+            continue
+        if requirement.attrib.get("namespace") not in (None, "org.eclipse.equinox.p2.iu"):
+            continue
+        if requirement.attrib.get("range", "") in expected_ranges:
+            return True
+    return False
+
+
+def artifact_file(repository: Path, classifier: str, identifier: str, version: str) -> Path:
+    if classifier == "osgi.bundle":
+        return repository / "plugins" / f"{identifier}_{version}.jar"
+    if classifier == "org.eclipse.update.feature":
+        return repository / "features" / f"{identifier}_{version}.jar"
+    fail(f"Unexpected artifact classifier {classifier!r}")
+
+
+def verify_integrity(path: Path, metadata: dict[str, str]) -> list[str]:
+    if not path.is_file():
+        fail(f"Artifact metadata references missing file: {path}")
+    checks: list[str] = []
+    size = metadata.get("download.size") or metadata.get("artifact.size")
+    if size and size.isdigit():
+        if path.stat().st_size != int(size):
+            fail(f"Size mismatch for {path.name}: file={path.stat().st_size}, metadata={size}")
+        checks.append("size")
+    for name, value in metadata.items():
+        lowered = name.lower()
+        if re.fullmatch(r"[0-9a-fA-F]{64}", value) and ("sha-256" in lowered or "sha256" in lowered):
+            if sha256(path).lower() != value.lower():
+                fail(f"SHA-256 mismatch for {path.name} ({name})")
+            checks.append("sha256")
+        elif re.fullmatch(r"[0-9a-fA-F]{32}", value) and "md5" in lowered:
+            if md5(path).lower() != value.lower():
+                fail(f"MD5 mismatch for {path.name} ({name})")
+            checks.append("md5")
+    if not any(check in {"sha256", "md5"} for check in checks):
+        fail(f"No verifiable checksum property was published for {path.name}")
+    return sorted(set(checks))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", required=True, type=Path)
+    parser.add_argument("--bundle-provenance", required=True, type=Path)
+    parser.add_argument("--compatibility", required=True, type=Path)
+    parser.add_argument("--feature-id", required=True)
+    parser.add_argument("--feature-version", required=True)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+
+    try:
+        repository = args.repository.resolve()
+        provenance = read_json(args.bundle_provenance)
+        compatibility = read_json(args.compatibility)
+        if compatibility.get("compatibleForReplacement") is not True:
+            fail("Stock-target compatibility report does not authorize p2 replacement")
+
+        bundle_id = str(provenance.get("bundleSymbolicName", ""))
+        bundle_version = str(provenance.get("bundleVersion", ""))
+        bundle_sha = str(provenance.get("bundleSha256", ""))
+        if not bundle_id or not bundle_version or not re.fullmatch(r"[0-9a-f]{64}", bundle_sha):
+            fail("Bundle provenance is missing a valid symbolic name, version, or SHA-256")
+
+        patched = compatibility.get("patchedBundle")
+        if not isinstance(patched, dict):
+            fail("Compatibility report has no patchedBundle object")
+        if patched.get("version") != bundle_version or patched.get("sha256") != bundle_sha:
+            fail("Compatibility report and bundle provenance refer to different patched artifacts")
+
+        content = repository_xml(repository, "content")
+        artifacts = repository_xml(repository, "artifacts")
+        units = content.findall("./units/unit")
+
+        bundle_units = [unit for unit in units if unit.attrib.get("id") == bundle_id]
+        found_bundle_units = [
+            (unit.attrib.get("id"), unit.attrib.get("version")) for unit in bundle_units
+        ]
+        if found_bundle_units != [(bundle_id, bundle_version)]:
+            fail(
+                f"Expected exactly one bundle IU {bundle_id} {bundle_version}, "
+                f"found {found_bundle_units}"
+            )
+
+        feature_group_id = f"{args.feature_id}.feature.group"
+        feature_jar_id = f"{args.feature_id}.feature.jar"
+        feature_groups = [unit for unit in units if unit.attrib.get("id") == feature_group_id]
+        feature_jars = [unit for unit in units if unit.attrib.get("id") == feature_jar_id]
+        if [
+            (unit.attrib.get("id"), unit.attrib.get("version")) for unit in feature_groups
+        ] != [(feature_group_id, args.feature_version)]:
+            fail(f"Expected exactly one feature group IU {feature_group_id} {args.feature_version}")
+        if [
+            (unit.attrib.get("id"), unit.attrib.get("version")) for unit in feature_jars
+        ] != [(feature_jar_id, args.feature_version)]:
+            fail(f"Expected exactly one feature jar IU {feature_jar_id} {args.feature_version}")
+        if not exact_requirement(feature_groups[0], feature_jar_id, args.feature_version):
+            fail("Feature group does not require its exact feature jar IU")
+        if not exact_requirement(feature_groups[0], bundle_id, bundle_version):
+            fail("Feature group does not require the exact patched JDT UI bundle version")
+
+        artifact_entries = artifacts.findall("./artifacts/artifact")
+        expected_keys = {
+            ("osgi.bundle", bundle_id, bundle_version),
+            ("org.eclipse.update.feature", args.feature_id, args.feature_version),
+        }
+        actual_keys = {
+            (
+                item.attrib.get("classifier", ""),
+                item.attrib.get("id", ""),
+                item.attrib.get("version", ""),
+            )
+            for item in artifact_entries
+        }
+        if actual_keys != expected_keys:
+            fail(
+                f"Unexpected p2 artifact keys: expected={sorted(expected_keys)}, "
+                f"actual={sorted(actual_keys)}"
+            )
+
+        integrity: dict[str, list[str]] = {}
+        for item in artifact_entries:
+            classifier = item.attrib["classifier"]
+            identifier = item.attrib["id"]
+            version = item.attrib["version"]
+            path = artifact_file(repository, classifier, identifier, version)
+            integrity[path.name] = verify_integrity(path, properties(item))
+
+        bundle_path = repository / "plugins" / f"{bundle_id}_{bundle_version}.jar"
+        if sha256(bundle_path) != bundle_sha:
+            fail("Published bundle bytes do not match the pinned build provenance")
+
+        feature_path = repository / "features" / f"{args.feature_id}_{args.feature_version}.jar"
+        with zipfile.ZipFile(feature_path) as archive:
+            feature_xml = ET.fromstring(archive.read("feature.xml"))
+        if (
+            feature_xml.attrib.get("id") != args.feature_id
+            or feature_xml.attrib.get("version") != args.feature_version
+        ):
+            fail("Published feature.xml identity differs from the expected feature")
+        plugin = feature_xml.find(f"./plugin[@id='{bundle_id}']")
+        if plugin is None or plugin.attrib.get("version") != bundle_version:
+            fail("Published feature.xml does not pin the exact patched bundle version")
+
+        payload: dict[str, object] = {
+            "schemaVersion": 1,
+            "result": "PASS",
+            "repository": str(repository),
+            "sourceCommit": provenance.get("sourceCommit"),
+            "bundle": {"id": bundle_id, "version": bundle_version, "sha256": bundle_sha},
+            "feature": {
+                "id": args.feature_id,
+                "version": args.feature_version,
+                "groupIU": feature_group_id,
+                "jarIU": feature_jar_id,
+            },
+            "artifactIntegrity": integrity,
+            "unitCount": len(units),
+            "artifactCount": len(artifact_entries),
+        }
+        args.output.mkdir(parents=True, exist_ok=True)
+        (args.output / "repository-verification.json").write_text(
+            json.dumps(payload, indent=2) + "\n", encoding="utf-8"
+        )
+        lines = [
+            "# Patched JDT UI p2 repository verification",
+            "",
+            "- Result: **PASS**",
+            f"- Bundle: `{bundle_id} {bundle_version}`",
+            f"- Feature group: `{feature_group_id} {args.feature_version}`",
+            f"- p2 units: **{len(units)}**",
+            f"- p2 artifacts: **{len(artifact_entries)}**",
+            "- Bundle bytes match pinned SHA-256 provenance: **PASS**",
+            "- Exact-version feature requirement: **PASS**",
+            "- Published artifact checksums: **PASS**",
+        ]
+        (args.output / "repository-verification.md").write_text(
+            "\n".join(lines) + "\n", encoding="utf-8"
+        )
+        print(json.dumps(payload, indent=2))
+        return 0
+    except (
+        OSError,
+        KeyError,
+        ValueError,
+        ET.ParseError,
+        zipfile.BadZipFile,
+        VerificationError,
+    ) as error:
+        print(f"patched JDT UI p2 verification failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/patched-jdt-ui-bundle.yml
+++ b/.github/workflows/patched-jdt-ui-bundle.yml
@@ -1,14 +1,31 @@
 name: Patched JDT UI Bundle
 
-# This is an optional, manually triggered compatibility experiment. The pinned
-# replacement bundle still targets the pre-2026-06 JDT UI baseline and must not
-# participate in normal pull-request or main-branch validation until #1209 is
-# rebased and revalidated against Eclipse 2026-06 / Platform 4.40.
+# This opt-in lane proves the Eclipse 2026-06 patched-product delivery. It runs
+# for changes to the delivery implementation and by manual dispatch, but it is
+# deliberately not a normal push-to-main/default-build check.
 on:
   workflow_dispatch:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '.github/patched-jdt-ui.env'
+      - '.github/probes/patched-jdt-ui/**'
+      - '.github/scripts/add_p2_sha256_checksums.py'
+      - '.github/scripts/build_patched_jdt_ui.sh'
+      - '.github/scripts/compare_patched_jdt_ui_with_target.sh'
+      - '.github/scripts/publish_patched_jdt_ui_repository.sh'
+      - '.github/scripts/run_patched_jdt_ui_scope_probe.sh'
+      - '.github/scripts/smoke_test_patched_jdt_ui_repository.sh'
+      - '.github/scripts/verify_patched_jdt_ui_repository.py'
+      - '.github/workflows/patched-jdt-ui-bundle.yml'
+      - 'docs/patched-jdt-ui-delivery.md'
 
 permissions:
   contents: read
+
+concurrency:
+  group: patched-jdt-ui-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -70,7 +87,7 @@ jobs:
         with:
           name: patched-jdt-ui-${{ github.sha }}
           path: ${{ runner.temp }}/patched-jdt-ui
-      - name: Resolve the Sandbox target and compare manifests
+      - name: Resolve Eclipse 2026-06 target and compare manifests
         shell: bash
         run: |
           bash .github/scripts/compare_patched_jdt_ui_with_target.sh \
@@ -81,20 +98,9 @@ jobs:
         shell: bash
         run: |
           report="$RUNNER_TEMP/patched-jdt-ui-compatibility/compatibility.md"
-          result="$RUNNER_TEMP/patched-jdt-ui-compatibility/compatibility.json"
           log="$RUNNER_TEMP/patched-jdt-ui-compatibility/compatibility-build.log"
-          if [[ -s "$report" && -s "$result" ]]; then
+          if [[ -s "$report" ]]; then
             cat "$report" >> "$GITHUB_STEP_SUMMARY"
-            if ! python3 - "$result" <<'PY'
-          import json
-          import sys
-          with open(sys.argv[1], encoding='utf-8') as stream:
-              compatible = json.load(stream)['compatibleForReplacement']
-          raise SystemExit(0 if compatible else 1)
-          PY
-            then
-              echo '::warning::The pinned bundle is not yet eligible for p2 replacement. The report records the exact stock-target incompatibility; publication remains disabled.'
-            fi
           else
             {
               echo '### Patched JDT UI target compatibility'
@@ -106,11 +112,147 @@ jobs:
               echo '```'
             } >> "$GITHUB_STEP_SUMMARY"
           fi
+      - name: Enforce exact stock-target replacement gate
+        shell: bash
+        run: |
+          python3 - "$RUNNER_TEMP/patched-jdt-ui-compatibility/compatibility.json" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          report = json.loads(Path(sys.argv[1]).read_text(encoding='utf-8'))
+          if report.get('compatibleForReplacement') is not True:
+              raise SystemExit('Pinned JDT UI bundle is not compatible with the Eclipse 2026-06 stock target')
+          PY
       - name: Upload stock-target compatibility report
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: patched-jdt-ui-target-compatibility-${{ github.sha }}
           path: ${{ runner.temp }}/patched-jdt-ui-compatibility/
+          retention-days: 14
+          if-no-files-found: warn
+
+  p2-repository:
+    needs: [ build, target-compatibility ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+      - uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1
+        with:
+          maven-version: 3.9.14
+      - name: Download verified replacement bundle
+        uses: actions/download-artifact@v7
+        with:
+          name: patched-jdt-ui-${{ github.sha }}
+          path: ${{ runner.temp }}/patched-jdt-ui
+      - name: Download stock-target compatibility evidence
+        uses: actions/download-artifact@v7
+        with:
+          name: patched-jdt-ui-target-compatibility-${{ github.sha }}
+          path: ${{ runner.temp }}/patched-jdt-ui-compatibility
+      - name: Publish and verify exact-version p2 repository
+        shell: bash
+        run: |
+          bash .github/scripts/publish_patched_jdt_ui_repository.sh \
+            "$RUNNER_TEMP/patched-jdt-ui" \
+            "$RUNNER_TEMP/patched-jdt-ui-compatibility" \
+            "$RUNNER_TEMP/patched-jdt-ui-p2"
+      - name: Publish p2 repository summary
+        if: always()
+        shell: bash
+        run: |
+          report="$RUNNER_TEMP/patched-jdt-ui-p2/evidence/repository-verification.md"
+          if [[ -s "$report" ]]; then
+            cat "$report" >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - name: Upload verified p2 repository
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: patched-jdt-ui-p2-${{ github.sha }}
+          path: ${{ runner.temp }}/patched-jdt-ui-p2/
+          retention-days: 14
+          if-no-files-found: warn
+
+  patched-product-installation:
+    needs: p2-repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 150
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+      - uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1
+        with:
+          maven-version: 3.9.14
+      - name: Install Linux desktop runtime
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            xvfb xauth libgtk-3-0 libxext6 libxrender1 libxtst6 libxi6 \
+            libxrandr2 libxfixes3 libasound2t64 libnss3 libgbm1
+      - name: Download verified patch repository
+        uses: actions/download-artifact@v7
+        with:
+          name: patched-jdt-ui-p2-${{ github.sha }}
+          path: ${{ runner.temp }}/patched-jdt-ui-p2
+      - name: Build the independent Eclipse 2026-06 stock product
+        run: >-
+          xvfb-run --auto-servernum mvn
+          -Pproduct
+          --batch-mode
+          -Dtycho.localArtifacts=ignore
+          clean verify
+      - name: Install exact patch feature and start the product
+        shell: bash
+        run: |
+          bash .github/scripts/smoke_test_patched_jdt_ui_repository.sh \
+            "$RUNNER_TEMP/patched-jdt-ui-p2" \
+            "$RUNNER_TEMP/patched-jdt-ui-installation"
+      - name: Execute real scope-expansion preview, apply, and undo probe
+        shell: bash
+        run: |
+          bash .github/scripts/run_patched_jdt_ui_scope_probe.sh \
+            "$RUNNER_TEMP/patched-jdt-ui-p2" \
+            "$RUNNER_TEMP/patched-jdt-ui-installation" \
+            "$RUNNER_TEMP/patched-jdt-ui-runtime-probe"
+      - name: Publish installation and runtime summaries
+        if: always()
+        shell: bash
+        run: |
+          for report in \
+            "$RUNNER_TEMP/patched-jdt-ui-installation/installation-verification.md" \
+            "$RUNNER_TEMP/patched-jdt-ui-runtime-probe/runtime-verification.md"; do
+            if [[ -s "$report" ]]; then
+              cat "$report" >> "$GITHUB_STEP_SUMMARY"
+              echo >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+      - name: Upload patched-product installation evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: patched-jdt-ui-installation-${{ github.sha }}
+          path: ${{ runner.temp }}/patched-jdt-ui-installation/
+          retention-days: 14
+          if-no-files-found: warn
+      - name: Upload patched JDT UI runtime behavior evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: patched-jdt-ui-runtime-probe-${{ github.sha }}
+          path: ${{ runner.temp }}/patched-jdt-ui-runtime-probe/
           retention-days: 14
           if-no-files-found: warn

--- a/docs/patched-jdt-ui-delivery.md
+++ b/docs/patched-jdt-ui-delivery.md
@@ -11,11 +11,11 @@ The replacement lane is isolated from ordinary `main` validation. It runs for pu
 The immutable coordinates are stored in `.github/patched-jdt-ui.env`:
 
 - repository: `https://github.com/carstenartur/eclipse.jdt.ui.git`;
-- commit: `450bfd46089c99608dd60203e1257e1c329ad2c5`;
+- commit: `f5270e1eb9e35be435ac4ff7d4e942ac3c1dc219`;
 - bundle: `org.eclipse.jdt.ui`;
 - expected base version: `3.39.0`.
 
-The commit is the merged result of `carstenartur/eclipse.jdt.ui#95`. Its fork synchronization manifest preserves both the modified `CleanUpRefactoring.java` source and `MultiFileCleanUpScopeExpansionTest.java`.
+The commit is the synchronized fork master for the Eclipse 2026-06 / Platform 4.40 development line. It retains the reviewed fixed-point cleanup scope expansion and the upstream PDE test. The fork synchronization manifest preserves both the modified `CleanUpRefactoring.java` source and `MultiFileCleanUpScopeExpansionTest.java` while later JDT UI changes are synchronized.
 
 ## Local rebuild
 

--- a/docs/patched-jdt-ui-delivery.md
+++ b/docs/patched-jdt-ui-delivery.md
@@ -2,9 +2,9 @@
 
 ## Purpose
 
-The normal Sandbox target and cleanup test reactor use the stock Eclipse JDT UI bundle. Automatic multi-file cleanup scope expansion is an optional product capability that requires a reviewed replacement of the singleton `org.eclipse.jdt.ui` bundle.
+The normal Sandbox target and default Maven build use the stock Eclipse 2026-06 JDT UI bundle. Automatic multi-file cleanup scope expansion is an optional product capability that requires a reviewed replacement of the singleton `org.eclipse.jdt.ui` bundle.
 
-This document covers the reproducible source-bundle and stock-target compatibility stages. Minimal p2 publication, exact-IU product resolution, product startup and stock-versus-patched runtime smoke tests remain tracked in #1209 and #1215.
+The replacement lane is isolated from ordinary `main` validation. It runs for pull requests that change the delivery implementation and by manual dispatch after merge. The stock product remains the supported default.
 
 ## Pinned source
 
@@ -38,7 +38,7 @@ The script:
 
 Generated JARs are not committed. CI publishes the verified output as a short-lived artifact.
 
-## Stock-target compatibility gate
+## Eclipse 2026-06 compatibility gate
 
 After building the bundle, CI runs:
 
@@ -48,21 +48,80 @@ bash .github/scripts/compare_patched_jdt_ui_with_target.sh \
   target/patched-jdt-ui-compatibility
 ```
 
-The comparison removes only cached `org.eclipse.jdt.ui` artifacts, resolves `sandbox_target/eclipse.target` through the normal Tycho build and identifies the single stock JDT UI bundle selected from Eclipse 2025-12. It then records:
+The comparison removes only cached `org.eclipse.jdt.ui` artifacts, resolves `sandbox_target/eclipse.target` through the normal Tycho build and identifies the single stock JDT UI bundle selected from Eclipse 2026-06. It records:
 
 - the exact stock and patched OSGi versions and SHA-256 checksums;
 - whether the patched version is strictly newer, as required for singleton replacement;
 - normalized differences in `Bundle-RequiredExecutionEnvironment`, `Require-Bundle` and `Import-Package`;
 - whether every stock `Export-Package` remains present in the patched bundle.
 
-Results are written to `compatibility.json` and `compatibility.md` and uploaded as a workflow artifact. A blocked result is emitted as an Actions warning and prevents the next p2-publication stage from being introduced. The source-bundle job may still remain green because it proves a different property: reproducibility of the pinned source build.
+A manifest or export-surface difference fails closed. The p2 repository is not produced unless `compatibleForReplacement` is true.
 
-The comparison is deliberately strict. A manifest difference is treated as unresolved compatibility work rather than assumed safe. Once the report passes, the next stage can publish a minimal p2 repository and prove exact IU selection in a patched product.
+## Exact-version p2 repository
+
+```bash
+bash .github/scripts/publish_patched_jdt_ui_repository.sh \
+  target/patched-jdt-ui \
+  target/patched-jdt-ui-compatibility \
+  target/patched-jdt-ui-p2
+```
+
+The publisher creates a minimal carrier feature whose plug-in entry and p2 requirement both pin the exact qualified patched bundle version. Repository verification requires:
+
+- exactly one patched bundle IU;
+- exactly one feature-group and feature-jar IU;
+- exact requirements from the feature group to its feature jar and replacement bundle;
+- only the expected bundle and feature artifacts;
+- file-size and checksum metadata for every artifact;
+- byte-for-byte agreement with the source-build SHA-256 provenance.
+
+## Stock-to-patched installation
+
+Build the ordinary Eclipse 2026-06 product first:
+
+```bash
+mvn -Pproduct --batch-mode -Dtycho.localArtifacts=ignore clean verify
+```
+
+Then install and verify the optional repository:
+
+```bash
+bash .github/scripts/smoke_test_patched_jdt_ui_repository.sh \
+  target/patched-jdt-ui-p2 \
+  target/patched-jdt-ui-installation
+```
+
+The smoke test records the stock selection, installs the exact feature with the product's own p2 director and requires:
+
+- one active `org.eclipse.jdt.ui` simpleconfigurator entry;
+- the exact patched version and SHA-256;
+- the carrier feature as an installed profile root;
+- successful product startup through the p2 director.
+
+## Runtime behavior proof
+
+The repository-owned Equinox application under `.github/probes/patched-jdt-ui/` is compiled against the plug-ins of the materialized patched product and published through a temporary one-bundle p2 repository. It is then installed into that same profile.
+
+```bash
+bash .github/scripts/run_patched_jdt_ui_scope_probe.sh \
+  target/patched-jdt-ui-p2 \
+  target/patched-jdt-ui-installation \
+  target/patched-jdt-ui-runtime-probe
+```
+
+The probe creates two Java compilation units, explicitly selects only the first and exposes `expandCleanUpScope(...)` to return the second. Success requires:
+
+- repeated scope expansion to a fixed point;
+- both compilation units in preconditions;
+- two text-change previews;
+- application of one composite cleanup change to both files;
+- a non-null undo change;
+- byte-for-byte restoration of both original UTF-8 files.
+
+The bounded JSON and Markdown evidence includes exact target, planning, preview, apply and restore counts. The temporary workspace project is deleted after success or failure.
 
 ## Trust boundary
 
-Passing the source-bundle stage proves the source revision, patch paths, singleton identity, compiled capability marker and artifact checksum. Passing the compatibility stage additionally proves that the resolved 2025-12 stock bundle can be replaced without changing its declared execution environment, imports, required bundles or exported package surface under the current strict policy.
+Passing the complete lane proves the pinned source revision, singleton identity, strict compatibility with the Eclipse 2026-06 stock target, exact p2 publication, installation into the stock product and real cleanup lifecycle behavior on Linux GTK x86_64 with Java 21.
 
-Neither stage proves p2 installation, product startup, runtime cleanup expansion, apply/undo behavior or rollback. Those checks belong to the p2/product stages before an installation channel is published.
-
-The stock target remains the default and has no dependency on this optional bundle artifact.
+It does not add the replacement to the normal Sandbox update site and does not claim runtime execution on Windows or macOS. The stock target remains independent of this optional artifact.


### PR DESCRIPTION
## Summary

Ports the complete #1209 delivery proof onto the current Eclipse 2026-06 / Platform 4.40 baseline without making the optional replacement part of the default build.

## Reproducible replacement

- builds the exact pinned `carstenartur/eclipse.jdt.ui` commit;
- verifies the productive scope-expansion source, upstream PDE test, singleton bundle identity and compiled marker;
- records exact source and bundle SHA-256 provenance;
- compares the patched manifest and exported-package surface with the resolved Eclipse 2026-06 stock target.

## Exact p2 delivery

- publishes a minimal carrier feature and replacement bundle repository;
- pins the exact qualified bundle version in both feature metadata and p2 requirements;
- verifies IU identities, expected artifact keys, file sizes, checksums and source provenance.

## Product and behavior proof

- builds the ordinary current `-Pproduct` Eclipse 2026-06 product;
- records the stock `org.eclipse.jdt.ui` selection;
- installs the exact patch feature with the materialized product's p2 director;
- requires one active patched singleton entry, exact bytes and an installed feature root;
- compiles and installs a repository-owned Equinox runtime probe against the patched product;
- proves fixed-point scope expansion, two-unit preconditions and preview, atomic apply, non-null undo and byte-for-byte restoration.

## Default-build boundary

The workflow runs for this delivery PR and by manual dispatch. It has no push-to-`main` trigger and does not reintroduce the optional patch lane as a default-build check. The stock target and normal Sandbox update site remain unchanged.

Closes #1209.