### PR TITLE
Expand coordinated JUnit cleanup scope for suite members

### DIFF
--- a/docs/junit-coordinated-migration.md
+++ b/docs/junit-coordinated-migration.md
@@ -1,0 +1,31 @@
+# Coordinated JUnit migration policy
+
+Sandbox separates local annotation/API rewrites from transformations that need a closed source scope.
+
+## Implemented coordinated components
+
+### ExternalResource rules
+
+Named `ExternalResource` implementations and proven `@Rule`/`@ClassRule` consumers are planned together. The immutable plan owns the generated Jupiter extension, field rewrite and lifecycle changes. An incomplete source scope is rejected rather than partially rewritten.
+
+### JUnit 4 suites
+
+When the RunWith migration is enabled and a selected source unit contains `@Suite.SuiteClasses`, the source test classes referenced by the annotation are added to the same fixed-point cleanup scope.
+
+Supported forms:
+
+```java
+@Suite.SuiteClasses({ FirstTest.class, SecondTest.class })
+```
+
+```java
+@Suite.SuiteClasses(OnlyTest.class)
+```
+
+Only source compilation units are added directly. Ordinary `@RunWith` annotations without `SuiteClasses` do not broaden the scope. If a syntactically recognized suite target cannot be resolved, the existing conservative source-root policy is used instead of assuming a partial suite closure.
+
+## Deliberate boundaries
+
+The Java cleanup does not silently remove JUnit 4 dependencies from Maven, OSGi manifests or other build resources. Dependency cleanup is a separate compatibility-managed/manual stage because mixed engines and non-Java resources require explicit project policy.
+
+Parameterized constructor migration, external method-source providers, shared assertion-helper signature changes and runners with custom runtime semantics also require their own immutable plan components. They must not be enabled merely by broadening the suite scope.

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnitScopeCandidateDetector.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnitScopeCandidateDetector.java
@@ -13,6 +13,7 @@ package org.sandbox.jdt.internal.corext.fix.multifile;
 import static org.sandbox.jdt.internal.corext.fix.helper.lib.JUnitConstants.ORG_JUNIT_CLASS_RULE;
 import static org.sandbox.jdt.internal.corext.fix.helper.lib.JUnitConstants.ORG_JUNIT_RULE;
 import static org.sandbox.jdt.internal.corext.fix.helper.lib.JUnitConstants.ORG_JUNIT_RULES_EXTERNAL_RESOURCE;
+import static org.sandbox.jdt.internal.corext.fix.helper.lib.JUnitConstants.ORG_JUNIT_SUITE_SUITECLASSES;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -26,24 +27,38 @@ import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.dom.ASTParser;
 import org.eclipse.jdt.core.dom.ASTRequestor;
 import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.Annotation;
+import org.eclipse.jdt.core.dom.ArrayInitializer;
 import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.FieldDeclaration;
 import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.MemberValuePair;
+import org.eclipse.jdt.core.dom.NormalAnnotation;
+import org.eclipse.jdt.core.dom.SingleMemberAnnotation;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.core.dom.TypeLiteral;
 import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
 import org.eclipse.jdt.internal.corext.refactoring.util.RefactoringASTParser;
 
-/** Lightweight selected-scope detector for coordinated JUnit resource migration. */
+/** Lightweight selected-scope detector for coordinated JUnit migration. */
 public final class JUnitScopeCandidateDetector {
 
-	/** Binding-derived resource types whose references define the required closure. */
-	public record SearchSeeds(boolean candidateFound, boolean complete, List<IJavaElement> elements) {
+	/** Binding-derived elements and direct source dependencies defining the required closure. */
+	public record SearchSeeds(boolean candidateFound, boolean complete, List<IJavaElement> elements,
+			List<ICompilationUnit> directCompilationUnits) {
 		public SearchSeeds {
 			elements= List.copyOf(elements);
+			directCompilationUnits= List.copyOf(directCompilationUnits);
+		}
+
+		/** Compatibility constructor for the original ExternalResource-only detector. */
+		public SearchSeeds(boolean candidateFound, boolean complete, List<IJavaElement> elements) {
+			this(candidateFound, complete, elements, List.of());
 		}
 	}
 
@@ -51,21 +66,28 @@ public final class JUnitScopeCandidateDetector {
 		// utility class
 	}
 
-	/** Returns whether the selection contains either side of a resource migration. */
+	/** Returns whether the selection contains either side of an ExternalResource migration. */
 	public static boolean containsCandidate(IJavaProject project, Collection<ICompilationUnit> currentScope,
 			IProgressMonitor monitor) {
 		return findSearchSeeds(project, currentScope, monitor).candidateFound();
 	}
 
-	/**
-	 * Finds source resource types referenced by selected declarations or Rule fields.
-	 * Syntactically recognizable candidates with missing bindings are marked
-	 * incomplete so callers preserve the existing complete-policy fallback.
-	 */
+	/** Finds ExternalResource migration seeds using the historical detector contract. */
 	public static SearchSeeds findSearchSeeds(IJavaProject project, Collection<ICompilationUnit> currentScope,
 			IProgressMonitor monitor) {
-		if (project == null || currentScope == null || currentScope.isEmpty()) {
-			return new SearchSeeds(false, true, List.of());
+		return findSearchSeeds(project, currentScope, true, false, monitor);
+	}
+
+	/**
+	 * Finds source dependencies required by the enabled coordinated JUnit components.
+	 * ExternalResource declarations use reverse-reference search seeds; JUnit 4 suite
+	 * annotations add their directly referenced source test classes.
+	 */
+	public static SearchSeeds findSearchSeeds(IJavaProject project, Collection<ICompilationUnit> currentScope,
+			boolean migrateExternalResourceRules, boolean migrateSuites, IProgressMonitor monitor) {
+		if (project == null || currentScope == null || currentScope.isEmpty()
+				|| !migrateExternalResourceRules && !migrateSuites) {
+			return new SearchSeeds(false, true, List.of(), List.of());
 		}
 		checkCanceled(monitor);
 		Set<ICompilationUnit> units= new LinkedHashSet<>();
@@ -75,12 +97,13 @@ public final class JUnitScopeCandidateDetector {
 			}
 		}
 		if (units.isEmpty()) {
-			return new SearchSeeds(false, true, List.of());
+			return new SearchSeeds(false, true, List.of(), List.of());
 		}
 
 		boolean[] candidateFound= { false };
 		boolean[] complete= { true };
 		Set<IJavaElement> elements= new LinkedHashSet<>();
+		Set<ICompilationUnit> directUnits= new LinkedHashSet<>();
 		ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
 		parser.setProject(project);
 		parser.setResolveBindings(true);
@@ -93,6 +116,9 @@ public final class JUnitScopeCandidateDetector {
 				ast.accept(new ASTVisitor() {
 					@Override
 					public boolean visit(TypeDeclaration node) {
+						if (!migrateExternalResourceRules) {
+							return true;
+						}
 						ITypeBinding binding= node.resolveBinding();
 						ITypeBinding superclass= binding == null ? null : binding.getSuperclass();
 						if (superclass != null && ORG_JUNIT_RULES_EXTERNAL_RESOURCE.equals(
@@ -111,6 +137,9 @@ public final class JUnitScopeCandidateDetector {
 
 					@Override
 					public boolean visit(FieldDeclaration node) {
+						if (!migrateExternalResourceRules) {
+							return true;
+						}
 						boolean ruleField= false;
 						boolean unresolvedRuleAnnotation= false;
 						for (Object modifier : node.modifiers()) {
@@ -138,11 +167,61 @@ public final class JUnitScopeCandidateDetector {
 						complete[0]&= addJavaElement(fieldType, elements);
 						return true;
 					}
+
+					@Override
+					public boolean visit(SingleMemberAnnotation node) {
+						if (migrateSuites && isSuiteClasses(node)) {
+							candidateFound[0]= true;
+							complete[0]&= collectSuiteTargets(node.getValue(), directUnits);
+						}
+						return true;
+					}
+
+					@Override
+					public boolean visit(NormalAnnotation node) {
+						if (!migrateSuites || !isSuiteClasses(node)) {
+							return true;
+						}
+						candidateFound[0]= true;
+						boolean valueFound= false;
+						for (Object valueObject : node.values()) {
+							MemberValuePair pair= (MemberValuePair) valueObject;
+							if ("value".equals(pair.getName().getIdentifier())) { //$NON-NLS-1$
+								valueFound= true;
+								complete[0]&= collectSuiteTargets(pair.getValue(), directUnits);
+							}
+						}
+						complete[0]&= valueFound;
+						return true;
+					}
 				});
 			}
 		}, monitor);
 		checkCanceled(monitor);
-		return new SearchSeeds(candidateFound[0], complete[0], new ArrayList<>(elements));
+		return new SearchSeeds(candidateFound[0], complete[0], new ArrayList<>(elements),
+				new ArrayList<>(directUnits));
+	}
+
+	private static boolean isSuiteClasses(Annotation annotation) {
+		ITypeBinding binding= annotation.resolveTypeBinding();
+		if (binding != null) {
+			return ORG_JUNIT_SUITE_SUITECLASSES.equals(binding.getQualifiedName());
+		}
+		return "SuiteClasses".equals(simpleName(annotation.getTypeName().getFullyQualifiedName())); //$NON-NLS-1$
+	}
+
+	private static boolean collectSuiteTargets(Expression expression, Set<ICompilationUnit> units) {
+		if (expression instanceof TypeLiteral literal) {
+			return addCompilationUnit(literal.getType().resolveBinding(), units);
+		}
+		if (expression instanceof ArrayInitializer initializer) {
+			boolean complete= true;
+			for (Object expressionObject : initializer.expressions()) {
+				complete&= expressionObject instanceof Expression nested && collectSuiteTargets(nested, units);
+			}
+			return complete;
+		}
+		return false;
 	}
 
 	private static boolean isSyntacticRuleName(String name) {
@@ -161,6 +240,20 @@ public final class JUnitScopeCandidateDetector {
 			return false;
 		}
 		elements.add(element);
+		return true;
+	}
+
+	private static boolean addCompilationUnit(ITypeBinding binding, Set<ICompilationUnit> units) {
+		IJavaElement element= binding == null ? null : binding.getErasure().getJavaElement();
+		if (element == null || !element.exists()) {
+			return false;
+		}
+		if (element instanceof IType type) {
+			ICompilationUnit compilationUnit= type.getCompilationUnit();
+			if (compilationUnit != null && compilationUnit.exists()) {
+				units.add(compilationUnit.getPrimary());
+			}
+		}
 		return true;
 	}
 

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/ui/fix/JUnitCleanUpCore.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/ui/fix/JUnitCleanUpCore.java
@@ -123,7 +123,10 @@ public class JUnitCleanUpCore extends AbstractPlannedMultiFileCleanUp<JUnitMigra
 	@Override
 	protected Collection<ICompilationUnit> discoverAdditionalCompilationUnits(IJavaProject project,
 			Collection<ICompilationUnit> currentScope, IProgressMonitor monitor) throws CoreException {
-		if (!computeFixSet().contains(JUnitCleanUpFixCore.RULEEXTERNALRESOURCE)) {
+		EnumSet<JUnitCleanUpFixCore> fixes= computeFixSet();
+		boolean migrateExternalResourceRules= fixes.contains(JUnitCleanUpFixCore.RULEEXTERNALRESOURCE);
+		boolean migrateSuites= fixes.contains(JUnitCleanUpFixCore.RUNWITH);
+		if (!migrateExternalResourceRules && !migrateSuites) {
 			return List.of();
 		}
 		if (monitor != null && monitor.isCanceled()) {
@@ -137,8 +140,8 @@ public class JUnitCleanUpCore extends AbstractPlannedMultiFileCleanUp<JUnitMigra
 			return List.of();
 		}
 		rejectedScopes.remove(project);
-		JUnitScopeCandidateDetector.SearchSeeds seeds=
-				JUnitScopeCandidateDetector.findSearchSeeds(project, currentScope, monitor);
+		JUnitScopeCandidateDetector.SearchSeeds seeds= JUnitScopeCandidateDetector.findSearchSeeds(project,
+				currentScope, migrateExternalResourceRules, migrateSuites, monitor);
 		if (!seeds.candidateFound()) {
 			clearScopeDecision(project);
 			return List.of();
@@ -150,14 +153,18 @@ public class JUnitCleanUpCore extends AbstractPlannedMultiFileCleanUp<JUnitMigra
 		if (!seeds.complete()) {
 			requiredUnits= allowedUnits;
 		} else {
-			RelatedCompilationUnitSearch.Result related= RelatedCompilationUnitSearch.findReferences(project,
-					seeds.elements(), currentScope, allowedUnits, monitor);
-			if (!related.complete()) {
-				clearScopeDecision(project);
-				rejectedScopes.add(project);
-				return List.of();
+			Set<ICompilationUnit> required= new LinkedHashSet<>(seeds.directCompilationUnits());
+			if (!seeds.elements().isEmpty()) {
+				RelatedCompilationUnitSearch.Result related= RelatedCompilationUnitSearch.findReferences(project,
+						seeds.elements(), currentScope, allowedUnits, monitor);
+				if (!related.complete()) {
+					clearScopeDecision(project);
+					rejectedScopes.add(project);
+					return List.of();
+				}
+				required.addAll(related.compilationUnits());
 			}
-			requiredUnits= related.compilationUnits();
+			requiredUnits= new ArrayList<>(required);
 		}
 		return registerRequiredScope(project, currentHandles, requiredUnits);
 	}

--- a/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/JUnitSuiteScopeExpansionTest.java
+++ b/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/JUnitSuiteScopeExpansionTest.java
@@ -1,0 +1,141 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.quickfix.Java8;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.junit.JUnitCore;
+import org.eclipse.jdt.ui.cleanup.CleanUpOptions;
+
+import org.sandbox.jdt.internal.corext.fix2.MYCleanUpConstants;
+import org.sandbox.jdt.internal.ui.fix.JUnitCleanUpCore;
+import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
+import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava17;
+
+/** Scope-expansion tests for JUnit 4 suite migrations. */
+public class JUnitSuiteScopeExpansionTest {
+
+	@RegisterExtension
+	AbstractEclipseJava context= new EclipseJava17();
+
+	private IPackageFragmentRoot root;
+
+	@BeforeEach
+	public void setup() throws CoreException {
+		root= context.createClasspathForJUnit(JUnitCore.JUNIT4_CONTAINER_PATH);
+	}
+
+	@Test
+	public void selectedSuiteAddsOnlyReferencedSourceTests() throws CoreException {
+		IPackageFragment pack= root.createPackageFragment("test", true, null); //$NON-NLS-1$
+		ICompilationUnit first= testClass(pack, "FirstTest.java"); //$NON-NLS-1$
+		ICompilationUnit second= testClass(pack, "SecondTest.java"); //$NON-NLS-1$
+		ICompilationUnit unrelated= testClass(pack, "UnrelatedTest.java"); //$NON-NLS-1$
+		ICompilationUnit suite= pack.createCompilationUnit("AllTests.java", //$NON-NLS-1$
+				"""
+				package test;
+
+				import org.junit.runner.RunWith;
+				import org.junit.runners.Suite;
+
+				@RunWith(Suite.class)
+				@Suite.SuiteClasses({ FirstTest.class, SecondTest.class })
+				public class AllTests {
+				}
+				""", false, null);
+
+		JUnitCleanUpCore cleanup= suiteCleanup();
+		Collection<ICompilationUnit> expanded= cleanup.expandCleanUpScope(suite.getJavaProject(),
+				List.of(suite), null);
+
+		assertEquals(Set.of(first.getHandleIdentifier(), second.getHandleIdentifier()), handles(expanded));
+		assertTrue(!expanded.contains(unrelated));
+		assertTrue(cleanup.expandCleanUpScope(suite.getJavaProject(), List.of(suite, first, second), null).isEmpty(),
+				"Scope expansion must reach a fixed point once all suite members are present");
+	}
+
+	@Test
+	public void singleSuiteClassLiteralAddsItsSourceTest() throws CoreException {
+		IPackageFragment pack= root.createPackageFragment("test", true, null); //$NON-NLS-1$
+		ICompilationUnit referenced= testClass(pack, "OnlyTest.java"); //$NON-NLS-1$
+		ICompilationUnit suite= pack.createCompilationUnit("OnlySuite.java", //$NON-NLS-1$
+				"""
+				package test;
+
+				import org.junit.runner.RunWith;
+				import org.junit.runners.Suite;
+
+				@RunWith(Suite.class)
+				@Suite.SuiteClasses(OnlyTest.class)
+				public class OnlySuite {
+				}
+				""", false, null);
+
+		Collection<ICompilationUnit> expanded= suiteCleanup().expandCleanUpScope(suite.getJavaProject(),
+				List.of(suite), null);
+
+		assertEquals(Set.of(referenced.getHandleIdentifier()), handles(expanded));
+	}
+
+	@Test
+	public void runWithWithoutSuiteClassesDoesNotBroadenScope() throws CoreException {
+		IPackageFragment pack= root.createPackageFragment("test", true, null); //$NON-NLS-1$
+		testClass(pack, "UnrelatedTest.java"); //$NON-NLS-1$
+		ICompilationUnit runner= pack.createCompilationUnit("CustomRunnerTest.java", //$NON-NLS-1$
+				"""
+				package test;
+
+				import org.junit.runner.RunWith;
+				import org.junit.runners.JUnit4;
+
+				@RunWith(JUnit4.class)
+				public class CustomRunnerTest {
+				}
+				""", false, null);
+
+		Collection<ICompilationUnit> expanded= suiteCleanup().expandCleanUpScope(runner.getJavaProject(),
+				List.of(runner), null);
+
+		assertTrue(expanded.isEmpty(), "An ordinary runner annotation has no forward source closure");
+	}
+
+	private static JUnitCleanUpCore suiteCleanup() {
+		return new JUnitCleanUpCore(Map.of(
+				MYCleanUpConstants.JUNIT_CLEANUP, CleanUpOptions.TRUE,
+				MYCleanUpConstants.JUNIT_CLEANUP_4_RUNWITH, CleanUpOptions.TRUE));
+	}
+
+	private static ICompilationUnit testClass(IPackageFragment pack, String name) throws CoreException {
+		String typeName= name.substring(0, name.length() - ".java".length()); //$NON-NLS-1$
+		return pack.createCompilationUnit(name,
+				"package test;%n%npublic class %s {%n}%n".formatted(typeName), false, null); //$NON-NLS-1$
+	}
+
+	private static Set<String> handles(Collection<ICompilationUnit> units) {
+		return units.stream().map(ICompilationUnit::getHandleIdentifier).collect(Collectors.toSet());
+	}
+}


### PR DESCRIPTION
## Summary

Implements the first bounded Suites and Runners stage from #1217: a selected JUnit 4 suite now adds the source test classes referenced by `@Suite.SuiteClasses` to the same fixed-point cleanup scope.

## Behavior

- supports array and single-class-literal `SuiteClasses` values;
- uses resolved type bindings and adds only source compilation units;
- preserves the existing reverse-reference closure for `ExternalResource` migrations;
- unions direct suite dependencies with resource-reference dependencies when both components are enabled;
- does not broaden ordinary `@RunWith` annotations without `SuiteClasses`;
- retains the conservative complete-policy fallback when a syntactically recognized suite target cannot be resolved;
- reaches a fixed point after the referenced suite members have been added.

## Verification

Tests cover exact two-member expansion without unrelated tests, single-member syntax, ordinary runner non-expansion, and the second fixed-point invocation. The coordinated-migration document records the implemented ExternalResource and suite contracts and keeps build dependency removal, parameterized providers and custom runner semantics outside this Java-only scope.

This PR deliberately does not remove JUnit 4 dependencies or rewrite build resources. Those remain separate compatibility-managed/manual stages in #1217.

Refs #1217.