### PR TITLE
Coordinate inherited JUnit lifecycle migrations

### DIFF
--- a/docs/junit-lifecycle-scope.md
+++ b/docs/junit-lifecycle-scope.md
@@ -1,0 +1,35 @@
+# Coordinated JUnit lifecycle migration
+
+JUnit 4 lifecycle annotations can participate in inherited contracts. Migrating only the currently selected compilation unit can therefore create a mixed JUnit 4/Jupiter hierarchy even when the local annotation replacement itself is syntactically valid.
+
+## Coordinated options
+
+The following migrations are classified as `PROJECT_CLOSED`:
+
+- `@Before` to `@BeforeEach`;
+- `@After` to `@AfterEach`;
+- `@BeforeClass` to `@BeforeAll`;
+- `@AfterClass` to `@AfterAll`.
+
+They are not offered as ordinary save actions. A cleanup run may apply them only after the source hierarchy has been closed and previewed.
+
+## Scope closure
+
+`JUnitLifecycleScopeCandidateDetector` starts from the selected source types and follows:
+
+- source superclasses;
+- implemented source interfaces;
+- lifecycle annotations declared directly on the selected type;
+- lifecycle annotations inherited from a source superclass or interface default method.
+
+Binding-derived hierarchy types are passed to the workspace reference search. This adds source subclasses and implementors within the allowed test/support roots. Scope expansion repeats until it reaches a fixed point.
+
+## Fail-closed behavior
+
+Lifecycle plugins are removed from the local rewrite set unless the cleanup instance has proved a complete hierarchy scope. This prevents a stock/unpatched cleanup orchestrator, a manually restricted selection or an unresolved hierarchy from producing a partial migration.
+
+Syntactically recognizable lifecycle annotations with missing or recovered bindings request the conservative allowed-source fallback. References outside the project or permitted source-root policy reject automatic migration.
+
+## Current boundary
+
+This stage coordinates lifecycle annotations only. It does not yet remove JUnit 4 build dependencies, migrate arbitrary custom runners, infer parameterized providers or rewrite non-Java build resources. Those remain separate stages of issue #1217.

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnitLifecycleScopeCandidateDetector.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnitLifecycleScopeCandidateDetector.java
@@ -50,6 +50,9 @@ public final class JUnitLifecycleScopeCandidateDetector {
 	private static final Set<String> LIFECYCLE_SIMPLE_NAMES= Set.of(
 			"Before", "After", "BeforeClass", "AfterClass"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 
+	private record LifecycleSyntax(boolean candidateFound, boolean complete) {
+	}
+
 	/** Types whose declarations and references define the required hierarchy closure. */
 	public record SearchSeeds(boolean candidateFound, boolean complete, List<IJavaElement> elements) {
 		public SearchSeeds {
@@ -94,12 +97,13 @@ public final class JUnitLifecycleScopeCandidateDetector {
 					public boolean visit(TypeDeclaration node) {
 						checkCanceled(monitor);
 						ITypeBinding binding= node.resolveBinding();
-						boolean syntacticLifecycle= hasSyntacticLifecycle(node);
+						LifecycleSyntax syntax= inspectLifecycleSyntax(node);
 						boolean bindingLifecycle= hierarchyDeclaresLifecycle(binding, new LinkedHashSet<>());
-						if (!syntacticLifecycle && !bindingLifecycle) {
+						if (!syntax.candidateFound() && !bindingLifecycle) {
 							return true;
 						}
 						candidateFound[0]= true;
+						complete[0]&= syntax.complete();
 						if (binding == null) {
 							complete[0]= false;
 							return true;
@@ -114,7 +118,9 @@ public final class JUnitLifecycleScopeCandidateDetector {
 		return new SearchSeeds(candidateFound[0], complete[0], new ArrayList<>(elements));
 	}
 
-	private static boolean hasSyntacticLifecycle(TypeDeclaration type) {
+	private static LifecycleSyntax inspectLifecycleSyntax(TypeDeclaration type) {
+		boolean candidate= false;
+		boolean complete= true;
 		for (MethodDeclaration method : type.getMethods()) {
 			for (Object modifier : method.modifiers()) {
 				if (!(modifier instanceof Annotation annotation)) {
@@ -122,15 +128,17 @@ public final class JUnitLifecycleScopeCandidateDetector {
 				}
 				ITypeBinding annotationBinding= annotation.resolveTypeBinding();
 				if (annotationBinding != null && LIFECYCLE_ANNOTATIONS.contains(annotationBinding.getQualifiedName())) {
-					return true;
+					candidate= true;
+					continue;
 				}
 				String name= annotation.getTypeName().getFullyQualifiedName();
 				if (LIFECYCLE_SIMPLE_NAMES.contains(simpleName(name))) {
-					return true;
+					candidate= true;
+					complete&= annotationBinding != null;
 				}
 			}
 		}
-		return false;
+		return new LifecycleSyntax(candidate, complete);
 	}
 
 	private static boolean hierarchyDeclaresLifecycle(ITypeBinding binding, Set<String> visited) {

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnitLifecycleScopeCandidateDetector.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnitLifecycleScopeCandidateDetector.java
@@ -104,7 +104,7 @@ public final class JUnitLifecycleScopeCandidateDetector {
 						}
 						candidateFound[0]= true;
 						complete[0]&= syntax.complete();
-						if (binding == null) {
+						if (binding == null || binding.isRecovered()) {
 							complete[0]= false;
 							return true;
 						}
@@ -127,14 +127,15 @@ public final class JUnitLifecycleScopeCandidateDetector {
 					continue;
 				}
 				ITypeBinding annotationBinding= annotation.resolveTypeBinding();
-				if (annotationBinding != null && LIFECYCLE_ANNOTATIONS.contains(annotationBinding.getQualifiedName())) {
+				if (annotationBinding != null && !annotationBinding.isRecovered()
+						&& LIFECYCLE_ANNOTATIONS.contains(annotationBinding.getQualifiedName())) {
 					candidate= true;
 					continue;
 				}
 				String name= annotation.getTypeName().getFullyQualifiedName();
 				if (LIFECYCLE_SIMPLE_NAMES.contains(simpleName(name))) {
 					candidate= true;
-					complete&= annotationBinding != null;
+					complete= false;
 				}
 			}
 		}
@@ -142,7 +143,7 @@ public final class JUnitLifecycleScopeCandidateDetector {
 	}
 
 	private static boolean hierarchyDeclaresLifecycle(ITypeBinding binding, Set<String> visited) {
-		if (binding == null) {
+		if (binding == null || binding.isRecovered()) {
 			return false;
 		}
 		ITypeBinding declaration= binding.getErasure().getTypeDeclaration();
@@ -153,7 +154,7 @@ public final class JUnitLifecycleScopeCandidateDetector {
 		for (IMethodBinding method : declaration.getDeclaredMethods()) {
 			for (IAnnotationBinding annotation : method.getAnnotations()) {
 				ITypeBinding type= annotation.getAnnotationType();
-				if (type != null && LIFECYCLE_ANNOTATIONS.contains(type.getQualifiedName())) {
+				if (type != null && !type.isRecovered() && LIFECYCLE_ANNOTATIONS.contains(type.getQualifiedName())) {
 					return true;
 				}
 			}
@@ -171,8 +172,8 @@ public final class JUnitLifecycleScopeCandidateDetector {
 
 	private static boolean addHierarchyElements(ITypeBinding binding, Set<IJavaElement> elements,
 			Set<String> visited) {
-		if (binding == null) {
-			return true;
+		if (binding == null || binding.isRecovered()) {
+			return false;
 		}
 		ITypeBinding declaration= binding.getErasure().getTypeDeclaration();
 		String key= declaration.getKey();
@@ -193,7 +194,7 @@ public final class JUnitLifecycleScopeCandidateDetector {
 	}
 
 	private static boolean sourceHierarchyType(ITypeBinding binding) {
-		if (binding == null) {
+		if (binding == null || binding.isRecovered()) {
 			return false;
 		}
 		IJavaElement element= binding.getErasure().getJavaElement();

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnitLifecycleScopeCandidateDetector.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnitLifecycleScopeCandidateDetector.java
@@ -1,0 +1,214 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.corext.fix.multifile;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.ASTRequestor;
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.Annotation;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.IAnnotationBinding;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
+import org.eclipse.jdt.internal.corext.refactoring.util.RefactoringASTParser;
+
+/**
+ * Finds source type hierarchies whose JUnit 4 lifecycle annotations must be
+ * migrated as one closed cleanup scope.
+ */
+public final class JUnitLifecycleScopeCandidateDetector {
+
+	private static final Set<String> LIFECYCLE_ANNOTATIONS= Set.of(
+			"org.junit.Before", //$NON-NLS-1$
+			"org.junit.After", //$NON-NLS-1$
+			"org.junit.BeforeClass", //$NON-NLS-1$
+			"org.junit.AfterClass"); //$NON-NLS-1$
+
+	private static final Set<String> LIFECYCLE_SIMPLE_NAMES= Set.of(
+			"Before", "After", "BeforeClass", "AfterClass"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+
+	/** Types whose declarations and references define the required hierarchy closure. */
+	public record SearchSeeds(boolean candidateFound, boolean complete, List<IJavaElement> elements) {
+		public SearchSeeds {
+			elements= List.copyOf(elements);
+		}
+	}
+
+	private JUnitLifecycleScopeCandidateDetector() {
+	}
+
+	/** Finds selected lifecycle types plus all source supertypes declaring lifecycle methods. */
+	public static SearchSeeds findSearchSeeds(IJavaProject project, Collection<ICompilationUnit> currentScope,
+			IProgressMonitor monitor) {
+		if (project == null || currentScope == null || currentScope.isEmpty()) {
+			return new SearchSeeds(false, true, List.of());
+		}
+		checkCanceled(monitor);
+		Set<ICompilationUnit> units= new LinkedHashSet<>();
+		for (ICompilationUnit unit : currentScope) {
+			if (unit != null && unit.exists() && project.equals(unit.getJavaProject())) {
+				units.add(unit.getPrimary());
+			}
+		}
+		if (units.isEmpty()) {
+			return new SearchSeeds(false, true, List.of());
+		}
+
+		boolean[] candidateFound= { false };
+		boolean[] complete= { true };
+		Set<IJavaElement> elements= new LinkedHashSet<>();
+		ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
+		parser.setProject(project);
+		parser.setResolveBindings(true);
+		parser.setBindingsRecovery(IASTSharedValues.SHARED_BINDING_RECOVERY);
+		parser.setStatementsRecovery(IASTSharedValues.SHARED_AST_STATEMENT_RECOVERY);
+		parser.setCompilerOptions(RefactoringASTParser.getCompilerOptions(project));
+		parser.createASTs(units.toArray(ICompilationUnit[]::new), new String[0], new ASTRequestor() {
+			@Override
+			public void acceptAST(ICompilationUnit source, CompilationUnit ast) {
+				ast.accept(new ASTVisitor() {
+					@Override
+					public boolean visit(TypeDeclaration node) {
+						checkCanceled(monitor);
+						ITypeBinding binding= node.resolveBinding();
+						boolean syntacticLifecycle= hasSyntacticLifecycle(node);
+						boolean bindingLifecycle= hierarchyDeclaresLifecycle(binding, new LinkedHashSet<>());
+						if (!syntacticLifecycle && !bindingLifecycle) {
+							return true;
+						}
+						candidateFound[0]= true;
+						if (binding == null) {
+							complete[0]= false;
+							return true;
+						}
+						complete[0]&= addHierarchyElements(binding, elements, new LinkedHashSet<>());
+						return true;
+					}
+				});
+			}
+		}, monitor);
+		checkCanceled(monitor);
+		return new SearchSeeds(candidateFound[0], complete[0], new ArrayList<>(elements));
+	}
+
+	private static boolean hasSyntacticLifecycle(TypeDeclaration type) {
+		for (MethodDeclaration method : type.getMethods()) {
+			for (Object modifier : method.modifiers()) {
+				if (!(modifier instanceof Annotation annotation)) {
+					continue;
+				}
+				ITypeBinding annotationBinding= annotation.resolveTypeBinding();
+				if (annotationBinding != null && LIFECYCLE_ANNOTATIONS.contains(annotationBinding.getQualifiedName())) {
+					return true;
+				}
+				String name= annotation.getTypeName().getFullyQualifiedName();
+				if (LIFECYCLE_SIMPLE_NAMES.contains(simpleName(name))) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	private static boolean hierarchyDeclaresLifecycle(ITypeBinding binding, Set<String> visited) {
+		if (binding == null) {
+			return false;
+		}
+		ITypeBinding declaration= binding.getErasure().getTypeDeclaration();
+		String key= declaration.getKey();
+		if (key == null || !visited.add(key)) {
+			return false;
+		}
+		for (IMethodBinding method : declaration.getDeclaredMethods()) {
+			for (IAnnotationBinding annotation : method.getAnnotations()) {
+				ITypeBinding type= annotation.getAnnotationType();
+				if (type != null && LIFECYCLE_ANNOTATIONS.contains(type.getQualifiedName())) {
+					return true;
+				}
+			}
+		}
+		if (hierarchyDeclaresLifecycle(declaration.getSuperclass(), visited)) {
+			return true;
+		}
+		for (ITypeBinding interfaceBinding : declaration.getInterfaces()) {
+			if (hierarchyDeclaresLifecycle(interfaceBinding, visited)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static boolean addHierarchyElements(ITypeBinding binding, Set<IJavaElement> elements,
+			Set<String> visited) {
+		if (binding == null) {
+			return true;
+		}
+		ITypeBinding declaration= binding.getErasure().getTypeDeclaration();
+		String key= declaration.getKey();
+		if (key == null || !visited.add(key)) {
+			return key != null;
+		}
+		boolean complete= addJavaElement(declaration, elements);
+		ITypeBinding superclass= declaration.getSuperclass();
+		if (superclass != null && sourceHierarchyType(superclass)) {
+			complete&= addHierarchyElements(superclass, elements, visited);
+		}
+		for (ITypeBinding interfaceBinding : declaration.getInterfaces()) {
+			if (sourceHierarchyType(interfaceBinding)) {
+				complete&= addHierarchyElements(interfaceBinding, elements, visited);
+			}
+		}
+		return complete;
+	}
+
+	private static boolean sourceHierarchyType(ITypeBinding binding) {
+		if (binding == null) {
+			return false;
+		}
+		IJavaElement element= binding.getErasure().getJavaElement();
+		return element != null && element.exists() && element.getAncestor(IJavaElement.COMPILATION_UNIT) != null;
+	}
+
+	private static boolean addJavaElement(ITypeBinding binding, Set<IJavaElement> elements) {
+		IJavaElement element= binding == null ? null : binding.getErasure().getJavaElement();
+		if (element == null || !element.exists()) {
+			return false;
+		}
+		elements.add(element);
+		return true;
+	}
+
+	private static String simpleName(String name) {
+		int separator= name.lastIndexOf('.');
+		return separator < 0 ? name : name.substring(separator + 1);
+	}
+
+	private static void checkCanceled(IProgressMonitor monitor) {
+		if (monitor != null && monitor.isCanceled()) {
+			throw new OperationCanceledException();
+		}
+	}
+}

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnitMigrationPlan.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnitMigrationPlan.java
@@ -35,7 +35,14 @@ import org.sandbox.jdt.cleanup.multifile.SelectedCompilationUnitPlan;
 
 /** Immutable project plan for coordinated JUnit migration edits. */
 public record JUnitMigrationPlan(SelectedCompilationUnitPlan selectedScope,
-		List<ExternalResourceRuleMigration> externalResourceRules) {
+		List<ExternalResourceRuleMigration> externalResourceRules,
+		boolean lifecycleScopeClosed) {
+
+	/** Source-compatible constructor for plans without hierarchy-sensitive lifecycle work. */
+	public JUnitMigrationPlan(SelectedCompilationUnitPlan selectedScope,
+			List<ExternalResourceRuleMigration> externalResourceRules) {
+		this(selectedScope, externalResourceRules, true);
+	}
 
 	/** Defensively copies plan data. */
 	public JUnitMigrationPlan {
@@ -50,7 +57,7 @@ public record JUnitMigrationPlan(SelectedCompilationUnitPlan selectedScope,
 
 	/** Returns whether the plan contains coordinated cross-file work. */
 	public boolean hasCoordinatedChanges() {
-		return !externalResourceRules.isEmpty();
+		return !externalResourceRules.isEmpty() || !lifecycleScopeClosed;
 	}
 
 	/**

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/ui/fix/JUnitCleanUpCore.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/ui/fix/JUnitCleanUpCore.java
@@ -34,6 +34,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 
 import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.CompilationUnit;
@@ -50,6 +51,7 @@ import org.sandbox.jdt.cleanup.multifile.MultiFileCleanUpPlanResult;
 import org.sandbox.jdt.cleanup.multifile.RelatedCompilationUnitSearch;
 import org.sandbox.jdt.cleanup.multifile.SourceRootPolicy;
 import org.sandbox.jdt.internal.corext.fix.JUnitCleanUpFixCore;
+import org.sandbox.jdt.internal.corext.fix.multifile.JUnitLifecycleScopeCandidateDetector;
 import org.sandbox.jdt.internal.corext.fix.multifile.JUnitMigrationPlan;
 import org.sandbox.jdt.internal.corext.fix.multifile.JUnitMultiFilePlanner;
 import org.sandbox.jdt.internal.corext.fix.multifile.JUnitScopeCandidateDetector;
@@ -57,6 +59,12 @@ import org.sandbox.jdt.internal.corext.fix2.MYCleanUpConstants;
 
 /** Core cleanup implementation for JUnit 3/4 to Jupiter migration. */
 public class JUnitCleanUpCore extends AbstractPlannedMultiFileCleanUp<JUnitMigrationPlan> {
+
+	private static final EnumSet<JUnitCleanUpFixCore> LIFECYCLE_FIXES= EnumSet.of(
+			JUnitCleanUpFixCore.BEFORE,
+			JUnitCleanUpFixCore.AFTER,
+			JUnitCleanUpFixCore.BEFORECLASS,
+			JUnitCleanUpFixCore.AFTERCLASS);
 
 	private final Map<IJavaProject, Set<String>> pendingExpandedScopes= new HashMap<>();
 	private final Map<IJavaProject, Set<String>> verifiedClosedScopes= new HashMap<>();
@@ -90,10 +98,25 @@ public class JUnitCleanUpCore extends AbstractPlannedMultiFileCleanUp<JUnitMigra
 		}
 		Boolean closedScope= consumeClosedScopeDecision(project, compilationUnits);
 		boolean migrateExternalResourceRules= fixes.contains(JUnitCleanUpFixCore.RULEEXTERNALRESOURCE);
-		return closedScope == null
+		boolean migrateLifecycleContracts= lifecycleFixesEnabled(fixes);
+		MultiFileCleanUpPlanResult<JUnitMigrationPlan> base= closedScope == null
 				? JUnitMultiFilePlanner.create(project, compilationUnits, migrateExternalResourceRules, monitor)
 				: JUnitMultiFilePlanner.create(project, compilationUnits, migrateExternalResourceRules,
 						closedScope.booleanValue(), monitor);
+		if (base.plan() == null) {
+			return base;
+		}
+		boolean lifecycleScopeClosed= !migrateLifecycleContracts
+				|| (closedScope == null
+						? isCompleteProjectSelection(project, compilationUnits)
+						: closedScope.booleanValue());
+		if (migrateLifecycleContracts && !lifecycleScopeClosed) {
+			base.status().addInfo("Inherited JUnit lifecycle migration was skipped because the selected source scope " //$NON-NLS-1$
+					+ "does not contain the complete base-type/subtype hierarchy."); //$NON-NLS-1$
+		}
+		JUnitMigrationPlan plan= new JUnitMigrationPlan(base.plan().selectedScope(),
+				base.plan().externalResourceRules(), lifecycleScopeClosed);
+		return new MultiFileCleanUpPlanResult<>(plan, base.status(), base.metrics(), base.diagnostics());
 	}
 
 	@Override
@@ -118,6 +141,9 @@ public class JUnitCleanUpCore extends AbstractPlannedMultiFileCleanUp<JUnitMigra
 		// producing a partial signature/annotation migration.
 		localFixes.remove(JUnitCleanUpFixCore.RULEEXTERNALRESOURCE);
 		localFixes.remove(JUnitCleanUpFixCore.EXTERNALRESOURCE);
+		if (!plan.lifecycleScopeClosed()) {
+			localFixes.removeAll(LIFECYCLE_FIXES);
+		}
 		plan.addOperationsFor(context.getCompilationUnit(), compilationUnit, operations, sharedNodesProcessed);
 		localFixes.forEach(fix -> fix.findOperations(compilationUnit, operations, sharedNodesProcessed));
 		if (operations.isEmpty()) {
@@ -130,7 +156,10 @@ public class JUnitCleanUpCore extends AbstractPlannedMultiFileCleanUp<JUnitMigra
 	@Override
 	protected Collection<ICompilationUnit> discoverAdditionalCompilationUnits(IJavaProject project,
 			Collection<ICompilationUnit> currentScope, IProgressMonitor monitor) throws CoreException {
-		if (!computeFixSet().contains(JUnitCleanUpFixCore.RULEEXTERNALRESOURCE)) {
+		EnumSet<JUnitCleanUpFixCore> fixes= computeFixSet();
+		boolean externalResourceRequested= fixes.contains(JUnitCleanUpFixCore.RULEEXTERNALRESOURCE);
+		boolean lifecycleRequested= lifecycleFixesEnabled(fixes);
+		if (!externalResourceRequested && !lifecycleRequested) {
 			return List.of();
 		}
 		if (monitor != null && monitor.isCanceled()) {
@@ -144,9 +173,14 @@ public class JUnitCleanUpCore extends AbstractPlannedMultiFileCleanUp<JUnitMigra
 			return List.of();
 		}
 		rejectedScopes.remove(project);
-		JUnitScopeCandidateDetector.SearchSeeds seeds=
-				JUnitScopeCandidateDetector.findSearchSeeds(project, currentScope, monitor);
-		if (!seeds.candidateFound()) {
+
+		JUnitScopeCandidateDetector.SearchSeeds resourceSeeds= externalResourceRequested
+				? JUnitScopeCandidateDetector.findSearchSeeds(project, currentScope, monitor)
+				: new JUnitScopeCandidateDetector.SearchSeeds(false, true, List.of());
+		JUnitLifecycleScopeCandidateDetector.SearchSeeds lifecycleSeeds= lifecycleRequested
+				? JUnitLifecycleScopeCandidateDetector.findSearchSeeds(project, currentScope, monitor)
+				: new JUnitLifecycleScopeCandidateDetector.SearchSeeds(false, true, List.of());
+		if (!resourceSeeds.candidateFound() && !lifecycleSeeds.candidateFound()) {
 			clearScopeDecision(project);
 			return List.of();
 		}
@@ -154,11 +188,14 @@ public class JUnitCleanUpCore extends AbstractPlannedMultiFileCleanUp<JUnitMigra
 		List<ICompilationUnit> allowedUnits= JavaProjectCompilationUnits.collect(project, currentScope,
 				SourceRootPolicy.TEST_ROOTS_AND_SELECTED_SUPPORT);
 		List<ICompilationUnit> requiredUnits;
-		if (!seeds.complete()) {
+		if (!resourceSeeds.complete() || !lifecycleSeeds.complete()) {
 			requiredUnits= allowedUnits;
 		} else {
+			Set<IJavaElement> elements= new LinkedHashSet<>();
+			elements.addAll(resourceSeeds.elements());
+			elements.addAll(lifecycleSeeds.elements());
 			RelatedCompilationUnitSearch.Result related= RelatedCompilationUnitSearch.findReferences(project,
-					seeds.elements(), currentScope, allowedUnits, monitor);
+					elements, currentScope, allowedUnits, monitor);
 			if (!related.complete()) {
 				clearScopeDecision(project);
 				rejectedScopes.add(project);
@@ -238,6 +275,16 @@ public class JUnitCleanUpCore extends AbstractPlannedMultiFileCleanUp<JUnitMigra
 			}
 		});
 		return fixSetCombined;
+	}
+
+	private static boolean lifecycleFixesEnabled(EnumSet<JUnitCleanUpFixCore> fixes) {
+		return fixes.stream().anyMatch(LIFECYCLE_FIXES::contains);
+	}
+
+	private static boolean isCompleteProjectSelection(IJavaProject project, ICompilationUnit[] compilationUnits) {
+		Set<String> selected= handles(List.of(compilationUnits));
+		Set<String> projectUnits= handles(JavaProjectCompilationUnits.collect(project));
+		return !projectUnits.isEmpty() && selected.containsAll(projectUnits);
 	}
 
 	private EnumSet<JUnitCleanUpFixCore> allOfJunit4() {

--- a/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/JUnitLifecycleScopeExpansionTest.java
+++ b/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/JUnitLifecycleScopeExpansionTest.java
@@ -1,0 +1,218 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.quickfix.Java8;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.junit.JUnitCore;
+import org.eclipse.jdt.ui.cleanup.CleanUpOptions;
+
+import org.sandbox.jdt.internal.corext.fix.multifile.JUnitLifecycleScopeCandidateDetector;
+import org.sandbox.jdt.internal.corext.fix.multifile.JUnitLifecycleScopeCandidateDetector.SearchSeeds;
+import org.sandbox.jdt.internal.corext.fix2.MYCleanUpConstants;
+import org.sandbox.jdt.internal.ui.fix.JUnitCleanUpCore;
+import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
+import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava17;
+
+/** Scope and fail-closed tests for inherited JUnit 4 lifecycle migration. */
+public class JUnitLifecycleScopeExpansionTest {
+
+	@RegisterExtension
+	AbstractEclipseJava context= new EclipseJava17();
+
+	@Test
+	public void selectedSubclassAddsLifecycleBaseClassAndReachesFixedPoint() throws CoreException {
+		IPackageFragmentRoot root= context.createClasspathForJUnit(JUnitCore.JUNIT4_CONTAINER_PATH);
+		IPackageFragment pack= root.createPackageFragment("test", true, null); //$NON-NLS-1$
+		ICompilationUnit base= pack.createCompilationUnit("BaseTest.java", //$NON-NLS-1$
+				"""
+				package test;
+
+				import org.junit.Before;
+
+				public class BaseTest {
+					@Before
+					public void prepareBase() {
+					}
+				}
+				""", false, null);
+		ICompilationUnit child= pack.createCompilationUnit("ChildTest.java", //$NON-NLS-1$
+				"""
+				package test;
+
+				public class ChildTest extends BaseTest {
+				}
+				""", false, null);
+		ICompilationUnit unrelated= pack.createCompilationUnit("UnrelatedTest.java", //$NON-NLS-1$
+				"""
+				package test;
+
+				public class UnrelatedTest {
+				}
+				""", false, null);
+
+		JUnitCleanUpCore cleanup= lifecycleCleanup();
+		Collection<ICompilationUnit> expanded= cleanup.expandCleanUpScope(child.getJavaProject(), List.of(child), null);
+		Set<String> expandedHandles= handles(expanded);
+
+		assertTrue(expandedHandles.contains(base.getHandleIdentifier()));
+		assertTrue(expandedHandles.contains(child.getHandleIdentifier()));
+		assertFalse(expandedHandles.contains(unrelated.getHandleIdentifier()));
+		assertTrue(cleanup.expandCleanUpScope(child.getJavaProject(), List.of(child, base), null).isEmpty(),
+				"Lifecycle hierarchy expansion must reach a fixed point"); //$NON-NLS-1$
+	}
+
+	@Test
+	public void selectedImplementorAddsInterfaceDefaultLifecycleContract() throws CoreException {
+		IPackageFragmentRoot root= context.createClasspathForJUnit(JUnitCore.JUNIT4_CONTAINER_PATH);
+		IPackageFragment pack= root.createPackageFragment("test", true, null); //$NON-NLS-1$
+		ICompilationUnit contract= pack.createCompilationUnit("LifecycleContract.java", //$NON-NLS-1$
+				"""
+				package test;
+
+				import org.junit.Before;
+
+				public interface LifecycleContract {
+					@Before
+					default void prepareContract() {
+					}
+				}
+				""", false, null);
+		ICompilationUnit implementation= pack.createCompilationUnit("ContractTest.java", //$NON-NLS-1$
+				"""
+				package test;
+
+				public class ContractTest implements LifecycleContract {
+				}
+				""", false, null);
+
+		Collection<ICompilationUnit> expanded= lifecycleCleanup().expandCleanUpScope(
+				implementation.getJavaProject(), List.of(implementation), null);
+
+		assertTrue(handles(expanded).containsAll(Set.of(
+				contract.getHandleIdentifier(), implementation.getHandleIdentifier())));
+	}
+
+	@Test
+	public void unresolvedLifecycleAnnotationRequestsConservativeFallback() throws CoreException {
+		IPackageFragment pack= context.getSourceFolder().createPackageFragment("test", true, null); //$NON-NLS-1$
+		ICompilationUnit unresolved= pack.createCompilationUnit("UnresolvedTest.java", //$NON-NLS-1$
+				"""
+				package test;
+
+				public class UnresolvedTest {
+					@Before
+					public void prepare() {
+					}
+				}
+				""", false, null);
+
+		SearchSeeds seeds= JUnitLifecycleScopeCandidateDetector.findSearchSeeds(
+				unresolved.getJavaProject(), List.of(unresolved), null);
+
+		assertTrue(seeds.candidateFound());
+		assertFalse(seeds.complete());
+	}
+
+	@Test
+	public void incompleteSelectionDoesNotPartiallyRewriteLifecycleAnnotation() throws CoreException {
+		IPackageFragmentRoot root= context.createClasspathForJUnit(JUnitCore.JUNIT4_CONTAINER_PATH);
+		IPackageFragment pack= root.createPackageFragment("test", true, null); //$NON-NLS-1$
+		ICompilationUnit base= pack.createCompilationUnit("BaseTest.java", //$NON-NLS-1$
+				"""
+				package test;
+
+				import org.junit.Before;
+
+				public class BaseTest {
+					@Before
+					public void prepareBase() {
+					}
+				}
+				""", false, null);
+		pack.createCompilationUnit("ChildTest.java", //$NON-NLS-1$
+				"""
+				package test;
+
+				public class ChildTest extends BaseTest {
+				}
+				""", false, null);
+
+		context.enable(MYCleanUpConstants.JUNIT_CLEANUP);
+		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_4_BEFORE);
+
+		context.assertRefactoringHasNoChange(new ICompilationUnit[] { base });
+	}
+
+	@Test
+	public void detectorReturnsSourceHierarchyElements() throws CoreException {
+		IPackageFragmentRoot root= context.createClasspathForJUnit(JUnitCore.JUNIT4_CONTAINER_PATH);
+		IPackageFragment pack= root.createPackageFragment("test", true, null); //$NON-NLS-1$
+		ICompilationUnit base= pack.createCompilationUnit("BaseTest.java", //$NON-NLS-1$
+				"""
+				package test;
+				import org.junit.After;
+				public class BaseTest {
+					@After public void release() {
+					}
+				}
+				""", false, null);
+		ICompilationUnit child= pack.createCompilationUnit("ChildTest.java", //$NON-NLS-1$
+				"""
+				package test;
+				public class ChildTest extends BaseTest {
+				}
+				""", false, null);
+
+		SearchSeeds seeds= JUnitLifecycleScopeCandidateDetector.findSearchSeeds(
+				child.getJavaProject(), List.of(child), null);
+		Set<String> declarationUnits= seeds.elements().stream()
+				.map(element -> element.getAncestor(IJavaElement.COMPILATION_UNIT))
+				.filter(ICompilationUnit.class::isInstance)
+				.map(ICompilationUnit.class::cast)
+				.map(ICompilationUnit::getHandleIdentifier)
+				.collect(Collectors.toSet());
+
+		assertTrue(seeds.candidateFound());
+		assertTrue(seeds.complete());
+		assertEquals(Set.of(base.getHandleIdentifier(), child.getHandleIdentifier()), declarationUnits);
+	}
+
+	private static JUnitCleanUpCore lifecycleCleanup() {
+		return new JUnitCleanUpCore(Map.of(
+				MYCleanUpConstants.JUNIT_CLEANUP, CleanUpOptions.TRUE,
+				MYCleanUpConstants.JUNIT_CLEANUP_4_BEFORE, CleanUpOptions.TRUE,
+				MYCleanUpConstants.JUNIT_CLEANUP_4_AFTER, CleanUpOptions.TRUE,
+				MYCleanUpConstants.JUNIT_CLEANUP_4_BEFORECLASS, CleanUpOptions.TRUE,
+				MYCleanUpConstants.JUNIT_CLEANUP_4_AFTERCLASS, CleanUpOptions.TRUE));
+	}
+
+	private static Set<String> handles(Collection<ICompilationUnit> units) {
+		return units.stream().map(ICompilationUnit::getHandleIdentifier).collect(Collectors.toSet());
+	}
+}


### PR DESCRIPTION
## Summary

Implements the first prioritized hierarchy/lifecycle stage of #1217 on top of the cleanup-impact contract in #1289.

## Scope closure

- detects JUnit 4 lifecycle annotations declared in selected classes, source superclasses and source interfaces;
- includes interface default-method lifecycle contracts;
- feeds binding-derived hierarchy types into the existing exact workspace reference search so subclasses and implementors join the fixed-point scope;
- falls back conservatively when annotations or hierarchy bindings are unresolved or recovered.

## Fail-closed execution

- records whether the lifecycle hierarchy was proved closed in `JUnitMigrationPlan`;
- removes `BEFORE`, `AFTER`, `BEFORECLASS` and `AFTERCLASS` from the local rewrite set when the scope is incomplete;
- prevents stock/unpatched cleanup orchestration or manually restricted selections from producing a mixed JUnit 4/Jupiter hierarchy;
- keeps lifecycle options out of save actions through the base PR.

## Verification

Tests cover superclass expansion, fixed-point behavior, interface default methods, unresolved annotation fallback, hierarchy Java elements and the absence of partial edits for an incomplete selection.

This intentionally does not close #1217: suites, parameterized providers, custom runners, build dependency removal and non-Java resources remain separate bounded stages.

Refs #1217.