### PR TITLE
Make Codacy reporting resilient to registry outages

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [ main, 2022-12, 2022-09, 2022-06 ]
     paths:
-      - '**.java'
+      - '**/*.java'
       - '**/pom.xml'
       - '.codacy.yml'
       - 'ruleset.xml'
@@ -19,17 +19,16 @@ concurrency:
 jobs:
   codacy-java-tools:
     name: Codacy Java Tools
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 55
-    continue-on-error: true
     permissions:
       contents: read
       security-events: write
     strategy:
       fail-fast: false
       matrix:
-        # TODO: Re-enable pmd once the MalformedInputException in Codacy PMD/SARIF is fixed
-        # Temporarily disable pmd due to MalformedInputException in Codacy SARIF generation
+        # PMD remains disabled until Codacy's SARIF conversion no longer throws
+        # MalformedInputException on this repository.
         tool: [ spotbugs, checkstyle ]
     env:
       LC_ALL: C.UTF-8
@@ -48,154 +47,43 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: '21'
-          distribution: 'temurin'
+          distribution: temurin
           cache: maven
 
-      - name: Cache Maven dependencies
-        uses: actions/cache@v5
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-maven-
-
-      - name: Build (no tests)
+      # This is the authoritative analysis gate. The parent POM binds the
+      # SpotBugs Maven plugin with failOnError=true to the compile phase, so
+      # source or bytecode findings still fail the job without Codacy/Docker.
+      - name: Build and run Maven analysis
         run: mvn -B -DskipTests package
 
-      # Normalize all source files to UTF-8 to prevent encoding issues in SARIF generation
-      # Explicitly exclude binary JAR files and testresources directory to prevent MalformedInputException
-      - name: Normalize source files to UTF-8 (in-place)
+      # Codacy's action starts by pulling this image. Warm it with retries so a
+      # short Docker Hub outage does not immediately discard the reporting run.
+      - name: Warm Codacy CLI image cache
+        continue-on-error: true
+        env:
+          CODACY_CLI_IMAGE: codacy/codacy-analysis-cli:7.9.25
         run: |
           set -euo pipefail
-          sudo apt-get update -y
-          sudo apt-get install -y uchardet libxml2-utils
-          changes=0
-          errors=0
-          
-          # Helper function to clean invalid UTF-8 sequences
-          clean_utf8() {
-            local file=$1
-            if iconv -f utf-8 -t utf-8 -c "$file" -o "$file.tmp" 2>/dev/null; then
-              mv "$file.tmp" "$file"
-              return 0
-            else
-              rm -f "$file.tmp"
-              return 1
+          for attempt in 1 2 3 4 5; do
+            if docker pull "$CODACY_CLI_IMAGE"; then
+              exit 0
             fi
-          }
-          
-          # Process Java, XML, properties, and other text files
-          # IMPORTANT: Exclude testresources/ directory which contains binary JAR files
-          while IFS= read -r -d '' f; do
-            # Skip if file doesn't exist or is not readable
-            [ -r "$f" ] || continue
-            
-            
-            
-            
-            
-            
-            
-            charset=$(uchardet "$f" 2>/dev/null | tr '[:upper:]' '[:lower:]')
-            if [ -z "$charset" ]; then
-              echo "Warning: uchardet could not detect encoding for $f, attempting UTF-8 validation"
-              # Try to clean as UTF-8 anyway for files < 1MB
-              filesize=$(stat -f%z "$f" 2>/dev/null || stat -c%s "$f" 2>/dev/null || echo 0)
-              if [ "$filesize" -lt 1048576 ] && ! iconv -f utf-8 -t utf-8 "$f" > /dev/null 2>&1; then
-                echo "Cleaning invalid UTF-8 sequences in $f (unknown encoding)"
-                if clean_utf8 "$f"; then
-                  changes=$((changes+1))
-                else
-                  errors=$((errors+1))
-                fi
-              fi
-              continue
+            if [ "$attempt" -lt 5 ]; then
+              delay=$((attempt * 15))
+              echo "::warning::Docker pull failed on attempt $attempt/5; retrying in ${delay}s."
+              sleep "$delay"
             fi
-            
-            # Only convert if not already UTF-8/ASCII
-            if [ "$charset" != "utf-8" ] && [ "$charset" != "ascii" ] && [ "$charset" != "binary" ]; then
-              echo "Converting $f ($charset -> utf-8)"
-              if iconv -f "$charset" -t utf-8 "$f" -o "$f.tmp" 2>/dev/null; then
-                mv "$f.tmp" "$f"
-                changes=$((changes+1))
-              else
-                rm -f "$f.tmp"  # Clean up partially written file on conversion failure
-                echo "Warning: Failed to convert $f, trying to clean invalid UTF-8"
-                if clean_utf8 "$f"; then
-                  changes=$((changes+1))
-                else
-                  errors=$((errors+1))
-                fi
-              fi
-            elif [ "$charset" = "utf-8" ] || [ "$charset" = "ascii" ]; then
-              # Even if detected as UTF-8, validate and clean it (skip very large files > 1MB)
-              filesize=$(stat -c%s "$f" 2>/dev/null || echo 0)
-              # Check if file contains invalid UTF-8 sequences by comparing with cleaned version
-              if [ "$filesize" -lt 1048576 ] && ! diff -q "$f" <(iconv -f utf-8 -t utf-8 -c "$f" 2>/dev/null) > /dev/null 2>&1; then
-                echo "Cleaning invalid UTF-8 sequences in $f"
-                if clean_utf8 "$f"; then
-                  changes=$((changes+1))
-                else
-                  errors=$((errors+1))
-                fi
-              fi
-            fi
-          done < <(git ls-files -z '*.java' '*.xml' '*.properties' '*.txt' '*.md' | grep -zv '/testresources/')
-          echo "Converted/cleaned $changes files, $errors failures"
-          if [ "$errors" -gt 0 ]; then
-            echo "Error: Failed to process $errors files"
-            exit 1
-          fi
+          done
+          echo "::warning::Could not pre-pull $CODACY_CLI_IMAGE after five attempts."
+          exit 1
 
-      # Ensure PMD only analyzes Java source files and excludes binary JARs
-      # This prevents MalformedInputException during SARIF generation when PMD encounters binary files
-      - name: Verify PMD configuration
-        run: |
-          echo "PMD will use ruleset.xml and .codacy.yml for filtering"
-          echo "IMPORTANT: Binary JARs under sandbox_functional_converter_test/testresources/ must be excluded"
-          echo ""
-          if [ -f ruleset.xml ]; then
-            echo "✓ ruleset.xml found"
-            # Validate XML is well-formed
-            xml_check=$(xmllint --noout ruleset.xml 2>&1)
-            if [ $? -eq 0 ]; then
-              echo "✓ ruleset.xml is well-formed XML"
-            else
-              echo "⚠ ruleset.xml has XML syntax errors"
-              echo "$xml_check"
-            fi
-            echo ""
-            echo "Binary file exclusions from ruleset.xml:"
-            grep "exclude-pattern.*\\.jar" ruleset.xml || echo "  WARNING: No JAR exclusions found!"
-            grep "exclude-pattern.*\\.class" ruleset.xml || true
-            echo ""
-            echo "Key directory exclusions from ruleset.xml:"
-            grep "exclude-pattern.*testresources" ruleset.xml || echo "  WARNING: No testresources exclusions found!"
-            grep "exclude-pattern.*/.*/.*" ruleset.xml | head -8 || true
-          else
-            echo "⚠ ruleset.xml not found"
-          fi
-          echo ""
-          if [ -f .codacy.yml ]; then
-            echo "✓ .codacy.yml found"
-            echo "Included paths:"
-            grep -A 5 "include_paths:" .codacy.yml || true
-            echo ""
-            echo "Excluded paths (should include testresources and *.jar):"
-            grep -A 20 "exclude_paths:" .codacy.yml || true
-            echo ""
-            echo "PMD-specific exclusions:"
-            grep -A 10 "pmd:" .codacy.yml || true
-          fi
-          echo ""
-          echo "Java source files to be analyzed:"
-          java_count=$(find . -name "*.java" -path "*/src/*" -not -path "*/target/*" -not -path "*/bin/*" -not -path "*/testresources/*" | wc -l)
-          echo "Found $java_count Java files in src/ directories (excluding target/, bin/, and testresources/)"
-          echo ""
-          echo "JAR files that MUST be excluded from analysis:"
-          find . -name "*.jar" -path "*/testresources/*" || echo "  (none found - good!)"
-
+      # Keep Codacy as reporting integration, not as a second build authority.
+      # In particular, Docker Hub/registry outages must not turn a successful
+      # Maven build red. Missing SARIF is reported explicitly below.
       - name: Run Codacy Analysis CLI (${{ matrix.tool }})
-        uses: codacy/codacy-analysis-cli-action@v4
+        id: codacy_analysis
+        continue-on-error: true
+        uses: codacy/codacy-analysis-cli-action@562ee3e92b8e92df8b67e0a5ff8aa8e261919c08 # v4
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           tool: ${{ matrix.tool }}
@@ -207,31 +95,54 @@ jobs:
           skip-uncommitted-files-check: true
           tool-timeout: 1hour
 
-      # GitHub verlangt seit 2025-07 genau 1 run pro Upload/Kategorie
+      - name: Report unavailable Codacy result
+        if: steps.codacy_analysis.outcome == 'failure'
+        run: |
+          echo "::warning::Codacy ${{ matrix.tool }} reporting failed after the authoritative Maven build succeeded."
+          echo "::warning::No SARIF will be uploaded for this tool in this run."
+
+      # GitHub code scanning accepts one SARIF run per upload/category. The
+      # outputs avoid hashFiles(), which only searches GITHUB_WORKSPACE and
+      # therefore cannot detect files written below runner.temp.
       - name: Split SARIF into single-run files (${{ matrix.tool }})
+        id: split_sarif
         shell: bash
         env:
           SARIF: ${{ runner.temp }}/results-${{ matrix.tool }}.sarif
           OUTDIR: ${{ runner.temp }}/sarif_split_${{ matrix.tool }}
         run: |
           set -euo pipefail
+          echo "run0=false" >> "$GITHUB_OUTPUT"
+          echo "run1=false" >> "$GITHUB_OUTPUT"
+          echo "run2=false" >> "$GITHUB_OUTPUT"
+
           if [ ! -s "$SARIF" ]; then
-            echo "No SARIF produced for ${{ matrix.tool }} -> skip."
+            echo "No SARIF produced for ${{ matrix.tool }}; skipping upload."
             exit 0
           fi
-          sudo apt-get update -y
-          sudo apt-get install -y jq
+
           mkdir -p "$OUTDIR"
-          # safe default: 0 runs if field missing
           runs=$(jq '.runs | length // 0' "$SARIF")
           echo "Found $runs runs in $SARIF"
-          for ((i=0; i<runs; i++)); do
-            # korrektes Zugreifen auf das $schema-Feld und Extrahieren eines einzelnen runs
-            jq --argjson i "$i" '{ "$schema": .["$schema"], version: .version, runs: [ .runs[$i] ] }' "$SARIF" > "$OUTDIR/run-$i.sarif"
+
+          if [ "$runs" -gt 3 ]; then
+            echo "::warning::SARIF contains $runs runs; only the first three are uploaded."
+          fi
+
+          limit=$runs
+          if [ "$limit" -gt 3 ]; then
+            limit=3
+          fi
+
+          for ((i=0; i<limit; i++)); do
+            jq --argjson i "$i" \
+              '{ "$schema": .["$schema"], version: .version, runs: [ .runs[$i] ] }' \
+              "$SARIF" > "$OUTDIR/run-$i.sarif"
+            echo "run${i}=true" >> "$GITHUB_OUTPUT"
           done
 
       - name: Upload SARIF run 0 (${{ matrix.tool }})
-        if: ${{ hashFiles(format('{0}/sarif_split_{1}/run-0.sarif', runner.temp, matrix.tool)) != '' }}
+        if: steps.split_sarif.outputs.run0 == 'true'
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: ${{ runner.temp }}/sarif_split_${{ matrix.tool }}/run-0.sarif
@@ -239,7 +150,7 @@ jobs:
           wait-for-processing: true
 
       - name: Upload SARIF run 1 (${{ matrix.tool }})
-        if: ${{ hashFiles(format('{0}/sarif_split_{1}/run-1.sarif', runner.temp, matrix.tool)) != '' }}
+        if: steps.split_sarif.outputs.run1 == 'true'
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: ${{ runner.temp }}/sarif_split_${{ matrix.tool }}/run-1.sarif
@@ -247,7 +158,7 @@ jobs:
           wait-for-processing: true
 
       - name: Upload SARIF run 2 (${{ matrix.tool }})
-        if: ${{ hashFiles(format('{0}/sarif_split_{1}/run-2.sarif', runner.temp, matrix.tool)) != '' }}
+        if: steps.split_sarif.outputs.run2 == 'true'
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: ${{ runner.temp }}/sarif_split_${{ matrix.tool }}/run-2.sarif

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -20,16 +20,10 @@ jobs:
   codacy-java-tools:
     name: Codacy Java Tools
     runs-on: ubuntu-24.04
-    timeout-minutes: 55
+    timeout-minutes: 70
     permissions:
       contents: read
       security-events: write
-    strategy:
-      fail-fast: false
-      matrix:
-        # PMD remains disabled until Codacy's SARIF conversion no longer throws
-        # MalformedInputException on this repository.
-        tool: [ spotbugs, checkstyle ]
     env:
       LC_ALL: C.UTF-8
       LANG: C.UTF-8
@@ -38,7 +32,7 @@ jobs:
       - name: Set up Maven
         uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
         with:
-          maven-version: 3.9.9
+          maven-version: 3.9.14
 
       - name: Checkout code
         uses: actions/checkout@v6
@@ -77,90 +71,133 @@ jobs:
           echo "::warning::Could not pre-pull $CODACY_CLI_IMAGE after five attempts."
           exit 1
 
-      # Keep Codacy as reporting integration, not as a second build authority.
-      # In particular, Docker Hub/registry outages must not turn a successful
-      # Maven build red. Missing SARIF is reported explicitly below.
-      - name: Run Codacy Analysis CLI (${{ matrix.tool }})
-        id: codacy_analysis
+      # Codacy is a reporting integration after the Maven gate, not a second
+      # build authority. Registry outages therefore produce a warning rather
+      # than hiding a successful, locally reproducible Maven result.
+      - name: Run Codacy Analysis CLI (spotbugs)
+        id: codacy_spotbugs
         continue-on-error: true
         uses: codacy/codacy-analysis-cli-action@562ee3e92b8e92df8b67e0a5ff8aa8e261919c08 # v4
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          tool: ${{ matrix.tool }}
+          tool: spotbugs
           verbose: true
           format: sarif
-          output: ${{ runner.temp }}/results-${{ matrix.tool }}.sarif
+          output: ${{ runner.temp }}/results-spotbugs.sarif
           gh-code-scanning-compat: true
           max-allowed-issues: 2147483647
           skip-uncommitted-files-check: true
           tool-timeout: 1hour
 
-      - name: Report unavailable Codacy result
-        if: steps.codacy_analysis.outcome == 'failure'
+      - name: Report unavailable SpotBugs result
+        if: steps.codacy_spotbugs.outcome == 'failure'
         run: |
-          echo "::warning::Codacy ${{ matrix.tool }} reporting failed after the authoritative Maven build succeeded."
-          echo "::warning::No SARIF will be uploaded for this tool in this run."
+          echo "::warning::Codacy SpotBugs reporting failed after the authoritative Maven build succeeded."
+          echo "::warning::No SpotBugs SARIF will be uploaded in this run."
 
-      # GitHub code scanning accepts one SARIF run per upload/category. The
-      # outputs avoid hashFiles(), which only searches GITHUB_WORKSPACE and
-      # therefore cannot detect files written below runner.temp.
-      - name: Split SARIF into single-run files (${{ matrix.tool }})
+      - name: Run Codacy Analysis CLI (checkstyle)
+        id: codacy_checkstyle
+        continue-on-error: true
+        uses: codacy/codacy-analysis-cli-action@562ee3e92b8e92df8b67e0a5ff8aa8e261919c08 # v4
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          tool: checkstyle
+          verbose: true
+          format: sarif
+          output: ${{ runner.temp }}/results-checkstyle.sarif
+          gh-code-scanning-compat: true
+          max-allowed-issues: 2147483647
+          skip-uncommitted-files-check: true
+          tool-timeout: 1hour
+
+      - name: Report unavailable Checkstyle result
+        if: steps.codacy_checkstyle.outcome == 'failure'
+        run: |
+          echo "::warning::Codacy Checkstyle reporting failed after the authoritative Maven build succeeded."
+          echo "::warning::No Checkstyle SARIF will be uploaded in this run."
+
+      # hashFiles() searches only GITHUB_WORKSPACE, not runner.temp. Explicit
+      # outputs ensure generated SARIF files are really detected and uploaded.
+      - name: Split SARIF into single-run files
         id: split_sarif
         shell: bash
-        env:
-          SARIF: ${{ runner.temp }}/results-${{ matrix.tool }}.sarif
-          OUTDIR: ${{ runner.temp }}/sarif_split_${{ matrix.tool }}
         run: |
           set -euo pipefail
-          echo "run0=false" >> "$GITHUB_OUTPUT"
-          echo "run1=false" >> "$GITHUB_OUTPUT"
-          echo "run2=false" >> "$GITHUB_OUTPUT"
+          for tool in spotbugs checkstyle; do
+            for index in 0 1 2; do
+              echo "${tool}_run${index}=false" >> "$GITHUB_OUTPUT"
+            done
 
-          if [ ! -s "$SARIF" ]; then
-            echo "No SARIF produced for ${{ matrix.tool }}; skipping upload."
-            exit 0
-          fi
+            sarif="$RUNNER_TEMP/results-${tool}.sarif"
+            outdir="$RUNNER_TEMP/sarif_split_${tool}"
+            if [ ! -s "$sarif" ]; then
+              echo "No SARIF produced for $tool; skipping upload."
+              continue
+            fi
 
-          mkdir -p "$OUTDIR"
-          runs=$(jq '.runs | length // 0' "$SARIF")
-          echo "Found $runs runs in $SARIF"
+            mkdir -p "$outdir"
+            runs=$(jq '.runs | length // 0' "$sarif")
+            echo "Found $runs runs in $sarif"
+            if [ "$runs" -gt 3 ]; then
+              echo "::warning::${tool} SARIF contains $runs runs; only the first three are uploaded."
+            fi
 
-          if [ "$runs" -gt 3 ]; then
-            echo "::warning::SARIF contains $runs runs; only the first three are uploaded."
-          fi
-
-          limit=$runs
-          if [ "$limit" -gt 3 ]; then
-            limit=3
-          fi
-
-          for ((i=0; i<limit; i++)); do
-            jq --argjson i "$i" \
-              '{ "$schema": .["$schema"], version: .version, runs: [ .runs[$i] ] }' \
-              "$SARIF" > "$OUTDIR/run-$i.sarif"
-            echo "run${i}=true" >> "$GITHUB_OUTPUT"
+            limit=$runs
+            if [ "$limit" -gt 3 ]; then
+              limit=3
+            fi
+            for ((index=0; index<limit; index++)); do
+              jq --argjson index "$index" \
+                '{ "$schema": .["$schema"], version: .version, runs: [ .runs[$index] ] }' \
+                "$sarif" > "$outdir/run-$index.sarif"
+              echo "${tool}_run${index}=true" >> "$GITHUB_OUTPUT"
+            done
           done
 
-      - name: Upload SARIF run 0 (${{ matrix.tool }})
-        if: steps.split_sarif.outputs.run0 == 'true'
+      - name: Upload SpotBugs SARIF run 0
+        if: steps.split_sarif.outputs.spotbugs_run0 == 'true'
         uses: github/codeql-action/upload-sarif@v4
         with:
-          sarif_file: ${{ runner.temp }}/sarif_split_${{ matrix.tool }}/run-0.sarif
-          category: codacy-${{ matrix.tool }}-run-0
+          sarif_file: ${{ runner.temp }}/sarif_split_spotbugs/run-0.sarif
+          category: codacy-spotbugs-run-0
           wait-for-processing: true
 
-      - name: Upload SARIF run 1 (${{ matrix.tool }})
-        if: steps.split_sarif.outputs.run1 == 'true'
+      - name: Upload SpotBugs SARIF run 1
+        if: steps.split_sarif.outputs.spotbugs_run1 == 'true'
         uses: github/codeql-action/upload-sarif@v4
         with:
-          sarif_file: ${{ runner.temp }}/sarif_split_${{ matrix.tool }}/run-1.sarif
-          category: codacy-${{ matrix.tool }}-run-1
+          sarif_file: ${{ runner.temp }}/sarif_split_spotbugs/run-1.sarif
+          category: codacy-spotbugs-run-1
           wait-for-processing: true
 
-      - name: Upload SARIF run 2 (${{ matrix.tool }})
-        if: steps.split_sarif.outputs.run2 == 'true'
+      - name: Upload SpotBugs SARIF run 2
+        if: steps.split_sarif.outputs.spotbugs_run2 == 'true'
         uses: github/codeql-action/upload-sarif@v4
         with:
-          sarif_file: ${{ runner.temp }}/sarif_split_${{ matrix.tool }}/run-2.sarif
-          category: codacy-${{ matrix.tool }}-run-2
+          sarif_file: ${{ runner.temp }}/sarif_split_spotbugs/run-2.sarif
+          category: codacy-spotbugs-run-2
+          wait-for-processing: true
+
+      - name: Upload Checkstyle SARIF run 0
+        if: steps.split_sarif.outputs.checkstyle_run0 == 'true'
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: ${{ runner.temp }}/sarif_split_checkstyle/run-0.sarif
+          category: codacy-checkstyle-run-0
+          wait-for-processing: true
+
+      - name: Upload Checkstyle SARIF run 1
+        if: steps.split_sarif.outputs.checkstyle_run1 == 'true'
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: ${{ runner.temp }}/sarif_split_checkstyle/run-1.sarif
+          category: codacy-checkstyle-run-1
+          wait-for-processing: true
+
+      - name: Upload Checkstyle SARIF run 2
+        if: steps.split_sarif.outputs.checkstyle_run2 == 'true'
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: ${{ runner.temp }}/sarif_split_checkstyle/run-2.sarif
+          category: codacy-checkstyle-run-2
           wait-for-processing: true


### PR DESCRIPTION
## Problem

The Codacy matrix currently turns successful Maven builds red when Docker Hub cannot serve `codacy/codacy-analysis-cli`. The observed failure happened before SpotBugs started and exited with Docker code 125.

## Changes

- keeps `mvn -B -DskipTests package` as the authoritative analysis gate; the parent POM already runs SpotBugs with `failOnError=true` during `compile`;
- removes the source-mutating UTF-8 normalization and PMD diagnostics from this non-PMD workflow;
- pins the Codacy action and pre-pulls its CLI image with bounded retries;
- treats Codacy/Docker as reporting-only after a successful Maven build and emits explicit warnings when no report is available;
- replaces `hashFiles()` checks against `runner.temp` with step outputs, so generated SARIF runs are actually detected and uploaded;
- removes the duplicate Maven cache and pins the runner image.

## Result

Project or SpotBugs failures still fail the job through Maven. Temporary Docker Hub/Codacy reporting outages no longer make `main` and unrelated pull requests red.