### PR TITLE
Remove snapshot overrides from release archive metadata

### DIFF
--- a/.github/scripts/test_verify_release_identity.py
+++ b/.github/scripts/test_verify_release_identity.py
@@ -75,6 +75,21 @@ class ReleaseIdentityTest(unittest.TestCase):
         self.assertEqual("FAIL", report["status"])
         self.assertEqual("plugin/feature.xml", report["findings"][0]["path"])
 
+    def test_rejects_snapshot_in_archival_metadata(self) -> None:
+        (self.root / "CITATION.cff").write_text(
+            'version: "1.4.0-SNAPSHOT"\n', encoding="utf-8"
+        )
+        (self.root / ".zenodo.json").write_text(
+            '{"version": "1.4.0-SNAPSHOT"}\n', encoding="utf-8"
+        )
+
+        with self.assertRaises(ReleaseIdentityError):
+            self.invoke()
+
+        report = json.loads((self.root / "report.json").read_text(encoding="utf-8"))
+        paths = {finding["path"] for finding in report["findings"]}
+        self.assertEqual({"CITATION.cff", ".zenodo.json"}, paths)
+
     def test_rejects_snapshot_in_source_archive(self) -> None:
         snapshot = self.root / "snapshot-pom.xml"
         snapshot.write_text(

--- a/.github/scripts/verify_release_identity.py
+++ b/.github/scripts/verify_release_identity.py
@@ -12,7 +12,14 @@ from dataclasses import asdict, dataclass
 from pathlib import Path, PurePosixPath
 from typing import Iterable
 
-VERSIONED_NAMES = {"pom.xml", "MANIFEST.MF", "feature.xml", "release.properties"}
+VERSIONED_NAMES = {
+    "pom.xml",
+    "MANIFEST.MF",
+    "feature.xml",
+    "release.properties",
+    "CITATION.cff",
+    ".zenodo.json",
+}
 VERSIONED_SUFFIXES = {".product"}
 EXCLUDED_PARTS = {".git", "target", "node_modules"}
 

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -10,7 +10,6 @@
   "license": "EPL-2.0",
   "upload_type": "software",
   "access_right": "open",
-  "version": "1.3.2-SNAPSHOT",
   "keywords": [
     "Eclipse",
     "Eclipse JDT",

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,6 @@ authors:
 repository-code: "https://github.com/carstenartur/sandbox"
 url: "https://carstenartur.github.io/sandbox/"
 license: "EPL-2.0"
-version: "1.3.2-SNAPSHOT"
 keywords:
   - eclipse
   - eclipse-jdt


### PR DESCRIPTION
## Problem

The repository permanently encoded `1.3.2-SNAPSHOT` in both `.zenodo.json` and `CITATION.cff`. Those files can override metadata derived from a published GitHub Release and therefore keep an archival record labelled as a development snapshot.

## Changes

- remove the static `version` field from `.zenodo.json`;
- remove the static `version` field from `CITATION.cff`;
- let GitHub/Zenodo derive the version from the actual published release;
- extend the release-identity verifier to inspect both archival metadata files;
- add a regression test that rejects SNAPSHOT identity in either file.

## Boundary

This prevents future incorrect archive metadata. Correcting or withdrawing an already-created Zenodo deposit still requires access to that Zenodo deposit.

Refs #1285.