### PR TITLE
Run distribution smoke tests only for relevant changes

### DIFF
--- a/.github/workflows/distribution-smoke.yml
+++ b/.github/workflows/distribution-smoke.yml
@@ -3,8 +3,30 @@ name: Distribution Smoke Test
 on:
   pull_request:
     branches: [ main ]
+    paths:
+      - 'pom.xml'
+      - '.mvn/**'
+      - 'sandbox*/**'
+      - 'features/**'
+      - 'plugins/**'
+      - 'org/**'
+      - '*.xml'
+      - '*.properties'
+      - '.github/scripts/smoke_test_distribution.sh'
+      - '.github/workflows/distribution-smoke.yml'
   push:
     branches: [ main ]
+    paths:
+      - 'pom.xml'
+      - '.mvn/**'
+      - 'sandbox*/**'
+      - 'features/**'
+      - 'plugins/**'
+      - 'org/**'
+      - '*.xml'
+      - '*.properties'
+      - '.github/scripts/smoke_test_distribution.sh'
+      - '.github/workflows/distribution-smoke.yml'
   schedule:
     - cron: '30 3 * * 1'
   workflow_dispatch:


### PR DESCRIPTION
## Problem

`Distribution Smoke Test` currently runs a complete 150-minute-capable Eclipse product and p2 build for every pull request and every push to `main`, including changes limited to Codacy reporting, citation metadata, documentation or unrelated workflows. This creates very large logs, consumes runners and leaves otherwise healthy pull requests pending or red for reasons unrelated to their changes.

## Changes

- add identical path filters to `pull_request` and `push` triggers;
- retain full coverage for Maven configuration, Sandbox modules, product/features/plugins, target/platform files and the distribution verifier/workflow itself;
- keep the weekly scheduled full build unchanged;
- keep manual `workflow_dispatch` unchanged.

## Result

Java and product changes still receive the full distribution gate. Metadata-only and unrelated CI changes no longer launch a redundant full Eclipse product build.