### PR TITLE
Quiet Maven transfer logs and restore documented parallelism

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -79,6 +79,8 @@ jobs:
       - name: Maven clean verify
         run: >-
           xvfb-run --auto-servernum mvn
+          --threads 1C
+          --no-transfer-progress
           -e
           -V
           --batch-mode


### PR DESCRIPTION
## Problem

The simplified Java CI gate is correct but its first run emitted hundreds of thousands of p2 transfer-progress lines and ran substantially longer than the documented local quick build.

## Changes

- add `--no-transfer-progress` to suppress Maven/p2 download progress noise;
- add `--threads 1C`, matching the repository's documented `mvn -T 1C verify` local build mode;
- keep the same single Maven lifecycle, Java version, tests and failure semantics.

## Evidence

The previous Java workflow used one-thread-per-core Maven builds successfully. The current serial run's log grew by roughly 15,000 lines in 20 seconds solely because transfer progress was enabled. This change restores the proven execution mode while retaining the simplified one-workflow design.