### PR TITLE
Restore deterministic serial Maven CI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -79,7 +79,6 @@ jobs:
       - name: Maven clean verify
         run: >-
           xvfb-run --auto-servernum mvn
-          --threads 1C
           --no-transfer-progress
           -e
           -V


### PR DESCRIPTION
## Problem

The latest `main` push became red after #1302 enabled Maven reactor parallelism with `--threads 1C`. The pull-request run succeeded, but parallel Tycho builds can expose ordering/resource races that do not reproduce consistently.

## Change

- remove `--threads 1C` from the authoritative Maven CI gate;
- retain `--no-transfer-progress`, so p2/Maven download output remains manageable;
- preserve the same Maven lifecycle, tests, Java version and fail-closed behavior.

## Relation to #1285

The repository-controlled release hardening and archival metadata corrections are already present through #1290 and #1299. This PR restores a deterministic green prerequisite for using that hardened release pipeline.

Fixes the current red `main` build; contributes to #1285.