### PR TITLE
Migrate combined JUnit expected and timeout atomically

### DIFF
--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/JUnitCleanUpFixCore.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/JUnitCleanUpFixCore.java
@@ -38,7 +38,6 @@ import org.sandbox.jdt.internal.corext.fix.helper.CategoryJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.ExternalResourceJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.FixMethodOrderJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.IgnoreJUnitPlugin;
-import org.sandbox.jdt.internal.corext.fix.helper.LostTestFinderJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.ParameterizedTestJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.RuleErrorCollectorJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.RuleExpectedExceptionJUnitPlugin;
@@ -48,11 +47,12 @@ import org.sandbox.jdt.internal.corext.fix.helper.RuleTestnameJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.RuleTimeoutJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.RunWithJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.TestExpectedAndTimeoutJUnitPlugin;
-import org.sandbox.jdt.internal.corext.fix.helper.TestExpectedJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.TestJUnit3Plugin;
 import org.sandbox.jdt.internal.corext.fix.helper.TestJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.TestTimeoutJUnitPlugin;
+import org.sandbox.jdt.internal.corext.fix.helper.TestExpectedJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.ThrowingRunnableJUnitPlugin;
+import org.sandbox.jdt.internal.corext.fix.helper.LostTestFinderJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.lib.AbstractTool;
 import org.sandbox.jdt.internal.corext.fix.helper.lib.JunitHolder;
 import org.sandbox.jdt.internal.ui.fix.MultiFixMessages;
@@ -114,6 +114,8 @@ public enum JUnitCleanUpFixCore {
 	 * @param operations             set of all CompilationUnitRewriteOperations
 	 *                               created already
 	 * @param nodesprocessed         list to remember nodes already processed
+	 * @param createForOnlyIfVarUsed true if for loop should be created only only if
+	 *                               loop var used within
 	 */
 	public void findOperations(final CompilationUnit compilationUnit,
 			final Set<CompilationUnitRewriteOperationWithSourceRange> operations, final Set<ASTNode> nodesprocessed) {

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/JUnitCleanUpFixCore.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/JUnitCleanUpFixCore.java
@@ -38,6 +38,7 @@ import org.sandbox.jdt.internal.corext.fix.helper.CategoryJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.ExternalResourceJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.FixMethodOrderJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.IgnoreJUnitPlugin;
+import org.sandbox.jdt.internal.corext.fix.helper.LostTestFinderJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.ParameterizedTestJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.RuleErrorCollectorJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.RuleExpectedExceptionJUnitPlugin;
@@ -46,12 +47,12 @@ import org.sandbox.jdt.internal.corext.fix.helper.RuleTemporayFolderJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.RuleTestnameJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.RuleTimeoutJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.RunWithJUnitPlugin;
+import org.sandbox.jdt.internal.corext.fix.helper.TestExpectedAndTimeoutJUnitPlugin;
+import org.sandbox.jdt.internal.corext.fix.helper.TestExpectedJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.TestJUnit3Plugin;
 import org.sandbox.jdt.internal.corext.fix.helper.TestJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.TestTimeoutJUnitPlugin;
-import org.sandbox.jdt.internal.corext.fix.helper.TestExpectedJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.ThrowingRunnableJUnitPlugin;
-import org.sandbox.jdt.internal.corext.fix.helper.LostTestFinderJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.lib.AbstractTool;
 import org.sandbox.jdt.internal.corext.fix.helper.lib.JunitHolder;
 import org.sandbox.jdt.internal.ui.fix.MultiFixMessages;
@@ -62,6 +63,7 @@ public enum JUnitCleanUpFixCore {
 	AFTER(new AfterJUnitPlugin()),
 	TEST(new TestJUnitPlugin()),
 	TEST3(new TestJUnit3Plugin()),
+	TEST_EXPECTED_TIMEOUT(new TestExpectedAndTimeoutJUnitPlugin()),
 	TEST_TIMEOUT(new TestTimeoutJUnitPlugin()),
 	TEST_EXPECTED(new TestExpectedJUnitPlugin()),
 	BEFORECLASS(new BeforeClassJUnitPlugin()),
@@ -112,8 +114,6 @@ public enum JUnitCleanUpFixCore {
 	 * @param operations             set of all CompilationUnitRewriteOperations
 	 *                               created already
 	 * @param nodesprocessed         list to remember nodes already processed
-	 * @param createForOnlyIfVarUsed true if for loop should be created only only if
-	 *                               loop var used within
 	 */
 	public void findOperations(final CompilationUnit compilationUnit,
 			final Set<CompilationUnitRewriteOperationWithSourceRange> operations, final Set<ASTNode> nodesprocessed) {

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/TestExpectedAndTimeoutJUnitPlugin.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/TestExpectedAndTimeoutJUnitPlugin.java
@@ -23,7 +23,6 @@ import java.util.List;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.Block;
-import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.ExpressionStatement;
 import org.eclipse.jdt.core.dom.LambdaExpression;
 import org.eclipse.jdt.core.dom.MarkerAnnotation;

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/TestExpectedAndTimeoutJUnitPlugin.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/TestExpectedAndTimeoutJUnitPlugin.java
@@ -1,0 +1,191 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.corext.fix.helper;
+
+import static org.sandbox.jdt.internal.corext.fix.helper.lib.JUnitConstants.ANNOTATION_TEST;
+import static org.sandbox.jdt.internal.corext.fix.helper.lib.JUnitConstants.ANNOTATION_TIMEOUT;
+import static org.sandbox.jdt.internal.corext.fix.helper.lib.JUnitConstants.METHOD_ASSERT_THROWS;
+import static org.sandbox.jdt.internal.corext.fix.helper.lib.JUnitConstants.ORG_JUNIT_JUPITER_API_ASSERTIONS;
+import static org.sandbox.jdt.internal.corext.fix.helper.lib.JUnitConstants.ORG_JUNIT_JUPITER_API_TIMEOUT;
+import static org.sandbox.jdt.internal.corext.fix.helper.lib.JUnitConstants.ORG_JUNIT_JUPITER_TEST;
+import static org.sandbox.jdt.internal.corext.fix.helper.lib.JUnitConstants.ORG_JUNIT_TEST;
+
+import java.util.List;
+
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.Block;
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.ExpressionStatement;
+import org.eclipse.jdt.core.dom.LambdaExpression;
+import org.eclipse.jdt.core.dom.MarkerAnnotation;
+import org.eclipse.jdt.core.dom.MemberValuePair;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.NormalAnnotation;
+import org.eclipse.jdt.core.dom.NumberLiteral;
+import org.eclipse.jdt.core.dom.QualifiedName;
+import org.eclipse.jdt.core.dom.Statement;
+import org.eclipse.jdt.core.dom.TypeLiteral;
+import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
+import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
+import org.eclipse.jdt.internal.corext.dom.ASTNodes;
+
+import org.eclipse.text.edits.TextEditGroup;
+
+import org.sandbox.jdt.internal.corext.fix.helper.lib.JunitHolder;
+import org.sandbox.jdt.internal.corext.fix.helper.lib.TriggerPatternCleanupPlugin;
+import org.sandbox.jdt.internal.corext.util.AnnotationUtils;
+import org.sandbox.jdt.triggerpattern.api.CleanupPattern;
+import org.sandbox.jdt.triggerpattern.api.Match;
+import org.sandbox.jdt.triggerpattern.api.Pattern;
+import org.sandbox.jdt.triggerpattern.api.PatternKind;
+
+/**
+ * Coordinates migration of a JUnit 4 {@code @Test} annotation that declares
+ * both {@code expected} and {@code timeout}.
+ *
+ * <p>A single operation must own the annotation because the ordinary timeout
+ * and expected plugins deliberately share a processed-node set. Processing the
+ * attributes independently would either skip one migration or schedule
+ * conflicting replacements for the same annotation.</p>
+ */
+@CleanupPattern(value = "@Test(expected=$ex, timeout=$t)", kind = PatternKind.ANNOTATION,
+		qualifiedType = ORG_JUNIT_TEST, cleanupId = "cleanup.junit.test.expected-timeout",
+		description = "Migrate combined @Test(expected, timeout)",
+		displayName = "JUnit 4 @Test(expected, timeout) → assertThrows() and @Timeout")
+public class TestExpectedAndTimeoutJUnitPlugin extends TriggerPatternCleanupPlugin {
+
+	private record Parameters(MemberValuePair expected, MemberValuePair timeout) {
+	}
+
+	@Override
+	protected List<Pattern> getPatterns() {
+		return List.of(
+				new Pattern("@Test(expected=$ex, timeout=$t)", PatternKind.ANNOTATION, null, null, //$NON-NLS-1$
+						ORG_JUNIT_TEST, null, null),
+				new Pattern("@Test(timeout=$t, expected=$ex)", PatternKind.ANNOTATION, null, null, //$NON-NLS-1$
+						ORG_JUNIT_TEST, null, null));
+	}
+
+	@Override
+	protected JunitHolder createHolder(Match match) {
+		if (!(match.getMatchedNode() instanceof NormalAnnotation annotation)) {
+			return null;
+		}
+		MemberValuePair expected= pair(annotation, "expected"); //$NON-NLS-1$
+		MemberValuePair timeout= pair(annotation, "timeout"); //$NON-NLS-1$
+		if (expected == null || timeout == null || !(expected.getValue() instanceof TypeLiteral)
+				|| !(timeout.getValue() instanceof NumberLiteral number) || !isLong(number.getToken())) {
+			return null;
+		}
+		return new JunitHolder().setMinv(annotation).setAdditionalInfo(new Parameters(expected, timeout));
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	protected void process2Rewrite(TextEditGroup group, ASTRewrite rewriter, AST ast,
+			ImportRewrite importRewriter, JunitHolder junitHolder) {
+		if (!(junitHolder.getAnnotation() instanceof NormalAnnotation testAnnotation)
+				|| !(junitHolder.getAdditionalInfo() instanceof Parameters parameters)
+				|| !(parameters.expected().getValue() instanceof TypeLiteral expectedType)
+				|| !(parameters.timeout().getValue() instanceof NumberLiteral timeoutLiteral)) {
+			return;
+		}
+		MethodDeclaration method= ASTNodes.getParent(testAnnotation, MethodDeclaration.class);
+		Block methodBody= method == null ? null : method.getBody();
+		if (methodBody == null) {
+			return;
+		}
+		long timeoutMillis;
+		try {
+			timeoutMillis= Long.parseLong(timeoutLiteral.getToken());
+		} catch (NumberFormatException exception) {
+			return;
+		}
+
+		MethodInvocation assertThrows= ast.newMethodInvocation();
+		assertThrows.setName(ast.newSimpleName(METHOD_ASSERT_THROWS));
+		assertThrows.arguments().add(ASTNode.copySubtree(ast, expectedType));
+		LambdaExpression lambda= ast.newLambdaExpression();
+		lambda.setParentheses(true);
+		Block lambdaBody= ast.newBlock();
+		List<Statement> statements= methodBody.statements();
+		for (Statement statement : statements) {
+			lambdaBody.statements().add(ASTNode.copySubtree(ast, statement));
+		}
+		lambda.setBody(lambdaBody);
+		assertThrows.arguments().add(lambda);
+		ExpressionStatement assertion= ast.newExpressionStatement(assertThrows);
+		ListRewrite bodyRewrite= rewriter.getListRewrite(methodBody, Block.STATEMENTS_PROPERTY);
+		for (Statement statement : statements) {
+			bodyRewrite.remove(statement, group);
+		}
+		bodyRewrite.insertLast(assertion, group);
+
+		NormalAnnotation timeoutAnnotation= ast.newNormalAnnotation();
+		timeoutAnnotation.setTypeName(ast.newSimpleName(ANNOTATION_TIMEOUT));
+		MemberValuePair valuePair= ast.newMemberValuePair();
+		valuePair.setName(ast.newSimpleName("value")); //$NON-NLS-1$
+		boolean seconds= timeoutMillis >= 1000 && timeoutMillis % 1000 == 0;
+		valuePair.setValue(ast.newNumberLiteral(Long.toString(seconds ? timeoutMillis / 1000 : timeoutMillis)));
+		timeoutAnnotation.values().add(valuePair);
+		MemberValuePair unitPair= ast.newMemberValuePair();
+		unitPair.setName(ast.newSimpleName("unit")); //$NON-NLS-1$
+		QualifiedName unit= ast.newQualifiedName(ast.newSimpleName("TimeUnit"), //$NON-NLS-1$
+				ast.newSimpleName(seconds ? "SECONDS" : "MILLISECONDS")); //$NON-NLS-1$ //$NON-NLS-2$
+		unitPair.setValue(unit);
+		timeoutAnnotation.values().add(unitPair);
+		ListRewrite modifiers= rewriter.getListRewrite(method, MethodDeclaration.MODIFIERS2_PROPERTY);
+		modifiers.insertAfter(timeoutAnnotation, testAnnotation, group);
+
+		MarkerAnnotation markerTest= AnnotationUtils.createMarkerAnnotation(ast, ANNOTATION_TEST);
+		ASTNodes.replaceButKeepComment(rewriter, testAnnotation, markerTest, group);
+
+		importRewriter.removeImport(ORG_JUNIT_TEST);
+		importRewriter.addImport(ORG_JUNIT_JUPITER_TEST);
+		importRewriter.addImport(ORG_JUNIT_JUPITER_API_TIMEOUT);
+		importRewriter.addImport("java.util.concurrent.TimeUnit"); //$NON-NLS-1$
+		importRewriter.addStaticImport(ORG_JUNIT_JUPITER_API_ASSERTIONS, METHOD_ASSERT_THROWS, false);
+	}
+
+	private static MemberValuePair pair(NormalAnnotation annotation, String name) {
+		for (Object value : annotation.values()) {
+			MemberValuePair pair= (MemberValuePair) value;
+			if (name.equals(pair.getName().getIdentifier())) {
+				return pair;
+			}
+		}
+		return null;
+	}
+
+	private static boolean isLong(String token) {
+		try {
+			Long.parseLong(token);
+			return true;
+		} catch (NumberFormatException exception) {
+			return false;
+		}
+	}
+
+	@Override
+	public String getPreview(boolean afterRefactoring) {
+		return afterRefactoring
+				? "@Test\n@Timeout(value = 1, unit = TimeUnit.SECONDS)\nvoid test() { assertThrows(Exception.class, () -> work()); }" //$NON-NLS-1$
+				: "@Test(expected = Exception.class, timeout = 1000)\nvoid test() { work(); }"; //$NON-NLS-1$
+	}
+
+	@Override
+	public String toString() {
+		return "TestExpectedAndTimeout"; //$NON-NLS-1$
+	}
+}

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/TestExpectedAndTimeoutJUnitPlugin.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/TestExpectedAndTimeoutJUnitPlugin.java
@@ -69,11 +69,8 @@ public class TestExpectedAndTimeoutJUnitPlugin extends TriggerPatternCleanupPlug
 
 	@Override
 	protected List<Pattern> getPatterns() {
-		return List.of(
-				new Pattern("@Test(expected=$ex, timeout=$t)", PatternKind.ANNOTATION, null, null, //$NON-NLS-1$
-						ORG_JUNIT_TEST, null, null),
-				new Pattern("@Test(timeout=$t, expected=$ex)", PatternKind.ANNOTATION, null, null, //$NON-NLS-1$
-						ORG_JUNIT_TEST, null, null));
+		return List.of(new Pattern("@Test(expected=$ex, timeout=$t)", PatternKind.ANNOTATION, null, null, //$NON-NLS-1$
+				ORG_JUNIT_TEST, null, null));
 	}
 
 	@Override

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/TestExpectedJUnitPlugin.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/TestExpectedJUnitPlugin.java
@@ -20,7 +20,6 @@ import java.util.List;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.Block;
-import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.ExpressionStatement;
 import org.eclipse.jdt.core.dom.LambdaExpression;
 import org.eclipse.jdt.core.dom.MarkerAnnotation;

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/TestExpectedJUnitPlugin.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/TestExpectedJUnitPlugin.java
@@ -41,31 +41,7 @@ import org.sandbox.jdt.triggerpattern.api.CleanupPattern;
 import org.sandbox.jdt.triggerpattern.api.Match;
 import org.sandbox.jdt.triggerpattern.api.PatternKind;
 
-/**
- * Plugin to migrate JUnit 4 @Test(expected=...) to JUnit 5 assertThrows().
- * 
- * Transforms:
- * 
- * <pre>
- * {@literal @}Test(expected = IllegalArgumentException.class)
- * public void testException() {
- *     // code that throws
- * }
- * </pre>
- * 
- * To:
- * 
- * <pre>
- * {@literal @}Test
- * public void testException() {
- *     assertThrows(IllegalArgumentException.class, () -> {
- *         // code that throws
- *     });
- * }
- * </pre>
- * 
- * @since 1.3.0
- */
+/** Plugin to migrate JUnit 4 {@code @Test(expected=...)} to assertThrows(). */
 @CleanupPattern(value = "@Test(expected=$ex)", kind = PatternKind.ANNOTATION, qualifiedType = ORG_JUNIT_TEST, cleanupId = "cleanup.junit.test.expected", description = "Migrate @Test(expected=...) to assertThrows()", displayName = "JUnit 4 @Test(expected) → JUnit 5 assertThrows()")
 public class TestExpectedJUnitPlugin extends TriggerPatternCleanupPlugin {
 
@@ -79,9 +55,12 @@ public class TestExpectedJUnitPlugin extends TriggerPatternCleanupPlugin {
 		MemberValuePair expectedPair = null;
 		for (Object obj : annotation.values()) {
 			MemberValuePair pair = (MemberValuePair) obj;
-			if ("expected".equals(pair.getName().getIdentifier())) { //$NON-NLS-1$
+			String name= pair.getName().getIdentifier();
+			if ("timeout".equals(name)) { //$NON-NLS-1$
+				return null;
+			}
+			if ("expected".equals(name)) { //$NON-NLS-1$
 				expectedPair = pair;
-				break;
 			}
 		}
 		if (expectedPair == null || !(expectedPair.getValue() instanceof TypeLiteral)) {
@@ -98,92 +77,46 @@ public class TestExpectedJUnitPlugin extends TriggerPatternCleanupPlugin {
 			JunitHolder junitHolder) {
 		NormalAnnotation testAnnotation = (NormalAnnotation) junitHolder.getAnnotation();
 		MemberValuePair expectedPair = (MemberValuePair) junitHolder.getAdditionalInfo();
-
-		if (expectedPair == null) {
+		if (expectedPair == null || !(expectedPair.getValue() instanceof TypeLiteral expectedTypeLiteral)) {
 			return;
 		}
-
-		Expression expectedValue = expectedPair.getValue();
-		if (!(expectedValue instanceof TypeLiteral)) {
-			// Can't handle non-TypeLiteral expected values
-			return;
-		}
-
-		TypeLiteral expectedTypeLiteral = (TypeLiteral) expectedValue;
-
-		// Get the method declaration
 		MethodDeclaration method = ASTNodes.getParent(testAnnotation, MethodDeclaration.class);
-		if (method == null) {
+		if (method == null || method.getBody() == null) {
 			return;
 		}
-
 		Block methodBody = method.getBody();
-		if (methodBody == null) {
-			return;
-		}
-
 		List<Statement> statements = methodBody.statements();
-
-		// Create assertThrows method invocation
 		MethodInvocation assertThrowsCall = ast.newMethodInvocation();
 		assertThrowsCall.setName(ast.newSimpleName(METHOD_ASSERT_THROWS));
-
-		// Add the exception class as the first argument
 		TypeLiteral exceptionClass = (TypeLiteral) ASTNode.copySubtree(ast, expectedTypeLiteral);
 		assertThrowsCall.arguments().add(exceptionClass);
-
-		// Create lambda expression for the method body
 		LambdaExpression lambda = ast.newLambdaExpression();
 		lambda.setParentheses(true);
-
 		Block lambdaBody = ast.newBlock();
-
-		// Copy all statements from the original method body into the lambda
 		for (Statement stmt : statements) {
 			Statement copiedStmt = (Statement) ASTNode.copySubtree(ast, stmt);
 			lambdaBody.statements().add(copiedStmt);
 		}
-
 		lambda.setBody(lambdaBody);
 		assertThrowsCall.arguments().add(lambda);
-
-		// Create the new expression statement with assertThrows
 		ExpressionStatement assertThrowsStatement = ast.newExpressionStatement(assertThrowsCall);
-
-		// Remove all existing statements from the method body
 		for (int i = statements.size() - 1; i >= 0; i--) {
 			rewriter.remove(statements.get(i), group);
 		}
-
-		// Add the assertThrows statement as the only statement in the method
 		rewriter.getListRewrite(methodBody, Block.STATEMENTS_PROPERTY).insertLast(assertThrowsStatement, group);
-
-		// Remove the expected parameter from @Test annotation
-		// If expected is the only parameter remaining, replace with marker annotation
 		List<MemberValuePair> testValues = testAnnotation.values();
-
-		// Count how many parameters will remain after removing expected
-		// (need to account for other parameters that might be removed by other plugins
-		// like timeout)
 		int remainingParams = 0;
 		for (MemberValuePair pair : testValues) {
-			String paramName = pair.getName().getIdentifier();
-			// Count parameters that are not expected and not timeout (which is handled by
-			// TestTimeoutJUnitPlugin)
-			if (!"expected".equals(paramName) && !"timeout".equals(paramName)) {
+			if (!"expected".equals(pair.getName().getIdentifier())) { //$NON-NLS-1$
 				remainingParams++;
 			}
 		}
-
 		if (remainingParams == 0) {
-			// No other meaningful parameters remain, convert to marker annotation @Test
 			MarkerAnnotation markerTestAnnotation = AnnotationUtils.createMarkerAnnotation(ast, ANNOTATION_TEST);
 			ASTNodes.replaceButKeepComment(rewriter, testAnnotation, markerTestAnnotation, group);
 		} else {
 			rewriter.remove(expectedPair, group);
 		}
-
-		// Add imports - order matters: remove old import first, then add new imports
 		importRewriter.removeImport(ORG_JUNIT_TEST);
 		importRewriter.addImport(ORG_JUNIT_JUPITER_TEST);
 		importRewriter.addStaticImport(ORG_JUNIT_JUPITER_API_ASSERTIONS, METHOD_ASSERT_THROWS, false);

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/TestExpectedJUnitPlugin.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/TestExpectedJUnitPlugin.java
@@ -20,6 +20,7 @@ import java.util.List;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.Block;
+import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.ExpressionStatement;
 import org.eclipse.jdt.core.dom.LambdaExpression;
 import org.eclipse.jdt.core.dom.MarkerAnnotation;
@@ -40,7 +41,31 @@ import org.sandbox.jdt.triggerpattern.api.CleanupPattern;
 import org.sandbox.jdt.triggerpattern.api.Match;
 import org.sandbox.jdt.triggerpattern.api.PatternKind;
 
-/** Plugin to migrate JUnit 4 {@code @Test(expected=...)} to assertThrows(). */
+/**
+ * Plugin to migrate JUnit 4 @Test(expected=...) to JUnit 5 assertThrows().
+ * 
+ * Transforms:
+ * 
+ * <pre>
+ * {@literal @}Test(expected = IllegalArgumentException.class)
+ * public void testException() {
+ *     // code that throws
+ * }
+ * </pre>
+ * 
+ * To:
+ * 
+ * <pre>
+ * {@literal @}Test
+ * public void testException() {
+ *     assertThrows(IllegalArgumentException.class, () -> {
+ *         // code that throws
+ *     });
+ * }
+ * </pre>
+ * 
+ * @since 1.3.0
+ */
 @CleanupPattern(value = "@Test(expected=$ex)", kind = PatternKind.ANNOTATION, qualifiedType = ORG_JUNIT_TEST, cleanupId = "cleanup.junit.test.expected", description = "Migrate @Test(expected=...) to assertThrows()", displayName = "JUnit 4 @Test(expected) → JUnit 5 assertThrows()")
 public class TestExpectedJUnitPlugin extends TriggerPatternCleanupPlugin {
 
@@ -54,11 +79,11 @@ public class TestExpectedJUnitPlugin extends TriggerPatternCleanupPlugin {
 		MemberValuePair expectedPair = null;
 		for (Object obj : annotation.values()) {
 			MemberValuePair pair = (MemberValuePair) obj;
-			String name= pair.getName().getIdentifier();
-			if ("timeout".equals(name)) { //$NON-NLS-1$
+			String parameterName = pair.getName().getIdentifier();
+			if ("timeout".equals(parameterName)) { //$NON-NLS-1$
 				return null;
 			}
-			if ("expected".equals(name)) { //$NON-NLS-1$
+			if ("expected".equals(parameterName)) { //$NON-NLS-1$
 				expectedPair = pair;
 			}
 		}
@@ -76,46 +101,92 @@ public class TestExpectedJUnitPlugin extends TriggerPatternCleanupPlugin {
 			JunitHolder junitHolder) {
 		NormalAnnotation testAnnotation = (NormalAnnotation) junitHolder.getAnnotation();
 		MemberValuePair expectedPair = (MemberValuePair) junitHolder.getAdditionalInfo();
-		if (expectedPair == null || !(expectedPair.getValue() instanceof TypeLiteral expectedTypeLiteral)) {
+
+		if (expectedPair == null) {
 			return;
 		}
+
+		Expression expectedValue = expectedPair.getValue();
+		if (!(expectedValue instanceof TypeLiteral)) {
+			// Can't handle non-TypeLiteral expected values
+			return;
+		}
+
+		TypeLiteral expectedTypeLiteral = (TypeLiteral) expectedValue;
+
+		// Get the method declaration
 		MethodDeclaration method = ASTNodes.getParent(testAnnotation, MethodDeclaration.class);
-		if (method == null || method.getBody() == null) {
+		if (method == null) {
 			return;
 		}
+
 		Block methodBody = method.getBody();
+		if (methodBody == null) {
+			return;
+		}
+
 		List<Statement> statements = methodBody.statements();
+
+		// Create assertThrows method invocation
 		MethodInvocation assertThrowsCall = ast.newMethodInvocation();
 		assertThrowsCall.setName(ast.newSimpleName(METHOD_ASSERT_THROWS));
+
+		// Add the exception class as the first argument
 		TypeLiteral exceptionClass = (TypeLiteral) ASTNode.copySubtree(ast, expectedTypeLiteral);
 		assertThrowsCall.arguments().add(exceptionClass);
+
+		// Create lambda expression for the method body
 		LambdaExpression lambda = ast.newLambdaExpression();
 		lambda.setParentheses(true);
+
 		Block lambdaBody = ast.newBlock();
+
+		// Copy all statements from the original method body into the lambda
 		for (Statement stmt : statements) {
 			Statement copiedStmt = (Statement) ASTNode.copySubtree(ast, stmt);
 			lambdaBody.statements().add(copiedStmt);
 		}
+
 		lambda.setBody(lambdaBody);
 		assertThrowsCall.arguments().add(lambda);
+
+		// Create the new expression statement with assertThrows
 		ExpressionStatement assertThrowsStatement = ast.newExpressionStatement(assertThrowsCall);
+
+		// Remove all existing statements from the method body
 		for (int i = statements.size() - 1; i >= 0; i--) {
 			rewriter.remove(statements.get(i), group);
 		}
+
+		// Add the assertThrows statement as the only statement in the method
 		rewriter.getListRewrite(methodBody, Block.STATEMENTS_PROPERTY).insertLast(assertThrowsStatement, group);
+
+		// Remove the expected parameter from @Test annotation
+		// If expected is the only parameter remaining, replace with marker annotation
 		List<MemberValuePair> testValues = testAnnotation.values();
+
+		// Count how many parameters will remain after removing expected
+		// (need to account for other parameters that might be removed by other plugins
+		// like timeout)
 		int remainingParams = 0;
 		for (MemberValuePair pair : testValues) {
-			if (!"expected".equals(pair.getName().getIdentifier())) { //$NON-NLS-1$
+			String paramName = pair.getName().getIdentifier();
+			// Count parameters that are not expected and not timeout (which is handled by
+			// TestTimeoutJUnitPlugin)
+			if (!"expected".equals(paramName) && !"timeout".equals(paramName)) {
 				remainingParams++;
 			}
 		}
+
 		if (remainingParams == 0) {
+			// No other meaningful parameters remain, convert to marker annotation @Test
 			MarkerAnnotation markerTestAnnotation = AnnotationUtils.createMarkerAnnotation(ast, ANNOTATION_TEST);
 			ASTNodes.replaceButKeepComment(rewriter, testAnnotation, markerTestAnnotation, group);
 		} else {
 			rewriter.remove(expectedPair, group);
 		}
+
+		// Add imports - order matters: remove old import first, then add new imports
 		importRewriter.removeImport(ORG_JUNIT_TEST);
 		importRewriter.addImport(ORG_JUNIT_JUPITER_TEST);
 		importRewriter.addStaticImport(ORG_JUNIT_JUPITER_API_ASSERTIONS, METHOD_ASSERT_THROWS, false);

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/TestTimeoutJUnitPlugin.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/TestTimeoutJUnitPlugin.java
@@ -38,11 +38,7 @@ import org.sandbox.jdt.triggerpattern.api.CleanupPattern;
 import org.sandbox.jdt.triggerpattern.api.Match;
 import org.sandbox.jdt.triggerpattern.api.PatternKind;
 
-/**
- * Plugin to migrate JUnit 4 @Test(timeout=...) to JUnit 5 @Timeout.
- * 
- * @since 1.3.0
- */
+/** Plugin to migrate JUnit 4 {@code @Test(timeout=...)} to JUnit 5 {@code @Timeout}. */
 @CleanupPattern(value = "@Test(timeout=$t)", kind = PatternKind.ANNOTATION, qualifiedType = ORG_JUNIT_TEST, cleanupId = "cleanup.junit.test.timeout", description = "Migrate @Test(timeout=...) to @Timeout", displayName = "JUnit 4 @Test(timeout) → JUnit 5 @Timeout")
 public class TestTimeoutJUnitPlugin extends TriggerPatternCleanupPlugin {
 
@@ -56,21 +52,20 @@ public class TestTimeoutJUnitPlugin extends TriggerPatternCleanupPlugin {
 		MemberValuePair timeoutPair = null;
 		for (Object obj : annotation.values()) {
 			MemberValuePair pair = (MemberValuePair) obj;
-			if ("timeout".equals(pair.getName().getIdentifier())) { //$NON-NLS-1$
+			String name= pair.getName().getIdentifier();
+			if ("expected".equals(name)) { //$NON-NLS-1$
+				return null;
+			}
+			if ("timeout".equals(name)) { //$NON-NLS-1$
 				timeoutPair = pair;
-				break;
 			}
 		}
-		if (timeoutPair == null) {
-			return null;
-		}
-		Expression value = timeoutPair.getValue();
-		if (!(value instanceof NumberLiteral)) {
+		if (timeoutPair == null || !(timeoutPair.getValue() instanceof NumberLiteral number)) {
 			return null;
 		}
 		try {
-			Long.parseLong(((NumberLiteral) value).getToken());
-		} catch (NumberFormatException e) {
+			Long.parseLong(number.getToken());
+		} catch (NumberFormatException exception) {
 			return null;
 		}
 		JunitHolder holder = new JunitHolder();
@@ -84,69 +79,34 @@ public class TestTimeoutJUnitPlugin extends TriggerPatternCleanupPlugin {
 			JunitHolder junitHolder) {
 		NormalAnnotation testAnnotation = (NormalAnnotation) junitHolder.getAnnotation();
 		MemberValuePair timeoutPair = (MemberValuePair) junitHolder.getAdditionalInfo();
-
-		if (timeoutPair == null) {
+		if (timeoutPair == null || !(timeoutPair.getValue() instanceof NumberLiteral timeoutValue)) {
 			return;
 		}
-
-		Expression timeoutValue = timeoutPair.getValue();
-		if (!(timeoutValue instanceof NumberLiteral)) {
-			return;
-		}
-
 		final long timeoutMillis;
 		try {
-			timeoutMillis = Long.parseLong(((NumberLiteral) timeoutValue).getToken());
-		} catch (NumberFormatException e) {
-			// Malformed timeout value, skip refactoring for this method
+			timeoutMillis = Long.parseLong(timeoutValue.getToken());
+		} catch (NumberFormatException exception) {
 			return;
 		}
-
-		// Determine the best time unit (optimize for readability)
-		// Use SECONDS if the value is >= 1000ms and evenly divisible by 1000
-		// This makes the timeout more readable (e.g., "5 seconds" vs "5000
-		// milliseconds")
-		long timeout;
-		String timeUnit;
-		if (timeoutMillis % 1000 == 0 && timeoutMillis >= 1000) {
-			// Use SECONDS for better readability (e.g., 1 second instead of 1000
-			// milliseconds)
-			timeout = timeoutMillis / 1000;
-			timeUnit = "SECONDS";
-		} else {
-			// Use MILLISECONDS for values < 1000ms or not evenly divisible by 1000
-			timeout = timeoutMillis;
-			timeUnit = "MILLISECONDS";
-		}
-
-		// Create @Timeout annotation
+		boolean seconds = timeoutMillis % 1000 == 0 && timeoutMillis >= 1000;
+		long timeout = seconds ? timeoutMillis / 1000 : timeoutMillis;
+		String timeUnit = seconds ? "SECONDS" : "MILLISECONDS"; //$NON-NLS-1$ //$NON-NLS-2$
 		NormalAnnotation timeoutAnnotation = ast.newNormalAnnotation();
 		timeoutAnnotation.setTypeName(ast.newSimpleName(ANNOTATION_TIMEOUT));
-
-		// Add value parameter
 		MemberValuePair valuePair = ast.newMemberValuePair();
-		valuePair.setName(ast.newSimpleName("value"));
+		valuePair.setName(ast.newSimpleName("value")); //$NON-NLS-1$
 		valuePair.setValue(ast.newNumberLiteral(String.valueOf(timeout)));
 		timeoutAnnotation.values().add(valuePair);
-
-		// Add unit parameter
 		MemberValuePair unitPair = ast.newMemberValuePair();
-		unitPair.setName(ast.newSimpleName("unit"));
-		QualifiedName timeUnitName = ast.newQualifiedName(ast.newSimpleName("TimeUnit"), ast.newSimpleName(timeUnit));
+		unitPair.setName(ast.newSimpleName("unit")); //$NON-NLS-1$
+		QualifiedName timeUnitName = ast.newQualifiedName(ast.newSimpleName("TimeUnit"), ast.newSimpleName(timeUnit)); //$NON-NLS-1$
 		unitPair.setValue(timeUnitName);
 		timeoutAnnotation.values().add(unitPair);
-
-		// Add the @Timeout annotation to the method (after @Test)
 		MethodDeclaration method = ASTNodes.getParent(testAnnotation, MethodDeclaration.class);
 		if (method != null) {
 			ListRewrite listRewrite = rewriter.getListRewrite(method, MethodDeclaration.MODIFIERS2_PROPERTY);
 			listRewrite.insertAfter(timeoutAnnotation, testAnnotation, group);
 		}
-
-		// Remove the timeout parameter from @Test annotation
-		// If the timeout is the only parameter, replace the NormalAnnotation with a
-		// MarkerAnnotation
-		// to avoid leaving an empty @Test() annotation.
 		List<MemberValuePair> testValues = testAnnotation.values();
 		if (testValues.size() == 1 && testValues.get(0) == timeoutPair) {
 			MarkerAnnotation markerTestAnnotation = AnnotationUtils.createMarkerAnnotation(ast, ANNOTATION_TEST);
@@ -154,12 +114,10 @@ public class TestTimeoutJUnitPlugin extends TriggerPatternCleanupPlugin {
 		} else {
 			rewriter.remove(timeoutPair, group);
 		}
-
-		// Add imports - order matters: remove old import first, then add new imports
 		importRewriter.removeImport(ORG_JUNIT_TEST);
 		importRewriter.addImport(ORG_JUNIT_JUPITER_TEST);
 		importRewriter.addImport(ORG_JUNIT_JUPITER_API_TIMEOUT);
-		importRewriter.addImport("java.util.concurrent.TimeUnit");
+		importRewriter.addImport("java.util.concurrent.TimeUnit"); //$NON-NLS-1$
 	}
 
 	@Override

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/TestTimeoutJUnitPlugin.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/TestTimeoutJUnitPlugin.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.MarkerAnnotation;
 import org.eclipse.jdt.core.dom.MemberValuePair;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
@@ -37,7 +38,11 @@ import org.sandbox.jdt.triggerpattern.api.CleanupPattern;
 import org.sandbox.jdt.triggerpattern.api.Match;
 import org.sandbox.jdt.triggerpattern.api.PatternKind;
 
-/** Plugin to migrate JUnit 4 {@code @Test(timeout=...)} to JUnit 5 {@code @Timeout}. */
+/**
+ * Plugin to migrate JUnit 4 @Test(timeout=...) to JUnit 5 @Timeout.
+ * 
+ * @since 1.3.0
+ */
 @CleanupPattern(value = "@Test(timeout=$t)", kind = PatternKind.ANNOTATION, qualifiedType = ORG_JUNIT_TEST, cleanupId = "cleanup.junit.test.timeout", description = "Migrate @Test(timeout=...) to @Timeout", displayName = "JUnit 4 @Test(timeout) → JUnit 5 @Timeout")
 public class TestTimeoutJUnitPlugin extends TriggerPatternCleanupPlugin {
 
@@ -51,20 +56,24 @@ public class TestTimeoutJUnitPlugin extends TriggerPatternCleanupPlugin {
 		MemberValuePair timeoutPair = null;
 		for (Object obj : annotation.values()) {
 			MemberValuePair pair = (MemberValuePair) obj;
-			String name= pair.getName().getIdentifier();
-			if ("expected".equals(name)) { //$NON-NLS-1$
+			String parameterName = pair.getName().getIdentifier();
+			if ("expected".equals(parameterName)) { //$NON-NLS-1$
 				return null;
 			}
-			if ("timeout".equals(name)) { //$NON-NLS-1$
+			if ("timeout".equals(parameterName)) { //$NON-NLS-1$
 				timeoutPair = pair;
 			}
 		}
-		if (timeoutPair == null || !(timeoutPair.getValue() instanceof NumberLiteral number)) {
+		if (timeoutPair == null) {
+			return null;
+		}
+		Expression value = timeoutPair.getValue();
+		if (!(value instanceof NumberLiteral)) {
 			return null;
 		}
 		try {
-			Long.parseLong(number.getToken());
-		} catch (NumberFormatException exception) {
+			Long.parseLong(((NumberLiteral) value).getToken());
+		} catch (NumberFormatException e) {
 			return null;
 		}
 		JunitHolder holder = new JunitHolder();
@@ -78,34 +87,69 @@ public class TestTimeoutJUnitPlugin extends TriggerPatternCleanupPlugin {
 			JunitHolder junitHolder) {
 		NormalAnnotation testAnnotation = (NormalAnnotation) junitHolder.getAnnotation();
 		MemberValuePair timeoutPair = (MemberValuePair) junitHolder.getAdditionalInfo();
-		if (timeoutPair == null || !(timeoutPair.getValue() instanceof NumberLiteral timeoutValue)) {
+
+		if (timeoutPair == null) {
 			return;
 		}
+
+		Expression timeoutValue = timeoutPair.getValue();
+		if (!(timeoutValue instanceof NumberLiteral)) {
+			return;
+		}
+
 		final long timeoutMillis;
 		try {
-			timeoutMillis = Long.parseLong(timeoutValue.getToken());
-		} catch (NumberFormatException exception) {
+			timeoutMillis = Long.parseLong(((NumberLiteral) timeoutValue).getToken());
+		} catch (NumberFormatException e) {
+			// Malformed timeout value, skip refactoring for this method
 			return;
 		}
-		boolean seconds = timeoutMillis % 1000 == 0 && timeoutMillis >= 1000;
-		long timeout = seconds ? timeoutMillis / 1000 : timeoutMillis;
-		String timeUnit = seconds ? "SECONDS" : "MILLISECONDS"; //$NON-NLS-1$ //$NON-NLS-2$
+
+		// Determine the best time unit (optimize for readability)
+		// Use SECONDS if the value is >= 1000ms and evenly divisible by 1000
+		// This makes the timeout more readable (e.g., "5 seconds" vs "5000
+		// milliseconds")
+		long timeout;
+		String timeUnit;
+		if (timeoutMillis % 1000 == 0 && timeoutMillis >= 1000) {
+			// Use SECONDS for better readability (e.g., 1 second instead of 1000
+			// milliseconds)
+			timeout = timeoutMillis / 1000;
+			timeUnit = "SECONDS";
+		} else {
+			// Use MILLISECONDS for values < 1000ms or not evenly divisible by 1000
+			timeout = timeoutMillis;
+			timeUnit = "MILLISECONDS";
+		}
+
+		// Create @Timeout annotation
 		NormalAnnotation timeoutAnnotation = ast.newNormalAnnotation();
 		timeoutAnnotation.setTypeName(ast.newSimpleName(ANNOTATION_TIMEOUT));
+
+		// Add value parameter
 		MemberValuePair valuePair = ast.newMemberValuePair();
-		valuePair.setName(ast.newSimpleName("value")); //$NON-NLS-1$
+		valuePair.setName(ast.newSimpleName("value"));
 		valuePair.setValue(ast.newNumberLiteral(String.valueOf(timeout)));
 		timeoutAnnotation.values().add(valuePair);
+
+		// Add unit parameter
 		MemberValuePair unitPair = ast.newMemberValuePair();
-		unitPair.setName(ast.newSimpleName("unit")); //$NON-NLS-1$
-		QualifiedName timeUnitName = ast.newQualifiedName(ast.newSimpleName("TimeUnit"), ast.newSimpleName(timeUnit)); //$NON-NLS-1$
+		unitPair.setName(ast.newSimpleName("unit"));
+		QualifiedName timeUnitName = ast.newQualifiedName(ast.newSimpleName("TimeUnit"), ast.newSimpleName(timeUnit));
 		unitPair.setValue(timeUnitName);
 		timeoutAnnotation.values().add(unitPair);
+
+		// Add the @Timeout annotation to the method (after @Test)
 		MethodDeclaration method = ASTNodes.getParent(testAnnotation, MethodDeclaration.class);
 		if (method != null) {
 			ListRewrite listRewrite = rewriter.getListRewrite(method, MethodDeclaration.MODIFIERS2_PROPERTY);
 			listRewrite.insertAfter(timeoutAnnotation, testAnnotation, group);
 		}
+
+		// Remove the timeout parameter from @Test annotation
+		// If the timeout is the only parameter, replace the NormalAnnotation with a
+		// MarkerAnnotation
+		// to avoid leaving an empty @Test() annotation.
 		List<MemberValuePair> testValues = testAnnotation.values();
 		if (testValues.size() == 1 && testValues.get(0) == timeoutPair) {
 			MarkerAnnotation markerTestAnnotation = AnnotationUtils.createMarkerAnnotation(ast, ANNOTATION_TEST);
@@ -113,10 +157,12 @@ public class TestTimeoutJUnitPlugin extends TriggerPatternCleanupPlugin {
 		} else {
 			rewriter.remove(timeoutPair, group);
 		}
+
+		// Add imports - order matters: remove old import first, then add new imports
 		importRewriter.removeImport(ORG_JUNIT_TEST);
 		importRewriter.addImport(ORG_JUNIT_JUPITER_TEST);
 		importRewriter.addImport(ORG_JUNIT_JUPITER_API_TIMEOUT);
-		importRewriter.addImport("java.util.concurrent.TimeUnit"); //$NON-NLS-1$
+		importRewriter.addImport("java.util.concurrent.TimeUnit");
 	}
 
 	@Override

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/TestTimeoutJUnitPlugin.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/TestTimeoutJUnitPlugin.java
@@ -19,7 +19,6 @@ import java.util.List;
 
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
-import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.MarkerAnnotation;
 import org.eclipse.jdt.core.dom.MemberValuePair;
 import org.eclipse.jdt.core.dom.MethodDeclaration;

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/ui/fix/JUnitCleanUpCore.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/ui/fix/JUnitCleanUpCore.java
@@ -237,12 +237,17 @@ public class JUnitCleanUpCore extends AbstractPlannedMultiFileCleanUp<JUnitMigra
 				fixSetCombined.remove(fix);
 			}
 		});
+		if (isEnabled(MYCleanUpConstants.JUNIT_CLEANUP_4_TEST_EXPECTED)
+				&& isEnabled(MYCleanUpConstants.JUNIT_CLEANUP_4_TEST_TIMEOUT)) {
+			fixSetCombined.add(JUnitCleanUpFixCore.TEST_EXPECTED_TIMEOUT);
+		}
 		return fixSetCombined;
 	}
 
 	private EnumSet<JUnitCleanUpFixCore> allOfJunit4() {
 		EnumSet<JUnitCleanUpFixCore> allOf= EnumSet.allOf(JUnitCleanUpFixCore.class);
 		allOf.remove(JUnitCleanUpFixCore.TEST3);
+		allOf.remove(JUnitCleanUpFixCore.TEST_EXPECTED_TIMEOUT);
 		return allOf;
 	}
 

--- a/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/CombinedExpectedTimeoutMigrationTest.java
+++ b/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/CombinedExpectedTimeoutMigrationTest.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.quickfix.Java8;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.junit.JUnitCore;
+
+import org.sandbox.jdt.internal.corext.fix2.MYCleanUpConstants;
+import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
+import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava17;
+
+/** Tests coordinated migration of the two JUnit 4 {@code @Test} attributes. */
+public class CombinedExpectedTimeoutMigrationTest {
+
+	@RegisterExtension
+	AbstractEclipseJava context= new EclipseJava17();
+
+	private IPackageFragmentRoot root;
+
+	@BeforeEach
+	public void setup() throws CoreException {
+		root= context.createClasspathForJUnit(JUnitCore.JUNIT4_CONTAINER_PATH);
+	}
+
+	@Test
+	public void migratesExpectedThenTimeoutAtomically() throws CoreException {
+		assertCombinedMigration("expected = IllegalArgumentException.class, timeout = 1000"); //$NON-NLS-1$
+	}
+
+	@Test
+	public void migratesTimeoutThenExpectedAtomically() throws CoreException {
+		assertCombinedMigration("timeout = 1000, expected = IllegalArgumentException.class"); //$NON-NLS-1$
+	}
+
+	@Test
+	public void refusesPartialMigrationWhenOnlyExpectedIsEnabled() throws CoreException {
+		ICompilationUnit unit= createTest("expected = IllegalArgumentException.class, timeout = 1000"); //$NON-NLS-1$
+		context.enable(MYCleanUpConstants.JUNIT_CLEANUP);
+		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_4_TEST_EXPECTED);
+
+		context.assertRefactoringHasNoChange(new ICompilationUnit[] { unit });
+	}
+
+	@Test
+	public void refusesPartialMigrationWhenOnlyTimeoutIsEnabled() throws CoreException {
+		ICompilationUnit unit= createTest("expected = IllegalArgumentException.class, timeout = 1000"); //$NON-NLS-1$
+		context.enable(MYCleanUpConstants.JUNIT_CLEANUP);
+		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_4_TEST_TIMEOUT);
+
+		context.assertRefactoringHasNoChange(new ICompilationUnit[] { unit });
+	}
+
+	private void assertCombinedMigration(String attributes) throws CoreException {
+		ICompilationUnit unit= createTest(attributes);
+		context.enable(MYCleanUpConstants.JUNIT_CLEANUP);
+		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_4_TEST);
+		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_4_TEST_EXPECTED);
+		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_4_TEST_TIMEOUT);
+
+		context.assertRefactoringResultAsExpected(new ICompilationUnit[] { unit }, new String[] {
+				"""
+				package test;
+				import static org.junit.jupiter.api.Assertions.assertThrows;
+
+				import java.util.concurrent.TimeUnit;
+
+				import org.junit.jupiter.api.Test;
+				import org.junit.jupiter.api.Timeout;
+
+				public class MyTest {
+					@Test
+					@Timeout(value = 1, unit = TimeUnit.SECONDS)
+					public void testBoth() {
+						assertThrows(IllegalArgumentException.class, () -> {
+							throw new IllegalArgumentException("Expected");
+						});
+					}
+				}
+				""" }, null);
+	}
+
+	private ICompilationUnit createTest(String attributes) throws CoreException {
+		IPackageFragment pack= root.createPackageFragment("test", true, null); //$NON-NLS-1$
+		return pack.createCompilationUnit("MyTest.java", //$NON-NLS-1$
+				"""
+				package test;
+				import org.junit.Test;
+
+				public class MyTest {
+					@Test(__ATTRIBUTES__)
+					public void testBoth() {
+						throw new IllegalArgumentException("Expected");
+					}
+				}
+				""".replace("__ATTRIBUTES__", attributes), false, null); //$NON-NLS-1$
+	}
+}

--- a/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/MigrationEdgeCasesTest.java
+++ b/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/MigrationEdgeCasesTest.java
@@ -19,7 +19,6 @@ import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.junit.JUnitCore;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.sandbox.jdt.internal.corext.fix2.MYCleanUpConstants;
@@ -47,7 +46,6 @@ public class MigrationEdgeCasesTest {
 		fRoot = context.createClasspathForJUnit(JUnitCore.JUNIT4_CONTAINER_PATH);
 	}
 
-	@Disabled("Combined @Test(expected + timeout) transformation not yet implemented - both parameters need simultaneous migration")
 	@Test
 	public void handles_combined_test_expected_and_timeout() throws CoreException {
 		IPackageFragment pack = fRoot.createPackageFragment("test", true, null); //$NON-NLS-1$

--- a/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/MigrationTestAnnotationTest.java
+++ b/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/MigrationTestAnnotationTest.java
@@ -19,7 +19,6 @@ import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.junit.JUnitCore;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.sandbox.jdt.internal.corext.fix2.MYCleanUpConstants;
@@ -294,12 +293,8 @@ public class MigrationTestAnnotationTest {
 		}, null);
 	}
 
-	@Disabled("Combined @Test(expected + timeout) transformation not yet implemented - both parameters need simultaneous migration")
 	@Test
 	public void migrates_test_timeout_with_other_parameters() throws CoreException {
-		// This test verifies that both timeout and expected parameters are migrated correctly.
-		// The timeout parameter is migrated to @Timeout annotation by TestTimeoutJUnitPlugin.
-		// The expected parameter is migrated to assertThrows() by TestExpectedJUnitPlugin.
 		IPackageFragment pack = fRoot.createPackageFragment("test", true, null);
 		ICompilationUnit cu = pack.createCompilationUnit("MyTest.java",
 				"""


### PR DESCRIPTION
## Problem

JUnit 4 allows `@Test(expected = ..., timeout = ...)`. The existing timeout and expected plugins operate independently but share the same processed-node set. Whichever plugin claims the normal annotation first prevents the other attribute from being migrated.

A partial migration is unsafe: converting only `expected` or only `timeout` changes the annotation while silently dropping or retaining incompatible JUnit 4 semantics.

## Change

- add a coordinated `TestExpectedAndTimeoutJUnitPlugin` that owns annotations containing both attributes;
- support both source orders: `expected, timeout` and `timeout, expected`;
- replace the original body with `assertThrows(Exception.class, () -> { ... })`;
- add Jupiter `@Timeout` using seconds for exact whole-second values and milliseconds otherwise;
- run the combined plugin before the individual expected/timeout plugins;
- enable it only when both cleanup options are selected;
- make the individual plugins reject annotations that contain the other attribute, preventing half migrations;
- add active tests for both attribute orders and for both partial-option rejection paths;
- re-enable both existing combined-attribute regression tests in `MigrationEdgeCasesTest` and `MigrationTestAnnotationTest`.

## Safety

The transformation is atomic at the AST-operation level: one plugin owns the annotation, method-body rewrite and imports. Unsupported non-literal timeout or expected values are rejected without changes.

## Verification

The canonical Maven, CodeQL, Codacy and distribution workflows are required before merge.

Refs #1217