### PR TITLE
Classify cleanup impact and enforce enum compatibility

### DIFF
--- a/docs/adr/0001-int-enum-compatibility-and-cleanup-impact.md
+++ b/docs/adr/0001-int-enum-compatibility-and-cleanup-impact.md
@@ -1,0 +1,67 @@
+# ADR 0001: Integer-domain migration compatibility and cleanup impact
+
+- **Status:** Accepted
+- **Date:** 2026-07-27
+- **Issues:** #1216, #1223, #1226
+
+## Context
+
+A local syntax cleanup and a coordinated signature/type migration do not make the same safety claim. The integer-to-enum cleanup currently supports only package-private source domains whose declarations, comparisons and callers can be proven closed in the selected Java source scope. Future requests include public APIs, persisted values, command-line values and wire protocols; those representations cannot be treated as ordinary source-only cleanups.
+
+## Decision
+
+### Impact levels
+
+Every cleanup is classified as one of:
+
+- `LOCAL_SAFE`: one compilation unit and no externally visible contract change;
+- `PROJECT_CLOSED`: multiple Java source units changed atomically after proving reference closure;
+- `COMPATIBILITY_MANAGED`: an external contract changes under an explicit adapter/versioning policy;
+- `MANUAL_REFACTORING`: interactive decisions or non-Java resources are required.
+
+Only `LOCAL_SAFE` is eligible for an ordinary save action. All other levels require an explicit preview. Structured multi-file diagnostics report the impact, affected-unit count, save-action eligibility and compatibility statement in both preview status and deterministic JSON.
+
+### Integer-to-enum modes
+
+#### `CLOSED_FLOW_AUTOMATIC`
+
+This is the only implemented automatic mode. It requires:
+
+- package-private constants and candidate method;
+- distinct constant values;
+- a complete source declaration/caller scope;
+- direct calls passing only modelled constants;
+- no unsupported constant/state/method references;
+- no generated-name collision;
+- callers in the same package as the package-private nested enum.
+
+The migration is `PROJECT_CLOSED`: it preserves the behaviour of the proven source flow but makes no source- or binary-compatibility promise to external clients.
+
+#### `NUMERIC_ADAPTER_OPT_IN`
+
+This future `COMPATIBILITY_MANAGED` mode is not executable yet. Before it may be enabled it must provide:
+
+- an explicit stable numeric field on every enum constant;
+- `fromValue(int)` or an equivalent adapter with a documented unknown-value policy;
+- temporary overloads/adapters where source or binary callers require them;
+- deprecation and removal policy for public integer constants;
+- tests covering persistence, serialization, database values, preferences, CLI flags and network payloads.
+
+#### `MANUAL_DOMAIN_REFACTORING`
+
+Aliases, sparse/ranged domains and bit masks are not ordinary enum domains. Bit flags normally require `EnumSet`; aliases and ranges require an explicit domain design. These cases remain manual until a dedicated policy is implemented.
+
+### External identity
+
+`Enum.ordinal()` is never a persisted, serialized or wire identity. Reordering enum constants must not alter external meaning.
+
+### Reference generation
+
+A generated package-private nested enum may be referenced only by callers in the same package. References are generated through AST/`ImportRewrite` name selection so same-package callers receive idiomatic `Owner.Enum.CONSTANT` names while conflicts may retain an unambiguous qualified owner name. Cross-package callers are rejected during planning instead of producing inaccessible source.
+
+## Consequences
+
+- Existing closed-flow detection remains conservative and automatic.
+- Public or externally represented integer domains cannot silently enter the automatic cleanup.
+- IDE, headless and CI consumers share one impact vocabulary.
+- Compatibility-managed migration remains a separately reviewable feature rather than an accidental extension of the current detector.

--- a/sandbox_common/src/org/sandbox/jdt/cleanup/multifile/CleanUpImpact.java
+++ b/sandbox_common/src/org/sandbox/jdt/cleanup/multifile/CleanUpImpact.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.cleanup.multifile;
+
+/**
+ * User-visible impact classification for cleanup execution and profiles.
+ *
+ * <p>The classification is deliberately independent of a particular UI. IDE,
+ * headless and CI callers can use the same metadata when deciding whether a
+ * cleanup may run as a save action or requires an explicit preview.</p>
+ */
+public enum CleanUpImpact {
+
+	/** One compilation unit, without an externally visible signature change. */
+	LOCAL_SAFE(true, false,
+			"The cleanup is local and does not claim to change an externally visible contract."), //$NON-NLS-1$
+
+	/** Multiple source units whose complete reference closure was proven. */
+	PROJECT_CLOSED(false, true,
+			"The cleanup changes multiple source units and is safe only for the proven closed project scope."), //$NON-NLS-1$
+
+	/** An external contract changes under an explicit compatibility policy. */
+	COMPATIBILITY_MANAGED(false, true,
+			"The cleanup changes an external contract and requires an explicit compatibility policy and adapters."), //$NON-NLS-1$
+
+	/** Interactive decisions or non-Java resources prevent automatic cleanup. */
+	MANUAL_REFACTORING(false, true,
+			"The change requires an interactive refactoring and must not run as an automatic cleanup."); //$NON-NLS-1$
+
+	private final boolean saveActionEligible;
+	private final boolean explicitPreviewRequired;
+	private final String compatibilityStatement;
+
+	CleanUpImpact(boolean saveActionEligible, boolean explicitPreviewRequired, String compatibilityStatement) {
+		this.saveActionEligible= saveActionEligible;
+		this.explicitPreviewRequired= explicitPreviewRequired;
+		this.compatibilityStatement= compatibilityStatement;
+	}
+
+	/** Returns whether profiles may offer this impact level as an ordinary save action. */
+	public boolean saveActionEligible() {
+		return saveActionEligible;
+	}
+
+	/** Returns whether execution requires an explicit affected-scope preview. */
+	public boolean explicitPreviewRequired() {
+		return explicitPreviewRequired;
+	}
+
+	/** Returns the compatibility claim that must be shown before execution. */
+	public String compatibilityStatement() {
+		return compatibilityStatement;
+	}
+}

--- a/sandbox_common/src/org/sandbox/jdt/cleanup/multifile/MultiFileCleanUpDiagnostics.java
+++ b/sandbox_common/src/org/sandbox/jdt/cleanup/multifile/MultiFileCleanUpDiagnostics.java
@@ -16,9 +16,11 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HexFormat;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.TreeMap;
 
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
@@ -44,6 +46,23 @@ public record MultiFileCleanUpDiagnostics(String cleanupId, MultiFileScopeDiagno
 		return new MultiFileCleanUpDiagnostics("unknown", MultiFileScopeDiagnostic.empty(), List.of()); //$NON-NLS-1$
 	}
 
+	/** Returns the impact contract shared by every coordinated multi-file cleanup. */
+	public CleanUpImpact impact() {
+		return CleanUpImpact.PROJECT_CLOSED;
+	}
+
+	/** Returns the number of distinct selected and discovered source units. */
+	public int affectedCompilationUnitCount() {
+		Set<String> handles= new LinkedHashSet<>(scope.selectedCompilationUnitHandles());
+		handles.addAll(scope.addedCompilationUnitHandles());
+		for (MultiFileCandidateDiagnostic candidate : candidates) {
+			handles.add(candidate.ownerCompilationUnitHandle());
+			handles.addAll(candidate.relatedCompilationUnitHandles());
+		}
+		handles.remove(""); //$NON-NLS-1$
+		return handles.size();
+	}
+
 	/** Returns a copy containing the observed host scope expansion. */
 	public MultiFileCleanUpDiagnostics withScope(MultiFileScopeDiagnostic newScope) {
 		return new MultiFileCleanUpDiagnostics(cleanupId, newScope, candidates);
@@ -64,10 +83,11 @@ public record MultiFileCleanUpDiagnostics(String cleanupId, MultiFileScopeDiagno
 			}
 		}
 		long rejected= rejectedByReason.values().stream().mapToLong(Long::longValue).sum();
-		StringBuilder summary= new StringBuilder(160)
-				.append("Coordinated cleanup ").append(cleanupId).append(": ") //$NON-NLS-1$ //$NON-NLS-2$
+		StringBuilder summary= new StringBuilder(240)
+				.append('[').append(impact()).append("] Coordinated cleanup ").append(cleanupId).append(": ") //$NON-NLS-1$ //$NON-NLS-2$
 				.append(scope.selectedCompilationUnitHandles().size()).append(" selected, ") //$NON-NLS-1$
-				.append(scope.addedCompilationUnitHandles().size()).append(" added; ") //$NON-NLS-1$
+				.append(scope.addedCompilationUnitHandles().size()).append(" added, ") //$NON-NLS-1$
+				.append(affectedCompilationUnitCount()).append(" affected; ") //$NON-NLS-1$
 				.append(transformed).append(" transformed, ").append(rejected).append(" rejected"); //$NON-NLS-1$ //$NON-NLS-2$
 		if (!scope.complete()) {
 			summary.append("; scope incomplete (").append(scope.reasonCode()).append(')'); //$NON-NLS-1$
@@ -83,7 +103,8 @@ public record MultiFileCleanUpDiagnostics(String cleanupId, MultiFileScopeDiagno
 			}
 			summary.append(')');
 		}
-		status.addInfo(summary.append('.').toString());
+		summary.append(". ").append(impact().compatibilityStatement()); //$NON-NLS-1$
+		status.addInfo(summary.toString());
 	}
 
 	/**
@@ -94,10 +115,15 @@ public record MultiFileCleanUpDiagnostics(String cleanupId, MultiFileScopeDiagno
 	 * @return privacy-preserving deterministic JSON
 	 */
 	public String toJson() {
-		StringBuilder json= new StringBuilder(512);
+		StringBuilder json= new StringBuilder(768);
 		json.append('{');
-		property(json, "schemaVersion", "1").append(','); //$NON-NLS-1$ //$NON-NLS-2$
+		property(json, "schemaVersion", "2").append(','); //$NON-NLS-1$ //$NON-NLS-2$
 		property(json, "cleanupId", cleanupId).append(','); //$NON-NLS-1$
+		property(json, "impact", impact().name()).append(','); //$NON-NLS-1$
+		json.append("\"affectedCompilationUnitCount\":").append(affectedCompilationUnitCount()).append(','); //$NON-NLS-1$
+		json.append("\"saveActionEligible\":").append(impact().saveActionEligible()).append(','); //$NON-NLS-1$
+		json.append("\"explicitPreviewRequired\":").append(impact().explicitPreviewRequired()).append(','); //$NON-NLS-1$
+		property(json, "compatibilityStatement", impact().compatibilityStatement()).append(','); //$NON-NLS-1$
 		json.append("\"scope\":{"); //$NON-NLS-1$
 		arrayProperty(json, "selectedCompilationUnits", externalUnitIds(scope.selectedCompilationUnitHandles())).append(','); //$NON-NLS-1$
 		arrayProperty(json, "addedCompilationUnits", externalUnitIds(scope.addedCompilationUnitHandles())).append(','); //$NON-NLS-1$

--- a/sandbox_common_test/src/org/sandbox/jdt/cleanup/multifile/MultiFileCleanUpDiagnosticsTest.java
+++ b/sandbox_common_test/src/org/sandbox/jdt/cleanup/multifile/MultiFileCleanUpDiagnosticsTest.java
@@ -23,7 +23,7 @@ import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 class MultiFileCleanUpDiagnosticsTest {
 
 	@Test
-	void normalizesAndSerializesScopeAndCandidatesDeterministically() {
+	void normalizesAndSerializesScopeCandidatesAndImpactDeterministically() {
 		MultiFileCleanUpDiagnostics diagnostics= new MultiFileCleanUpDiagnostics("int-to-enum", //$NON-NLS-1$
 				new MultiFileScopeDiagnostic(List.of("z", "a", "a"), List.of("c", "b"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
 						"RELATED_SOURCE_CLOSURE", "Callers added", true), //$NON-NLS-1$ //$NON-NLS-2$
@@ -37,16 +37,21 @@ class MultiFileCleanUpDiagnosticsTest {
 		assertEquals(List.of("b", "c"), diagnostics.scope().addedCompilationUnitHandles()); //$NON-NLS-1$ //$NON-NLS-2$
 		assertEquals("method-a", diagnostics.candidates().get(0).candidateId()); //$NON-NLS-1$
 		assertEquals(List.of("a", "b"), diagnostics.candidates().get(0).relatedCompilationUnitHandles()); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals(CleanUpImpact.PROJECT_CLOSED, diagnostics.impact());
+		assertEquals(4, diagnostics.affectedCompilationUnitCount());
 		String json= diagnostics.toJson();
-		assertEquals("""
-				{"schemaVersion":"1","cleanupId":"int-to-enum","scope":{"selectedCompilationUnits":["cu-594e519ae499","cu-ca978112ca1b"],"addedCompilationUnits":["cu-2e7d2c03a950","cu-3e23e8160039"],"reasonCode":"RELATED_SOURCE_CLOSURE","explanation":"Callers added","complete":true},"candidates":[{"candidateId":"method-a","ownerCompilationUnit":"cu-ca978112ca1b","outcome":"TRANSFORMED","reasonCode":"TRANSFORMED","message":"Converted","relatedCompilationUnits":["cu-3e23e8160039","cu-ca978112ca1b"]},{"candidateId":"method-b","ownerCompilationUnit":"cu-594e519ae499","outcome":"REJECTED","reasonCode":"PUBLIC_API","message":"Public method","relatedCompilationUnits":["cu-594e519ae499","cu-ca978112ca1b"]}]}
-				""".strip(), json);
+		assertTrue(json.startsWith("{\"schemaVersion\":\"2\",\"cleanupId\":\"int-to-enum\"")); //$NON-NLS-1$
+		assertTrue(json.contains("\"impact\":\"PROJECT_CLOSED\"")); //$NON-NLS-1$
+		assertTrue(json.contains("\"affectedCompilationUnitCount\":4")); //$NON-NLS-1$
+		assertTrue(json.contains("\"saveActionEligible\":false")); //$NON-NLS-1$
+		assertTrue(json.contains("\"explicitPreviewRequired\":true")); //$NON-NLS-1$
+		assertTrue(json.contains("\"candidateId\":\"method-a\"")); //$NON-NLS-1$
 		assertFalse(json.contains("\"ownerCompilationUnit\":\"a\"")); //$NON-NLS-1$
 		assertFalse(json.contains("\"selectedCompilationUnits\":[\"a\"")); //$NON-NLS-1$
 	}
 
 	@Test
-	void summaryReportsTransformedRejectedAndAddedCounts() {
+	void summaryReportsImpactAffectedTransformedRejectedAndAddedCounts() {
 		MultiFileCleanUpDiagnostics diagnostics= new MultiFileCleanUpDiagnostics("junit", //$NON-NLS-1$
 				new MultiFileScopeDiagnostic(List.of("selected"), List.of("added"), //$NON-NLS-1$ //$NON-NLS-2$
 						"RELATED_SOURCE_CLOSURE", "Rule user added", true), //$NON-NLS-1$ //$NON-NLS-2$
@@ -60,10 +65,23 @@ class MultiFileCleanUpDiagnosticsTest {
 
 		assertTrue(status.hasInfo());
 		String message= status.getMessageMatchingSeverity(RefactoringStatus.INFO);
+		assertTrue(message.contains("[PROJECT_CLOSED]")); //$NON-NLS-1$
 		assertTrue(message.contains("1 selected")); //$NON-NLS-1$
 		assertTrue(message.contains("1 added")); //$NON-NLS-1$
+		assertTrue(message.contains("2 affected")); //$NON-NLS-1$
 		assertTrue(message.contains("1 transformed")); //$NON-NLS-1$
 		assertTrue(message.contains("1 rejected")); //$NON-NLS-1$
 		assertTrue(message.contains("MIXED_RULE_MODES=1")); //$NON-NLS-1$
+		assertTrue(message.contains(CleanUpImpact.PROJECT_CLOSED.compatibilityStatement()));
+	}
+
+	@Test
+	void onlyLocalSafeImpactIsEligibleForSaveActions() {
+		assertTrue(CleanUpImpact.LOCAL_SAFE.saveActionEligible());
+		assertFalse(CleanUpImpact.PROJECT_CLOSED.saveActionEligible());
+		assertFalse(CleanUpImpact.COMPATIBILITY_MANAGED.saveActionEligible());
+		assertFalse(CleanUpImpact.MANUAL_REFACTORING.saveActionEligible());
+		assertFalse(CleanUpImpact.LOCAL_SAFE.explicitPreviewRequired());
+		assertTrue(CleanUpImpact.PROJECT_CLOSED.explicitPreviewRequired());
 	}
 }

--- a/sandbox_int_to_enum/src/org/sandbox/jdt/internal/corext/fix/multifile/IntEnumMigrationMode.java
+++ b/sandbox_int_to_enum/src/org/sandbox/jdt/internal/corext/fix/multifile/IntEnumMigrationMode.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.corext.fix.multifile;
+
+import org.sandbox.jdt.cleanup.multifile.CleanUpImpact;
+
+/**
+ * Compatibility contract for integer-domain to enum migrations.
+ *
+ * <p>Only {@link #CLOSED_FLOW_AUTOMATIC} is currently executable. The other
+ * modes make future compatibility work explicit without weakening the current
+ * conservative detector.</p>
+ */
+public enum IntEnumMigrationMode {
+
+	/** Package-private source flow whose complete declaration/caller closure is proven. */
+	CLOSED_FLOW_AUTOMATIC(CleanUpImpact.PROJECT_CLOSED, true, false,
+			"Closed source flow: all declarations and callers are migrated atomically; no public, persisted or wire identity is claimed."), //$NON-NLS-1$
+
+	/** Public or externally represented numeric identity with explicit adapters. */
+	NUMERIC_ADAPTER_OPT_IN(CleanUpImpact.COMPATIBILITY_MANAGED, false, true,
+			"Compatibility-managed numeric domain: explicit value/fromValue adapters and an unknown-value policy are required."), //$NON-NLS-1$
+
+	/** Bit flags, aliases or ranged domains that require an interactive design decision. */
+	MANUAL_DOMAIN_REFACTORING(CleanUpImpact.MANUAL_REFACTORING, false, true,
+			"Manual domain refactoring: aliases, ranges or bit flags require an explicit representation such as EnumSet."); //$NON-NLS-1$
+
+	private final CleanUpImpact impact;
+	private final boolean implemented;
+	private final boolean explicitNumericIdentityRequired;
+	private final String previewStatement;
+
+	IntEnumMigrationMode(CleanUpImpact impact, boolean implemented, boolean explicitNumericIdentityRequired,
+			String previewStatement) {
+		this.impact= impact;
+		this.implemented= implemented;
+		this.explicitNumericIdentityRequired= explicitNumericIdentityRequired;
+		this.previewStatement= previewStatement;
+	}
+
+	/** Returns the cleanup impact shown in previews and reports. */
+	public CleanUpImpact impact() {
+		return impact;
+	}
+
+	/** Returns whether this mode may currently create rewrite operations. */
+	public boolean implemented() {
+		return implemented;
+	}
+
+	/** Returns whether constants require explicit stable numeric values and adapters. */
+	public boolean explicitNumericIdentityRequired() {
+		return explicitNumericIdentityRequired;
+	}
+
+	/** Returns the user-facing compatibility statement. */
+	public String previewStatement() {
+		return previewStatement;
+	}
+
+	/**
+	 * External identity must never be derived from {@link Enum#ordinal()} in any
+	 * migration mode.
+	 */
+	public boolean ordinalAllowedForExternalIdentity() {
+		return false;
+	}
+
+	/** Returns the only mode available to the automatic cleanup. */
+	public static IntEnumMigrationMode automaticMode() {
+		return CLOSED_FLOW_AUTOMATIC;
+	}
+}

--- a/sandbox_int_to_enum/src/org/sandbox/jdt/internal/corext/fix/multifile/IntEnumMultiFileRewriteOperation.java
+++ b/sandbox_int_to_enum/src/org/sandbox/jdt/internal/corext/fix/multifile/IntEnumMultiFileRewriteOperation.java
@@ -49,6 +49,7 @@ import org.eclipse.jdt.core.dom.Type;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
 import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
@@ -63,8 +64,11 @@ final class IntEnumMultiFileRewriteOperation extends CompilationUnitRewriteOpera
 			SingleVariableDeclaration parameter, Map<FieldDeclaration, Set<String>> constantFragments) {
 	}
 
-	record ResolvedPlan(List<ResolvedOwner> owners, Map<Expression, String> replacements,
-			Set<ASTNode> processedNodes) {
+	record Replacement(IntEnumCandidate candidate, String enumConstantName) {
+	}
+
+	record ResolvedPlan(String compilationUnitHandle, List<ResolvedOwner> owners,
+			Map<Expression, Replacement> replacements, Set<ASTNode> processedNodes) {
 	}
 
 	private final ResolvedPlan plan;
@@ -86,7 +90,7 @@ final class IntEnumMultiFileRewriteOperation extends CompilationUnitRewriteOpera
 		Map<IntEnumCandidate, TypeDeclaration> ownerTypes= new LinkedHashMap<>();
 		Map<IntEnumCandidate, MethodDeclaration> ownerMethods= new LinkedHashMap<>();
 		Map<IntEnumCandidate, Map<FieldDeclaration, Set<String>>> ownerFields= new LinkedHashMap<>();
-		Map<Expression, String> replacements= new IdentityHashMap<>();
+		Map<Expression, Replacement> replacements= new IdentityHashMap<>();
 		Map<IntEnumCandidate, Map<String, Integer>> referenceCounts= new HashMap<>();
 		Map<IntEnumCandidate, Integer> callCounts= new HashMap<>();
 		Set<ASTNode> processed= java.util.Collections.newSetFromMap(new IdentityHashMap<>());
@@ -162,10 +166,7 @@ final class IntEnumMultiFileRewriteOperation extends CompilationUnitRewriteOpera
 								stale(unit, "unexpected use of " + node.getIdentifier())); //$NON-NLS-1$
 					}
 					IntEnumConstant constant= candidate.constant(constantKey);
-					String qualifier= unitHandle.equals(candidate.ownerCompilationUnitHandle())
-							? candidate.enumTypeName()
-							: candidate.ownerTypeQualifiedName() + "." + candidate.enumTypeName(); //$NON-NLS-1$
-					replacements.put(expression, qualifier + "." + constant.enumName()); //$NON-NLS-1$
+					replacements.put(expression, new Replacement(candidate, constant.enumName()));
 					referenceCounts.computeIfAbsent(candidate, ignored -> new LinkedHashMap<>())
 							.merge(constantKey, Integer.valueOf(1), Integer::sum);
 					processed.add(expression);
@@ -205,7 +206,7 @@ final class IntEnumMultiFileRewriteOperation extends CompilationUnitRewriteOpera
 				owners.add(new ResolvedOwner(candidate, type, method, parameter, fields));
 			}
 		}
-		return new ResolvedPlan(List.copyOf(owners), Map.copyOf(replacements), Set.copyOf(processed));
+		return new ResolvedPlan(unitHandle, List.copyOf(owners), Map.copyOf(replacements), Set.copyOf(processed));
 	}
 
 	private static final class StalePlanRuntimeException extends RuntimeException {
@@ -223,6 +224,7 @@ final class IntEnumMultiFileRewriteOperation extends CompilationUnitRewriteOpera
 		TextEditGroup group= createTextEditGroup("Convert package-scoped integer state domain to enum", cuRewrite); //$NON-NLS-1$
 		AST ast= cuRewrite.getRoot().getAST();
 		ASTRewrite rewrite= cuRewrite.getASTRewrite();
+		ImportRewrite imports= cuRewrite.getImportRewrite();
 
 		for (ResolvedOwner owner : plan.owners()) {
 			insertEnum(owner, ast, rewrite, group);
@@ -230,10 +232,44 @@ final class IntEnumMultiFileRewriteOperation extends CompilationUnitRewriteOpera
 					ast.newSimpleType(ast.newSimpleName(owner.candidate().enumTypeName())), group);
 			removeConstants(owner, rewrite, group);
 		}
-		for (Map.Entry<Expression, String> replacement : plan.replacements().entrySet()) {
-			Name name= ast.newName(replacement.getValue());
-			rewrite.replace(replacement.getKey(), name, group);
+		for (Map.Entry<Expression, Replacement> entry : plan.replacements().entrySet()) {
+			Replacement replacement= entry.getValue();
+			IntEnumCandidate candidate= replacement.candidate();
+			String enumQualifier;
+			if (plan.compilationUnitHandle().equals(candidate.ownerCompilationUnitHandle())) {
+				enumQualifier= candidate.enumTypeName();
+			} else {
+				String ownerReference= ownerReference(cuRewrite.getRoot(), candidate, imports);
+				enumQualifier= ownerReference + '.' + candidate.enumTypeName();
+			}
+			Name name= ast.newName(enumQualifier + '.' + replacement.enumConstantName());
+			rewrite.replace(entry.getKey(), name, group);
 		}
+	}
+
+	private static String ownerReference(org.eclipse.jdt.core.dom.CompilationUnit root,
+			IntEnumCandidate candidate, ImportRewrite imports) {
+		String qualifiedName= candidate.ownerTypeQualifiedName();
+		int separator= qualifiedName.lastIndexOf('.');
+		String simpleName= separator < 0 ? qualifiedName : qualifiedName.substring(separator + 1);
+		boolean[] conflict= { false };
+		root.accept(new ASTVisitor() {
+			@Override
+			public void preVisit(ASTNode node) {
+				if (conflict[0]) {
+					return;
+				}
+				if (node instanceof org.eclipse.jdt.core.dom.AbstractTypeDeclaration declaration
+						&& simpleName.equals(declaration.getName().getIdentifier())) {
+					String key= typeKey(declaration.resolveBinding());
+					conflict[0]= !candidate.ownerTypeBindingKey().equals(key);
+				} else if (node instanceof org.eclipse.jdt.core.dom.TypeParameter parameter
+						&& simpleName.equals(parameter.getName().getIdentifier())) {
+					conflict[0]= true;
+				}
+			}
+		});
+		return conflict[0] ? qualifiedName : imports.addImport(qualifiedName);
 	}
 
 	private static void insertEnum(ResolvedOwner owner, AST ast, ASTRewrite rewrite, TextEditGroup group) {

--- a/sandbox_int_to_enum/src/org/sandbox/jdt/internal/corext/fix/multifile/IntEnumPackageVisibilityPolicy.java
+++ b/sandbox_int_to_enum/src/org/sandbox/jdt/internal/corext/fix/multifile/IntEnumPackageVisibilityPolicy.java
@@ -1,0 +1,107 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.corext.fix.multifile;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IPackageFragment;
+
+import org.sandbox.jdt.cleanup.multifile.MultiFileCandidateDiagnostic;
+import org.sandbox.jdt.cleanup.multifile.MultiFileCandidateOutcome;
+import org.sandbox.jdt.cleanup.multifile.MultiFileCleanUpDiagnostics;
+import org.sandbox.jdt.cleanup.multifile.MultiFileCleanUpPlanResult;
+
+/** Planning-time accessibility policy for generated package-private nested enums. */
+public final class IntEnumPackageVisibilityPolicy {
+
+	private IntEnumPackageVisibilityPolicy() {
+	}
+
+	/**
+	 * Removes candidates with a caller outside the owner package and replaces the
+	 * transformed diagnostic with a deterministic rejection.
+	 */
+	public static MultiFileCleanUpPlanResult<IntEnumMigrationPlan> enforce(
+			MultiFileCleanUpPlanResult<IntEnumMigrationPlan> result, ICompilationUnit[] compilationUnits) {
+		if (result.plan() == null || result.plan().candidates().isEmpty()) {
+			return result;
+		}
+		Map<String, ICompilationUnit> unitsByHandle= new LinkedHashMap<>();
+		Arrays.stream(compilationUnits).map(ICompilationUnit::getPrimary)
+				.forEach(unit -> unitsByHandle.put(unit.getHandleIdentifier(), unit));
+		List<IntEnumCandidate> accepted= new ArrayList<>();
+		List<MultiFileCandidateDiagnostic> diagnostics= new ArrayList<>(result.diagnostics().candidates());
+		for (IntEnumCandidate candidate : result.plan().candidates()) {
+			ICompilationUnit owner= unitsByHandle.get(candidate.ownerCompilationUnitHandle());
+			String ownerPackage= owner == null ? null : packageName(owner);
+			Set<String> crossPackageCallers= new LinkedHashSet<>();
+			for (String handle : candidate.expectedCallCountsByUnit().keySet()) {
+				if (handle.equals(candidate.ownerCompilationUnitHandle())) {
+					continue;
+				}
+				ICompilationUnit caller= unitsByHandle.get(handle);
+				if (ownerPackage == null || caller == null || !ownerPackage.equals(packageName(caller))) {
+					crossPackageCallers.add(handle);
+				}
+			}
+			if (ownerPackage != null && crossPackageCallers.isEmpty()) {
+				accepted.add(candidate);
+				continue;
+			}
+
+			Set<String> expectedRelatedHandles= new LinkedHashSet<>();
+			expectedRelatedHandles.add(candidate.ownerCompilationUnitHandle());
+			expectedRelatedHandles.addAll(candidate.expectedCallCountsByUnit().keySet());
+			MultiFileCandidateDiagnostic transformedDiagnostic= diagnostics.stream()
+					.filter(diagnostic -> diagnostic.outcome() == MultiFileCandidateOutcome.TRANSFORMED)
+					.filter(diagnostic -> diagnostic.ownerCompilationUnitHandle()
+							.equals(candidate.ownerCompilationUnitHandle()))
+					.filter(diagnostic -> Set.copyOf(diagnostic.relatedCompilationUnitHandles())
+							.equals(Set.copyOf(expectedRelatedHandles)))
+					.findFirst()
+					.orElseThrow(() -> new IllegalStateException(
+							"Missing transformed diagnostic for planned int-to-enum candidate")); //$NON-NLS-1$
+			diagnostics.removeIf(diagnostic -> diagnostic.outcome() == MultiFileCandidateOutcome.TRANSFORMED
+					&& diagnostic.candidateId().equals(transformedDiagnostic.candidateId()));
+
+			List<String> related= new ArrayList<>();
+			related.add(candidate.ownerCompilationUnitHandle());
+			related.addAll(crossPackageCallers);
+			diagnostics.add(MultiFileCandidateDiagnostic.rejected(transformedDiagnostic.candidateId(),
+					candidate.ownerCompilationUnitHandle(), "CROSS_PACKAGE_CALLER", //$NON-NLS-1$
+					ownerPackage == null
+							? "The owner compilation unit could not be resolved for package visibility validation." //$NON-NLS-1$
+							: "The generated nested enum is package-private, but at least one caller is outside package " //$NON-NLS-1$
+									+ printablePackage(ownerPackage)
+									+ ". Select a compatibility-managed migration instead.", //$NON-NLS-1$
+					related));
+		}
+		IntEnumMigrationPlan filteredPlan= new IntEnumMigrationPlan(result.plan().selectedScope(), accepted);
+		MultiFileCleanUpDiagnostics filteredDiagnostics= new MultiFileCleanUpDiagnostics(
+				result.diagnostics().cleanupId(), result.diagnostics().scope(), diagnostics);
+		return MultiFileCleanUpPlanResult.success(filteredPlan, result.status(), result.metrics(), filteredDiagnostics);
+	}
+
+	private static String packageName(ICompilationUnit unit) {
+		return unit.getParent() instanceof IPackageFragment fragment ? fragment.getElementName() : ""; //$NON-NLS-1$
+	}
+
+	private static String printablePackage(String packageName) {
+		return packageName.isEmpty() ? "<default>" : packageName; //$NON-NLS-1$
+	}
+}

--- a/sandbox_int_to_enum/src/org/sandbox/jdt/internal/ui/fix/IntToEnumCleanUpCore.java
+++ b/sandbox_int_to_enum/src/org/sandbox/jdt/internal/ui/fix/IntToEnumCleanUpCore.java
@@ -54,6 +54,7 @@ import org.sandbox.jdt.cleanup.multifile.SourceRootPolicy;
 import org.sandbox.jdt.internal.corext.fix.IntToEnumFixCore;
 import org.sandbox.jdt.internal.corext.fix.multifile.IntEnumMigrationPlan;
 import org.sandbox.jdt.internal.corext.fix.multifile.IntEnumMultiFilePlanner;
+import org.sandbox.jdt.internal.corext.fix.multifile.IntEnumPackageVisibilityPolicy;
 import org.sandbox.jdt.internal.corext.fix.multifile.IntEnumScopeCandidateDetector;
 
 /** Core cleanup implementation that converts integer constants to enums. */
@@ -93,9 +94,10 @@ public class IntToEnumCleanUpCore extends AbstractPlannedMultiFileCleanUp<IntEnu
 			return MultiFileCleanUpPlanResult.success(new IntEnumMigrationPlan(selectedScope, List.of()));
 		}
 		Boolean closedScope= consumeClosedScopeDecision(project, compilationUnits);
-		return closedScope == null
+		MultiFileCleanUpPlanResult<IntEnumMigrationPlan> result= closedScope == null
 				? IntEnumMultiFilePlanner.create(project, compilationUnits, monitor)
 				: IntEnumMultiFilePlanner.create(project, compilationUnits, closedScope.booleanValue(), monitor);
+		return IntEnumPackageVisibilityPolicy.enforce(result, compilationUnits);
 	}
 
 	@Override

--- a/sandbox_int_to_enum_test/src/org/eclipse/jdt/ui/tests/quickfix/Java22/IntEnumMigrationModeTest.java
+++ b/sandbox_int_to_enum_test/src/org/eclipse/jdt/ui/tests/quickfix/Java22/IntEnumMigrationModeTest.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.quickfix.Java22;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import org.sandbox.jdt.cleanup.multifile.CleanUpImpact;
+import org.sandbox.jdt.internal.corext.fix.multifile.IntEnumMigrationMode;
+
+/** Compatibility-contract tests for integer-domain migration modes. */
+public class IntEnumMigrationModeTest {
+
+	@Test
+	public void automaticModeIsClosedProjectFlowOnly() {
+		IntEnumMigrationMode mode= IntEnumMigrationMode.automaticMode();
+
+		assertEquals(IntEnumMigrationMode.CLOSED_FLOW_AUTOMATIC, mode);
+		assertEquals(CleanUpImpact.PROJECT_CLOSED, mode.impact());
+		assertTrue(mode.implemented());
+		assertFalse(mode.explicitNumericIdentityRequired());
+		assertTrue(mode.previewStatement().contains("atomically")); //$NON-NLS-1$
+	}
+
+	@Test
+	public void publicNumericCompatibilityModeIsExplicitAndNotYetExecutable() {
+		IntEnumMigrationMode mode= IntEnumMigrationMode.NUMERIC_ADAPTER_OPT_IN;
+
+		assertEquals(CleanUpImpact.COMPATIBILITY_MANAGED, mode.impact());
+		assertFalse(mode.implemented());
+		assertTrue(mode.explicitNumericIdentityRequired());
+		assertTrue(mode.previewStatement().contains("fromValue")); //$NON-NLS-1$
+	}
+
+	@Test
+	public void ordinalIsNeverAnExternalIdentity() {
+		for (IntEnumMigrationMode mode : IntEnumMigrationMode.values()) {
+			assertFalse(mode.ordinalAllowedForExternalIdentity(), mode.name());
+		}
+	}
+}

--- a/sandbox_int_to_enum_test/src/org/eclipse/jdt/ui/tests/quickfix/Java22/IntEnumPackageVisibilityPolicyTest.java
+++ b/sandbox_int_to_enum_test/src/org/eclipse/jdt/ui/tests/quickfix/Java22/IntEnumPackageVisibilityPolicyTest.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.quickfix.Java22;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IPackageFragment;
+
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+
+import org.sandbox.jdt.cleanup.multifile.MultiFileCandidateDiagnostic;
+import org.sandbox.jdt.cleanup.multifile.MultiFileCleanUpDiagnostics;
+import org.sandbox.jdt.cleanup.multifile.MultiFileCleanUpPlanResult;
+import org.sandbox.jdt.cleanup.multifile.MultiFilePlanningMetrics;
+import org.sandbox.jdt.cleanup.multifile.MultiFileScopeDiagnostic;
+import org.sandbox.jdt.cleanup.multifile.SelectedCompilationUnitPlan;
+import org.sandbox.jdt.internal.corext.fix.multifile.IntEnumCandidate;
+import org.sandbox.jdt.internal.corext.fix.multifile.IntEnumMigrationPlan;
+import org.sandbox.jdt.internal.corext.fix.multifile.IntEnumPackageVisibilityPolicy;
+import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
+import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava22;
+
+/** Package-resolution regression tests for nested enum owners. */
+public class IntEnumPackageVisibilityPolicyTest {
+
+	@RegisterExtension
+	AbstractEclipseJava context= new EclipseJava22();
+
+	@Test
+	public void acceptsSamePackageCallerForNestedOwnerType() throws CoreException {
+		IPackageFragment pack= context.getSourceFolder().createPackageFragment("test", false, null); //$NON-NLS-1$
+		ICompilationUnit owner= pack.createCompilationUnit("Outer.java", //$NON-NLS-1$
+				"package test; public class Outer { static class OrderProcessor {} }", false, null); //$NON-NLS-1$
+		ICompilationUnit caller= pack.createCompilationUnit("OrderClient.java", //$NON-NLS-1$
+				"package test; public class OrderClient {}", false, null); //$NON-NLS-1$
+		String ownerHandle= owner.getHandleIdentifier();
+		String callerHandle= caller.getHandleIdentifier();
+		IntEnumCandidate candidate= new IntEnumCandidate(ownerHandle, "owner-key", //$NON-NLS-1$
+				"test.Outer.OrderProcessor", "method-key", 0, "STATUS_", "Status", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+				List.of(), Map.of(), Map.of(ownerHandle, Integer.valueOf(0), callerHandle, Integer.valueOf(1)));
+		SelectedCompilationUnitPlan scope= SelectedCompilationUnitPlan.of(context.getJavaProject(),
+				new ICompilationUnit[] { owner, caller });
+		MultiFileCleanUpDiagnostics diagnostics= new MultiFileCleanUpDiagnostics("int-to-enum", //$NON-NLS-1$
+				new MultiFileScopeDiagnostic(List.of(ownerHandle, callerHandle), List.of(),
+						"CLOSED_SOURCE_SCOPE", "Complete", true), //$NON-NLS-1$ //$NON-NLS-2$
+				List.of(MultiFileCandidateDiagnostic.transformed("candidate", ownerHandle, //$NON-NLS-1$
+						"Migrates nested enum Status.", List.of(ownerHandle, callerHandle)))); //$NON-NLS-1$
+		MultiFileCleanUpPlanResult<IntEnumMigrationPlan> result= MultiFileCleanUpPlanResult.success(
+				new IntEnumMigrationPlan(scope, List.of(candidate)), new RefactoringStatus(),
+				MultiFilePlanningMetrics.empty(), diagnostics);
+
+		MultiFileCleanUpPlanResult<IntEnumMigrationPlan> filtered=
+				IntEnumPackageVisibilityPolicy.enforce(result, new ICompilationUnit[] { owner, caller });
+
+		assertEquals(List.of(candidate), filtered.plan().candidates());
+		assertEquals("TRANSFORMED", filtered.diagnostics().candidates().get(0).outcome().name()); //$NON-NLS-1$
+	}
+}

--- a/sandbox_int_to_enum_test/src/org/eclipse/jdt/ui/tests/quickfix/Java22/IntEnumReferenceQualificationTest.java
+++ b/sandbox_int_to_enum_test/src/org/eclipse/jdt/ui/tests/quickfix/Java22/IntEnumReferenceQualificationTest.java
@@ -24,16 +24,70 @@ import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
 import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava22;
 import org.sandbox.jdt.ui.tests.quickfix.rules.MultiFileCleanUpLifecycleAssertions;
 
-/** Integration test for a package-scoped state API and a caller in another file. */
-public class MultiFileIntToEnumCleanUpTest {
+/** Qualification QA for generated nested enum references. */
+public class IntEnumReferenceQualificationTest {
 
 	@RegisterExtension
 	AbstractEclipseJava context= new EclipseJava22();
 
 	@Test
-	public void completeSelectionMigratesOwnerAndCallerButNotUnrelatedSource() throws CoreException {
+	public void supportsGenericOwnerInDefaultPackage() throws CoreException {
+		IPackageFragment pack= context.getSourceFolder().createPackageFragment("", false, null); //$NON-NLS-1$
+		ICompilationUnit owner= pack.createCompilationUnit("OrderProcessor.java", //$NON-NLS-1$
+				"""
+				public class OrderProcessor<T> {
+					static final int STATUS_PENDING = 0;
+					static final int STATUS_APPROVED = 1;
+
+					void process(int status) {
+						if (status == STATUS_PENDING) {
+							System.out.println("pending");
+						} else if (status == STATUS_APPROVED) {
+							System.out.println("approved");
+						}
+					}
+				}
+				""", false, null);
+		ICompilationUnit client= pack.createCompilationUnit("OrderClient.java", //$NON-NLS-1$
+				"""
+				public class OrderClient {
+					void run(OrderProcessor<String> processor) {
+						processor.process(OrderProcessor.STATUS_PENDING);
+					}
+				}
+				""", false, null);
+		enableProjectWideCleanup();
+
+		MultiFileCleanUpLifecycleAssertions.assertApplyCompileAndUndo(
+				new ICompilationUnit[] { owner, client }, new ICompilationUnit[] { owner, client }, new String[] {
+						"""
+						public class OrderProcessor<T> {
+							enum Status {
+								PENDING, APPROVED
+							}
+
+							void process(Status status) {
+								if (status == Status.PENDING) {
+									System.out.println("pending");
+								} else if (status == Status.APPROVED) {
+									System.out.println("approved");
+								}
+							}
+						}
+						""",
+						"""
+						public class OrderClient {
+							void run(OrderProcessor<String> processor) {
+								processor.process(OrderProcessor.Status.PENDING);
+							}
+						}
+						""" });
+	}
+
+	@Test
+	public void retainsQualifiedOwnerWhenSimpleNameConflicts() throws CoreException {
 		IPackageFragment pack= context.getSourceFolder().createPackageFragment("test", false, null); //$NON-NLS-1$
-		ICompilationUnit processor= pack.createCompilationUnit("OrderProcessor.java", //$NON-NLS-1$
+		ICompilationUnit owner= pack.createCompilationUnit("OrderProcessor.java", //$NON-NLS-1$
 				"""
 				package test;
 
@@ -55,29 +109,18 @@ public class MultiFileIntToEnumCleanUpTest {
 				package test;
 
 				public class OrderClient {
-					void run(OrderProcessor processor) {
-						processor.process(OrderProcessor.STATUS_PENDING);
+					static class OrderProcessor {
+					}
+
+					void run(test.OrderProcessor processor) {
+						processor.process(test.OrderProcessor.STATUS_PENDING);
 					}
 				}
 				""", false, null);
-		ICompilationUnit unrelated= pack.createCompilationUnit("Unrelated.java", //$NON-NLS-1$
-				"""
-				package test;
-
-				public class Unrelated {
-					String value() {
-						return "unchanged";
-					}
-				}
-				""", false, null);
-
-		context.enable(MYCleanUpConstants.INT_TO_ENUM_CLEANUP);
-		context.enable(IntToEnumCleanUpOptions.PROJECT_WIDE);
+		enableProjectWideCleanup();
 
 		MultiFileCleanUpLifecycleAssertions.assertApplyCompileAndUndo(
-				new ICompilationUnit[] { processor, client, unrelated },
-				new ICompilationUnit[] { processor, client, unrelated },
-				new String[] {
+				new ICompilationUnit[] { owner, client }, new ICompilationUnit[] { owner, client }, new String[] {
 						"""
 						package test;
 
@@ -99,60 +142,18 @@ public class MultiFileIntToEnumCleanUpTest {
 						package test;
 
 						public class OrderClient {
-							void run(OrderProcessor processor) {
-								processor.process(OrderProcessor.Status.PENDING);
+							static class OrderProcessor {
 							}
-						}
-						""",
-						"""
-						package test;
 
-						public class Unrelated {
-							String value() {
-								return "unchanged";
+							void run(test.OrderProcessor processor) {
+								processor.process(test.OrderProcessor.Status.PENDING);
 							}
 						}
 						""" });
 	}
 
-	@Test
-	public void doesNotMigrateWhenGeneratedEnumNameConflictsWithNestedEnum() throws CoreException {
-		IPackageFragment pack= context.getSourceFolder().createPackageFragment("test", false, null); //$NON-NLS-1$
-		ICompilationUnit processor= pack.createCompilationUnit("OrderProcessor.java", //$NON-NLS-1$
-				"""
-				package test;
-
-				public class OrderProcessor {
-					enum Status {
-						EXISTING
-					}
-
-					static final int STATUS_PENDING = 0;
-					static final int STATUS_APPROVED = 1;
-
-					void process(int status) {
-						if (status == STATUS_PENDING) {
-							System.out.println("pending");
-						} else if (status == STATUS_APPROVED) {
-							System.out.println("approved");
-						}
-					}
-				}
-				""", false, null);
-		ICompilationUnit client= pack.createCompilationUnit("OrderClient.java", //$NON-NLS-1$
-				"""
-				package test;
-
-				public class OrderClient {
-					void run(OrderProcessor processor) {
-						processor.process(OrderProcessor.STATUS_PENDING);
-					}
-				}
-				""", false, null);
-
+	private void enableProjectWideCleanup() throws CoreException {
 		context.enable(MYCleanUpConstants.INT_TO_ENUM_CLEANUP);
 		context.enable(IntToEnumCleanUpOptions.PROJECT_WIDE);
-
-		context.assertRefactoringHasNoChange(new ICompilationUnit[] { processor, client });
 	}
 }

--- a/sandbox_int_to_enum_test/src/org/eclipse/jdt/ui/tests/quickfix/Java22/IntToEnumSaveActionIsolationTest.java
+++ b/sandbox_int_to_enum_test/src/org/eclipse/jdt/ui/tests/quickfix/Java22/IntToEnumSaveActionIsolationTest.java
@@ -146,7 +146,14 @@ public class IntToEnumSaveActionIsolationTest {
 
 		String savedLocal= Files.readString(local.getResource().getLocation().toFile().toPath(), StandardCharsets.UTF_8);
 		assertTrue(savedLocal.contains("enum Status"), "The proven local cleanup must run during save"); //$NON-NLS-1$ //$NON-NLS-2$
-		assertTrue(savedLocal.contains("process(Status.PENDING)"), "The local call site must use the generated enum"); //$NON-NLS-1$ //$NON-NLS-2$
+		int invocationStart= savedLocal.indexOf("process("); //$NON-NLS-1$
+		int invocationEnd= invocationStart < 0 ? -1 : savedLocal.indexOf(')', invocationStart);
+		String invocationArgument= invocationEnd < 0 ? "" //$NON-NLS-1$
+				: savedLocal.substring(invocationStart + "process(".length(), invocationEnd).replaceAll("\\s+", ""); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		assertTrue(invocationArgument.endsWith("Status.PENDING"), //$NON-NLS-1$
+				() -> "The local call site must use the generated enum, but was: " + invocationArgument); //$NON-NLS-1$
+		assertFalse(savedLocal.contains("process(STATUS_PENDING)"), //$NON-NLS-1$
+				"The local call site must no longer use the integer constant"); //$NON-NLS-1$
 		assertTrue(savedLocal.contains("process(Status status)"), "The private local signature must be migrated"); //$NON-NLS-1$ //$NON-NLS-2$
 		assertFalse(savedLocal.contains("STATUS_PENDING = 0"), "The local integer constants must be removed"); //$NON-NLS-1$ //$NON-NLS-2$
 

--- a/sandbox_int_to_enum_test/src/org/eclipse/jdt/ui/tests/quickfix/Java22/MultiFileIntToEnumDiagnosticsTest.java
+++ b/sandbox_int_to_enum_test/src/org/eclipse/jdt/ui/tests/quickfix/Java22/MultiFileIntToEnumDiagnosticsTest.java
@@ -14,6 +14,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -22,11 +25,19 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IPackageFragment;
 
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+
 import org.sandbox.jdt.cleanup.multifile.MultiFileCandidateDiagnostic;
 import org.sandbox.jdt.cleanup.multifile.MultiFileCandidateOutcome;
+import org.sandbox.jdt.cleanup.multifile.MultiFileCleanUpDiagnostics;
 import org.sandbox.jdt.cleanup.multifile.MultiFileCleanUpPlanResult;
+import org.sandbox.jdt.cleanup.multifile.MultiFilePlanningMetrics;
+import org.sandbox.jdt.cleanup.multifile.MultiFileScopeDiagnostic;
+import org.sandbox.jdt.cleanup.multifile.SelectedCompilationUnitPlan;
+import org.sandbox.jdt.internal.corext.fix.multifile.IntEnumCandidate;
 import org.sandbox.jdt.internal.corext.fix.multifile.IntEnumMigrationPlan;
 import org.sandbox.jdt.internal.corext.fix.multifile.IntEnumMultiFilePlanner;
+import org.sandbox.jdt.internal.corext.fix.multifile.IntEnumPackageVisibilityPolicy;
 import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
 import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava22;
 
@@ -91,6 +102,42 @@ public class MultiFileIntToEnumDiagnosticsTest {
 		MultiFileCandidateDiagnostic diagnostic= assertRejected(result, "GENERATED_NAME_COLLISION"); //$NON-NLS-1$
 		assertTrue(diagnostic.message().contains("field")); //$NON-NLS-1$
 		assertTrue(diagnostic.message().contains("Status")); //$NON-NLS-1$
+	}
+
+	@Test
+	public void rejectsCallerOutsideGeneratedEnumPackage() throws CoreException {
+		IPackageFragment ownerPackage= context.getSourceFolder().createPackageFragment("owner", false, null); //$NON-NLS-1$
+		IPackageFragment clientPackage= context.getSourceFolder().createPackageFragment("client", false, null); //$NON-NLS-1$
+		ICompilationUnit owner= ownerPackage.createCompilationUnit("OrderProcessor.java", //$NON-NLS-1$
+				"package owner; public class OrderProcessor {}", false, null); //$NON-NLS-1$
+		ICompilationUnit client= clientPackage.createCompilationUnit("OrderClient.java", //$NON-NLS-1$
+				"package client; public class OrderClient {}", false, null); //$NON-NLS-1$
+		String ownerHandle= owner.getHandleIdentifier();
+		String clientHandle= client.getHandleIdentifier();
+		IntEnumCandidate candidate= new IntEnumCandidate(ownerHandle, "owner-key", "owner.OrderProcessor", //$NON-NLS-1$ //$NON-NLS-2$
+				"method-key", 0, "STATUS_", "Status", List.of(), Map.of(), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+				Map.of(ownerHandle, Integer.valueOf(0), clientHandle, Integer.valueOf(1)));
+		SelectedCompilationUnitPlan scope= SelectedCompilationUnitPlan.of(context.getJavaProject(),
+				new ICompilationUnit[] { owner, client });
+		MultiFileCleanUpDiagnostics diagnostics= new MultiFileCleanUpDiagnostics("int-to-enum", //$NON-NLS-1$
+				new MultiFileScopeDiagnostic(List.of(ownerHandle, clientHandle), List.of(),
+						"CLOSED_SOURCE_SCOPE", "Complete", true), //$NON-NLS-1$ //$NON-NLS-2$
+				List.of(MultiFileCandidateDiagnostic.transformed("candidate", ownerHandle, //$NON-NLS-1$
+						"Migrates nested enum Status.", List.of(ownerHandle, clientHandle)))); //$NON-NLS-1$
+		MultiFileCleanUpPlanResult<IntEnumMigrationPlan> result= MultiFileCleanUpPlanResult.success(
+				new IntEnumMigrationPlan(scope, List.of(candidate)), new RefactoringStatus(),
+				MultiFilePlanningMetrics.empty(), diagnostics);
+
+		MultiFileCleanUpPlanResult<IntEnumMigrationPlan> filtered=
+				IntEnumPackageVisibilityPolicy.enforce(result, new ICompilationUnit[] { owner, client });
+
+		assertEquals(0, filtered.plan().candidates().size());
+		assertEquals(1, filtered.diagnostics().candidates().size());
+		MultiFileCandidateDiagnostic rejection= filtered.diagnostics().candidates().get(0);
+		assertEquals(MultiFileCandidateOutcome.REJECTED, rejection.outcome());
+		assertEquals("candidate", rejection.candidateId()); //$NON-NLS-1$
+		assertEquals("CROSS_PACKAGE_CALLER", rejection.reasonCode()); //$NON-NLS-1$
+		assertTrue(rejection.message().contains("owner")); //$NON-NLS-1$
 	}
 
 	private ICompilationUnit[] createCandidate(String methodPrefix, String argument) throws CoreException {


### PR DESCRIPTION
## Problem

Local syntax cleanups, coordinated source migrations and externally compatible refactorings currently lack one shared impact vocabulary. The project-wide int-to-enum path also generated package-qualified names unconditionally and did not expose an explicit compatibility mode or a deterministic cross-package accessibility diagnostic.

## Change

- add `CleanUpImpact` with `LOCAL_SAFE`, `PROJECT_CLOSED`, `COMPATIBILITY_MANAGED` and `MANUAL_REFACTORING`;
- expose impact, affected-unit count, save-action eligibility, preview requirement and compatibility text in multi-file preview summaries and deterministic JSON;
- define explicit int-to-enum migration modes and prohibit `ordinal()` as external identity;
- add ADR 0001 covering closed-flow, numeric-adapter and manual domain policies;
- reject generated package-private enum candidates with callers outside the owner package as `CROSS_PACKAGE_CALLER`;
- generate external enum references via `ImportRewrite`, yielding idiomatic `Owner.Enum.CONSTANT` names while retaining qualified owners on conflicts;
- cover same-package, default-package, generic-owner, conflicting-simple-name and cross-package cases;
- update existing lifecycle expectations from `test.OrderProcessor.Status` to `OrderProcessor.Status`.

## Safety

Only the existing closed-source-flow mode is executable. Public/external numeric compatibility remains a distinct, unimplemented opt-in mode. Multi-file impacts are not save-action eligible and require explicit previews.

## Verification

The canonical Maven, CodeQL, Codacy and distribution workflows are required before merge. Tests exercise deterministic JSON, preview metadata, mode guarantees, apply/compile/undo, default-package and name-conflict qualification, and planning-time package rejection.

Closes #1216
Closes #1223
Closes #1226