### PR TITLE
Activate advanced JUnit runner migration tests

### DIFF
--- a/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/MigrationRunnersAdvancedTest.java
+++ b/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/MigrationRunnersAdvancedTest.java
@@ -19,7 +19,6 @@ import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.junit.JUnitCore;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.sandbox.jdt.internal.corext.fix2.MYCleanUpConstants;
@@ -101,7 +100,6 @@ public class EnclosedTest {
 		}, null);
 	}
 
-	@Disabled("@RunWith(Theories.class) to @ParameterizedTest transformation not yet implemented")
 	@Test
 	public void migrates_runWith_theories_to_parameterizedTest() throws CoreException {
 		IPackageFragment pack = fRoot.createPackageFragment("test", true, null);
@@ -152,12 +150,10 @@ public class TheoriesTest {
 		}, null);
 	}
 
-	@Disabled("@RunWith(Categories.class) to @Suite with @IncludeTags/@ExcludeTags transformation not yet implemented")
 	@Test
 	public void migrates_runWith_categories_to_suite_with_tags() throws CoreException {
 		IPackageFragment pack = fRoot.createPackageFragment("test", true, null);
 		
-		// Create marker interfaces for categories
 		pack.createCompilationUnit("FastTests.java",
 				"""
 				package test;


### PR DESCRIPTION
## Problem

`RunWithJUnitPlugin` already contains implementations for `Theories` and `Categories`, but the corresponding integration tests remained disabled and the test inventory still reported both capabilities as missing.

## Change

- enable the existing `@RunWith(Theories.class)` migration test;
- enable the existing `@RunWith(Categories.class)` migration test;
- remove the now-unused `Disabled` import.

The tests exercise the complete cleanup paths:

- `@DataPoints` + `@Theory` → `@ParameterizedTest` + `@ValueSource`;
- Categories suite → `@Suite`, `@IncludeTags`, `@ExcludeTags`, and `@SelectClasses`.

## Verification

The canonical Maven, CodeQL, Codacy and distribution workflows are required. If either previously dormant path differs from the documented output, the implementation will be corrected in this PR rather than disabling the test again.

Refs #1217