### PR TITLE
Guard generated JUnit helper class names

### DIFF
--- a/sandbox_common/src/org/sandbox/jdt/internal/corext/util/NamingUtils.java
+++ b/sandbox_common/src/org/sandbox/jdt/internal/corext/util/NamingUtils.java
@@ -92,22 +92,23 @@ public final class NamingUtils {
 	 * <p>The historical field-name/checksum convention is retained for stable
 	 * output, but the proposed name is now checked by the shared generated-name
 	 * allocator against type, member, local and import namespaces before any
-	 * rewrite is scheduled.</p>
+	 * rewrite is committed.</p>
 	 *
 	 * @param anonymousClass the anonymous class declaration
 	 * @param baseName the base name from the field
-	 * @return the available class name, or {@code null} when it would collide
+	 * @return the available class name
+	 * @throws IllegalStateException if owner context is unavailable or the name collides
 	 */
 	public static String generateUniqueNestedClassName(AnonymousClassDeclaration anonymousClass, String baseName) {
 		String anonymousCode = anonymousClass.toString();
 		String checksum = generateChecksum(anonymousCode);
 		String requestedName = capitalizeFirstLetter(baseName) + "_" + checksum; //$NON-NLS-1$
 		if (!(anonymousClass.getRoot() instanceof CompilationUnit root)) {
-			return null;
+			throw new IllegalStateException("Cannot validate generated helper name without a compilation unit."); //$NON-NLS-1$
 		}
 		TypeDeclaration owner= ASTNavigationUtils.findEnclosingTypeDeclaration(anonymousClass);
 		if (owner == null) {
-			return null;
+			throw new IllegalStateException("Cannot validate generated helper name without an enclosing type."); //$NON-NLS-1$
 		}
 		ITypeBinding ownerBinding= owner.resolveBinding();
 		ITypeBinding ownerDeclaration= ownerBinding == null ? null : ownerBinding.getTypeDeclaration();
@@ -122,7 +123,12 @@ public final class NamingUtils {
 				requestedName);
 		Allocation allocation= GeneratedNameAllocator.allocateNestedTypes(List.of(root), List.of(request))
 				.get(requestId);
-		return allocation != null && allocation.available() ? requestedName : null;
+		if (allocation == null || !allocation.available()) {
+			String detail= allocation == null ? "allocation result is missing" : allocation.diagnosticMessage(); //$NON-NLS-1$
+			throw new IllegalStateException("Generated nested helper name " + requestedName //$NON-NLS-1$
+					+ " is unavailable: " + detail); //$NON-NLS-1$
+		}
+		return requestedName;
 	}
 
 	/**

--- a/sandbox_common/src/org/sandbox/jdt/internal/corext/util/NamingUtils.java
+++ b/sandbox_common/src/org/sandbox/jdt/internal/corext/util/NamingUtils.java
@@ -16,13 +16,24 @@ package org.sandbox.jdt.internal.corext.util;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.List;
 
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.AnonymousClassDeclaration;
+import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.FieldDeclaration;
+import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.QualifiedType;
 import org.eclipse.jdt.core.dom.SimpleType;
 import org.eclipse.jdt.core.dom.Type;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+
+import org.sandbox.jdt.cleanup.multifile.GeneratedNameAllocator;
+import org.sandbox.jdt.cleanup.multifile.GeneratedNameAllocator.Allocation;
+import org.sandbox.jdt.cleanup.multifile.GeneratedNameAllocator.NestedTypeRequest;
 
 /**
  * Utility class for naming and string operations.
@@ -76,22 +87,42 @@ public final class NamingUtils {
 	}
 
 	/**
-	 * Generates a unique nested class name based on the anonymous class content and field name.
-	 * Uses a checksum of the class code to ensure uniqueness.
-	 * 
+	 * Generates and validates a deterministic nested helper class name.
+	 *
+	 * <p>The historical field-name/checksum convention is retained for stable
+	 * output, but the proposed name is now checked by the shared generated-name
+	 * allocator against type, member, local and import namespaces before any
+	 * rewrite is scheduled.</p>
+	 *
 	 * @param anonymousClass the anonymous class declaration
 	 * @param baseName the base name from the field
-	 * @return a unique class name combining capitalized base name and checksum
+	 * @return the available class name, or {@code null} when it would collide
 	 */
 	public static String generateUniqueNestedClassName(AnonymousClassDeclaration anonymousClass, String baseName) {
-		// Convert anonymous class to string for checksum generation to ensure unique naming
 		String anonymousCode = anonymousClass.toString();
 		String checksum = generateChecksum(anonymousCode);
-
-		// Capitalize field name for class naming convention
-		String capitalizedBaseName = capitalizeFirstLetter(baseName);
-
-		return capitalizedBaseName + "_" + checksum; //$NON-NLS-1$
+		String requestedName = capitalizeFirstLetter(baseName) + "_" + checksum; //$NON-NLS-1$
+		if (!(anonymousClass.getRoot() instanceof CompilationUnit root)) {
+			return null;
+		}
+		TypeDeclaration owner= ASTNavigationUtils.findEnclosingTypeDeclaration(anonymousClass);
+		if (owner == null) {
+			return null;
+		}
+		ITypeBinding ownerBinding= owner.resolveBinding();
+		ITypeBinding ownerDeclaration= ownerBinding == null ? null : ownerBinding.getTypeDeclaration();
+		String ownerKey= ownerDeclaration == null || ownerDeclaration.getKey() == null
+				? "" : ownerDeclaration.getKey(); //$NON-NLS-1$
+		String ownerQualifiedName= ownerDeclaration == null || ownerDeclaration.getQualifiedName().isEmpty()
+				? qualifiedName(root, owner) : ownerDeclaration.getQualifiedName();
+		String unitHandle= root.getJavaElement() instanceof ICompilationUnit unit
+				? unit.getPrimary().getHandleIdentifier() : ""; //$NON-NLS-1$
+		String requestId= (ownerKey.isEmpty() ? ownerQualifiedName : ownerKey) + "#junit-helper:" + requestedName; //$NON-NLS-1$
+		NestedTypeRequest request= new NestedTypeRequest(requestId, unitHandle, ownerKey, ownerQualifiedName,
+				requestedName);
+		Allocation allocation= GeneratedNameAllocator.allocateNestedTypes(List.of(root), List.of(request))
+				.get(requestId);
+		return allocation != null && allocation.available() ? requestedName : null;
 	}
 
 	/**
@@ -182,5 +213,20 @@ public final class NamingUtils {
 			return simpleType.getName().getFullyQualifiedName();
 		}
 		return null;
+	}
+
+	private static String qualifiedName(CompilationUnit root, TypeDeclaration owner) {
+		List<String> typeNames= new ArrayList<>();
+		ASTNode current= owner;
+		while (current != null) {
+			if (current instanceof TypeDeclaration type) {
+				typeNames.add(0, type.getName().getIdentifier());
+			}
+			current= current.getParent();
+		}
+		String packageName= root.getPackage() == null
+				? "" : root.getPackage().getName().getFullyQualifiedName(); //$NON-NLS-1$
+		String localName= String.join(".", typeNames); //$NON-NLS-1$
+		return packageName.isEmpty() ? localName : packageName + '.' + localName;
 	}
 }

--- a/sandbox_common_test/src/org/sandbox/jdt/internal/corext/util/NamingUtilsGeneratedNameTest.java
+++ b/sandbox_common_test/src/org/sandbox/jdt/internal/corext/util/NamingUtilsGeneratedNameTest.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.corext.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.AnonymousClassDeclaration;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+
+/** Tests shared collision validation for generated JUnit helper classes. */
+class NamingUtilsGeneratedNameTest {
+
+	@Test
+	void retainsDeterministicFieldAndChecksumNameWhenAvailable() {
+		AnonymousClassDeclaration anonymous= parseAnonymous(sourceWithoutCollision());
+
+		String generated= NamingUtils.generateUniqueNestedClassName(anonymous, "resource"); //$NON-NLS-1$
+
+		assertTrue(generated.matches("Resource_[0-9a-f]{5}")); //$NON-NLS-1$
+		assertEquals(generated, NamingUtils.generateUniqueNestedClassName(anonymous, "resource")); //$NON-NLS-1$
+	}
+
+	@Test
+	void rejectsExistingNestedTypeWithGeneratedName() {
+		AnonymousClassDeclaration initial= parseAnonymous(sourceWithoutCollision());
+		String generated= NamingUtils.generateUniqueNestedClassName(initial, "resource"); //$NON-NLS-1$
+		String source= sourceWithoutCollision().replace("class Owner {", //$NON-NLS-1$
+				"class Owner {\n\tstatic class " + generated + " {} "); //$NON-NLS-1$ //$NON-NLS-2$
+		AnonymousClassDeclaration conflicting= parseAnonymous(source);
+
+		IllegalStateException exception= assertThrows(IllegalStateException.class,
+				() -> NamingUtils.generateUniqueNestedClassName(conflicting, "resource")); //$NON-NLS-1$
+
+		assertTrue(exception.getMessage().contains(generated));
+		assertTrue(exception.getMessage().contains("type declaration")); //$NON-NLS-1$
+	}
+
+	private static AnonymousClassDeclaration parseAnonymous(String source) {
+		ASTParser parser= ASTParser.newParser(AST.getJLSLatest());
+		parser.setKind(ASTParser.K_COMPILATION_UNIT);
+		parser.setSource(source.toCharArray());
+		CompilationUnit root= (CompilationUnit) parser.createAST(null);
+		AnonymousClassDeclaration[] result= new AnonymousClassDeclaration[1];
+		root.accept(new ASTVisitor() {
+			@Override
+			public boolean visit(AnonymousClassDeclaration node) {
+				result[0]= node;
+				return false;
+			}
+		});
+		return result[0];
+	}
+
+	private static String sourceWithoutCollision() {
+		return """
+				package test;
+
+				class Owner {
+					Object resource = new Object() {
+						void before() {
+						}
+					};
+				}
+				""";
+	}
+}


### PR DESCRIPTION
## Problem

The JUnit ExternalResource migration converts anonymous rules into generated nested helper classes. Their names were derived only from the field name and a five-character checksum. Existing type/member/import names were not checked, so a deterministic helper name could still collide and produce uncompilable source.

## Change

- retain the existing field-name/checksum convention for stable output;
- resolve the enclosing compilation unit and owner type;
- validate the prospective nested class through the shared `GeneratedNameAllocator`;
- fail closed with a concrete collision explanation when owner context is unavailable or the generated name is occupied;
- add tests for stable available names and an existing nested-type collision.

## Scope

This adopts the shared generated-name policy for the JUnit ExternalResource helper-class path. Other future helper/adapter generators and package/inheritance-wide collision analysis remain follow-up work under #1225.

## Verification

The canonical Maven, CodeQL, Codacy and distribution workflows are required before merge.

Refs #1225