### PR TITLE
Adopt released JGit storage core boundary

### DIFF
--- a/docs/adr/0002-adopt-released-jgit-storage-hibernate.md
+++ b/docs/adr/0002-adopt-released-jgit-storage-hibernate.md
@@ -1,0 +1,55 @@
+# ADR 0002: Adopt the released jgit-storage-hibernate modules
+
+- **Status:** Accepted
+- **Date:** 2026-07-27
+- **Issue:** #1303
+
+## Context
+
+`sandbox-jgit-storage-hibernate` currently contains a copied generic JGit/Hibernate implementation together with Sandbox-specific search presentation, embeddings and REST-facing query services. The released `io.github.carstenartur:jgit-storage-hibernate` project now owns generic database-backed Git storage, history search, Java analysis and architecture analysis as separate modules.
+
+Keeping both implementations independently editable would create divergent schemas, transaction behaviour, JGit compatibility and query semantics.
+
+## Decision
+
+Sandbox will adopt the released library in reviewable slices.
+
+### Ownership
+
+The external project owns:
+
+- Git objects, packs, refs, Reftables, reflogs and repository lifecycle;
+- generic history projections and full-text history search;
+- binding-aware Java history and semantic code analysis;
+- generic architecture rules, evidence and drift analysis;
+- module-owned entities, schema migrations, facades, query objects and DTOs.
+
+Sandbox owns:
+
+- Sandbox REST resources and transport DTOs;
+- UI and Eclipse integration;
+- operational configuration specific to the Sandbox product;
+- optional embedding/rank-fusion experiments not provided by the generic library;
+- migration adapters required only while copied callers are being removed.
+
+### First slice
+
+The module consumes released version `0.1.13` from the anonymous static Maven repository documented by the external project. `JGitStorageLibraryBoundary` exposes the public `RepositoryName` and `CoreEntities` contracts to Sandbox code. New integration code must use this boundary or another explicitly reviewed public-library adapter; it must not add new dependencies on copied `org.eclipse.jgit.storage.hibernate` implementation classes.
+
+### Subsequent slices
+
+1. Replace repository construction and lifecycle with `jgit-storage-hibernate-core`.
+2. Replace copied commit/history entities and indexers with `jgit-storage-hibernate-search`.
+3. Replace copied Java AST/history analysis with `jgit-storage-hibernate-java-analysis`.
+4. Move Sandbox-only embeddings and REST query composition behind application-owned interfaces.
+5. Remove copied generic packages, migrations and dependencies.
+6. Add a build rule that rejects new source references to removed/copied implementation packages.
+
+Each slice must preserve repository data through the external migration/adoption runbook and must keep one authoritative implementation active.
+
+## Consequences
+
+- The first slice adds a released dependency without immediately deleting the copied implementation.
+- The temporary coexistence is explicit and bounded by this migration plan.
+- Public external APIs, not implementation packages, define the replacement contract.
+- Database migration and service cut-over remain separate follow-up changes and cannot be represented as a package rename.

--- a/sandbox-jgit-storage-hibernate/README.md
+++ b/sandbox-jgit-storage-hibernate/README.md
@@ -1,39 +1,47 @@
-# JGit Storage Backend (`sandbox-jgit-storage-hibernate`)
+# Sandbox JGit storage integration (`sandbox-jgit-storage-hibernate`)
 
-> **Navigation**: [Main README](../README.md)
+> **Navigation**: [Main README](../README.md) · [ADR 0002](../docs/adr/0002-adopt-released-jgit-storage-hibernate.md)
 
-## Overview
+## Current role
 
-`sandbox-jgit-storage-hibernate` is a Hibernate/Lucene-based JGit storage backend for persistent Git object indexing and querying. It enables structural analysis and semantic search over Java source code stored in Git repositories.
+This module is being converted from a copied generic JGit/Hibernate implementation into the Sandbox-owned integration layer for [`jgit-storage-hibernate`](https://github.com/carstenartur/jgit-storage-hibernate).
 
-## Features
+Released version `0.1.13` is now consumed through its public Core API. New Sandbox code should enter generic database-backed Git storage through `org.sandbox.jgit.storage.integration.JGitStorageLibraryBoundary` or another explicitly reviewed adapter. It must not add new dependencies on the copied `org.eclipse.jgit.storage.hibernate` implementation packages.
 
-- **Commit indexing** — stores Git commits and blob contents in a relational database via Hibernate ORM
-- **Java structure extraction** — parses Java blobs with Eclipse JDT AST to extract structural information (`JavaBlobExtractor`, `JavaStructureVisitor`)
-- **Full-text and semantic search** — combines Lucene full-text keyword search with embedding-based semantic search (rank fusion via `RankFusionUtil`)
-- **Index migration** — `IndexMigrationService` supports schema evolution and incremental re-indexing
-- **REST-accessible query service** — `GitDatabaseQueryService` exposes indexed data to the server webapp
+## Ownership boundary
 
-## Architecture
+The external library owns:
 
-```
-CommitIndexer (walks Git history)
-  → JavaBlobExtractor (AST parse Java blobs)
-  → BlobIndexer (stores to Hibernate)
-  → EmbeddingBackfillService (generates embeddings for semantic search)
-  → GitDatabaseQueryService (query API)
-```
+- Git packs, refs, Reftables, reflogs and repository lifecycle;
+- generic commit/history projections and full-text search;
+- binding-aware Java history and semantic analysis;
+- generic architecture rules and drift analysis;
+- module-owned entities, migrations, facades and DTOs.
 
-Key packages:
-- `org.eclipse.jgit.storage.hibernate.service` — indexing and query services
-- `org.eclipse.jgit.storage.hibernate.search` — AST-based structure extraction and rank fusion
+Sandbox retains:
 
-## Dependencies
+- REST resources and transport DTOs;
+- Eclipse/UI integration;
+- Sandbox operational configuration;
+- optional embedding and rank-fusion experiments;
+- temporary migration adapters until copied callers are removed.
 
-- Hibernate ORM (JPA persistence)
-- Eclipse JDT Core (Java AST parsing)
-- JGit (Git repository access)
+## Migration status
 
-## Related Modules
+1. **Core dependency and public integration boundary — in progress.**
+2. Repository construction/lifecycle cut-over — pending.
+3. Search projection cut-over — pending.
+4. Java-analysis cut-over — pending.
+5. Removal of copied generic packages and schemas — pending.
 
-- **[sandbox-jgit-server-webapp](../sandbox-jgit-server-webapp/README.md)** — REST server that uses this storage backend
+The copied implementation remains temporarily buildable so each data/schema and service cut-over can be reviewed independently. It is no longer the intended location for new generic storage functionality.
+
+## Existing Sandbox-specific capabilities
+
+- semantic embedding and rank-fusion experiments;
+- REST-facing query composition used by `sandbox-jgit-server-webapp`;
+- operational integration with the Sandbox product.
+
+## Related module
+
+- **[sandbox-jgit-server-webapp](../sandbox-jgit-server-webapp/README.md)** — REST server that will consume the integration boundary during the repository-lifecycle cut-over.

--- a/sandbox-jgit-storage-hibernate/bnd.bnd
+++ b/sandbox-jgit-storage-hibernate/bnd.bnd
@@ -2,14 +2,16 @@ Bundle-SymbolicName: sandbox-jgit-storage-hibernate
 Bundle-Version: ${version_cleanup;${project.version}}
 Bundle-Name: Sandbox JGit Storage Hibernate
 
-Export-Package: org.eclipse.jgit.storage.hibernate.config,\
- org.eclipse.jgit.storage.hibernate.entity,\
- org.eclipse.jgit.storage.hibernate.search,\
+Export-Package: org.sandbox.jgit.storage.integration,
+ org.eclipse.jgit.storage.hibernate.config,
+ org.eclipse.jgit.storage.hibernate.entity,
+ org.eclipse.jgit.storage.hibernate.search,
  org.eclipse.jgit.storage.hibernate.service
 
-Import-Package: ai.djl.*;resolution:=optional,\
- jakarta.*;resolution:=optional,\
- org.apache.lucene.*;resolution:=optional,\
- org.hibernate.*;resolution:=optional,\
- org.hsqldb.*;resolution:=optional,\
+Import-Package: ai.djl.*;resolution:=optional,
+ io.github.carstenartur.jgit.storage.hibernate.*,
+ jakarta.*;resolution:=optional,
+ org.apache.lucene.*;resolution:=optional,
+ org.hibernate.*;resolution:=optional,
+ org.hsqldb.*;resolution:=optional,
  *

--- a/sandbox-jgit-storage-hibernate/pom.xml
+++ b/sandbox-jgit-storage-hibernate/pom.xml
@@ -15,7 +15,7 @@
 	<packaging>jar</packaging>
 
 	<name>Sandbox JGit Storage Hibernate</name>
-	<description>Hibernate ORM + Hibernate Search storage backend for JGit</description>
+	<description>Sandbox-specific REST, embedding and presentation integration for jgit-storage-hibernate</description>
 
 	<properties>
 		<!-- Disable Tycho for this plain jar module (parent uses tycho-maven-plugin with extensions=true) -->
@@ -23,9 +23,30 @@
 		<!-- Hibernate Search 8.4 targets Hibernate ORM 7.4; keep the mapper stack aligned. -->
 		<hibernate.version>7.4.5.Final</hibernate.version>
 		<hibernate-search.version>8.4.0.Final</hibernate-search.version>
+		<jgit-storage-hibernate.version>0.1.13</jgit-storage-hibernate.version>
 	</properties>
 
+	<repositories>
+		<repository>
+			<id>jgit-storage-hibernate-public</id>
+			<url>https://raw.githubusercontent.com/carstenartur/jgit-storage-hibernate/maven-repository/</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+
 	<dependencies>
+		<!-- Released generic storage implementation. New Sandbox integration code must use this public API. -->
+		<dependency>
+			<groupId>io.github.carstenartur</groupId>
+			<artifactId>jgit-storage-hibernate-core</artifactId>
+			<version>${jgit-storage-hibernate.version}</version>
+		</dependency>
+
 		<!-- JGit core -->
 		<dependency>
 			<groupId>org.eclipse.jgit</groupId>
@@ -186,9 +207,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<!-- Use 3.3.0: versions 3.4.0+ use maven-archiver with session-scoped injection
-				     that conflicts with Tycho extensions in M2E, causing
-				     "Cannot access session scope outside of a scoping block" -->
 				<version>${maven-jar-plugin.version}</version>
 				<configuration>
 					<archive>

--- a/sandbox-jgit-storage-hibernate/src/org/sandbox/jgit/storage/integration/JGitStorageLibraryBoundary.java
+++ b/sandbox-jgit-storage-hibernate/src/org/sandbox/jgit/storage/integration/JGitStorageLibraryBoundary.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jgit.storage.integration;
+
+import java.util.List;
+
+import io.github.carstenartur.jgit.storage.hibernate.RepositoryName;
+import io.github.carstenartur.jgit.storage.hibernate.config.CoreEntities;
+
+/**
+ * Sandbox-owned integration boundary to the released generic storage library.
+ *
+ * <p>New Sandbox code must enter database-backed Git storage through public
+ * {@code io.github.carstenartur.jgit.storage.hibernate} APIs. The copied
+ * {@code org.eclipse.jgit.storage.hibernate} implementation remains only as a
+ * temporary migration source until its callers and Sandbox-specific services
+ * have been separated.</p>
+ */
+public final class JGitStorageLibraryBoundary {
+
+	private JGitStorageLibraryBoundary() {
+	}
+
+	/** Creates the external library's validated logical repository identity. */
+	public static RepositoryName repositoryName(String value) {
+		return new RepositoryName(value);
+	}
+
+	/** Returns the stable public entity-registration contract for generic core storage. */
+	public static List<Class<?>> coreEntities() {
+		return CoreEntities.annotatedClasses();
+	}
+}

--- a/sandbox-jgit-storage-hibernate/tst/org/sandbox/jgit/storage/integration/JGitStorageLibraryBoundaryTest.java
+++ b/sandbox-jgit-storage-hibernate/tst/org/sandbox/jgit/storage/integration/JGitStorageLibraryBoundaryTest.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jgit.storage.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.carstenartur.jgit.storage.hibernate.RepositoryName;
+
+/** Public-API contract test for the first external-library adoption slice. */
+class JGitStorageLibraryBoundaryTest {
+
+	@Test
+	void createsValidatedExternalRepositoryName() {
+		RepositoryName name= JGitStorageLibraryBoundary.repositoryName("sandbox"); //$NON-NLS-1$
+
+		assertEquals("sandbox", name.value()); //$NON-NLS-1$
+		assertEquals("sandbox", name.toString()); //$NON-NLS-1$
+		assertThrows(IllegalArgumentException.class,
+				() -> JGitStorageLibraryBoundary.repositoryName(" ")); //$NON-NLS-1$
+	}
+
+	@Test
+	void exposesOnlyReleasedCoreEntityContract() {
+		List<Class<?>> entities= JGitStorageLibraryBoundary.coreEntities();
+
+		assertEquals(List.of(
+				"io.github.carstenartur.jgit.storage.hibernate.entity.GitPackEntity", //$NON-NLS-1$
+				"io.github.carstenartur.jgit.storage.hibernate.entity.GitReflogEntity"), //$NON-NLS-1$
+				entities.stream().map(Class::getName).toList());
+		assertTrue(entities.stream().allMatch(type ->
+				type.getPackageName().startsWith("io.github.carstenartur.jgit.storage.hibernate"))); //$NON-NLS-1$
+	}
+}


### PR DESCRIPTION
## Problem

`sandbox-jgit-storage-hibernate` still combines a copied generic JGit/Hibernate implementation with Sandbox-specific REST, embedding and presentation concerns. The released `jgit-storage-hibernate` project now owns generic storage through deliberately separate public modules.

## Change

- consume released `io.github.carstenartur:jgit-storage-hibernate-core:0.1.13` from the documented anonymous Maven repository;
- add `JGitStorageLibraryBoundary` as the Sandbox-owned entry point to public `RepositoryName` and `CoreEntities` contracts;
- export the Sandbox integration package through the existing OSGi bundle;
- add a contract test that verifies repository-name validation and the released Core entity registry;
- add ADR 0002 with module ownership, migration order and the rule that new code must not depend on copied implementation packages;
- rewrite the module README around its transitional Sandbox integration role.

## Scope

This is the first executable adoption slice, not the final removal. Repository lifecycle, Search, Java Analysis, schema adoption, REST cut-over and copied-package deletion remain follow-up steps under #1303. The temporary coexistence is explicit and bounded; no new generic functionality should be added to the copied packages.

## Verification

The canonical Maven, CodeQL, Codacy and distribution workflows are required before merge. Dependency resolution must prove that the public static Maven repository and the released API work inside the full Sandbox reactor and OSGi bundle generation.

Refs #1303