### PR TITLE
Reject inherited generated-name collisions

### DIFF
--- a/docs/qa/generated-name-collision-policy.md
+++ b/docs/qa/generated-name-collision-policy.md
@@ -1,6 +1,6 @@
 # Generated-name collision policy
 
-Multi-file cleanups must treat every generated declaration name as part of the immutable migration plan. A name is accepted unchanged or the candidate is rejected; domain types are not silently renamed with numeric suffixes.
+Multi-file cleanups must treat every generated declaration name as part of the immutable migration plan. A name is accepted unchanged or the candidate is rejected; domain types and generated helper classes are not silently renamed with numeric suffixes.
 
 ## Checked namespaces
 
@@ -14,8 +14,16 @@ The shared `GeneratedNameAllocator` classifies conflicts as:
 
 Results are sorted deterministically by request identity and collision metadata so previews, diagnostics and tests do not depend on source-unit iteration order.
 
+`GeneratedNameHierarchyPolicy` supplements the current-AST namespaces with binding-based hierarchy checks. It traverses superclasses and interfaces with cycle protection and rejects a generated nested name that would hide an accessible inherited member type. Public and protected member types are checked across packages; package-visible types are checked within their package; private member types are ignored because they are not inherited or accessible. Collision descriptions are sorted by qualified member-type name.
+
+Although Java permits a subclass to declare a nested type that hides an inherited member type, an automatic cleanup must not introduce that semantic name-resolution change without an explicit user decision.
+
 ## Int-to-enum application guard
 
 `IntEnumMigrationPlan` includes the proposed enum name in the generated-name request identity. Immediately before resolving rewrite targets in the owner compilation unit, it revalidates that name against the current AST. A collision raises a stale-plan `CoreException` before rewrite operations or processed-node state are added.
 
-This closes the apply-time race where a valid plan could otherwise become uncompilable after another edit introduced a conflicting declaration. Planning-time diagnostics for all cleanup families remain follow-up work under issue #1225.
+The executable closed-source Int-to-Enum mode already rejects inherited owner types, so no hierarchy lookup is needed after that planning gate.
+
+## Generated JUnit helper classes
+
+The ExternalResource-to-extension migration retains its deterministic field-name/checksum convention. Before creating the nested helper class, `NamingUtils` applies both the shared current-AST allocator and the hierarchy policy. Existing declarations, imports, prospective reservations and accessible inherited member types therefore fail before any AST rewrite is committed, with the requested generated name and collision source in the diagnostic.

--- a/sandbox_common/src/org/sandbox/jdt/cleanup/multifile/GeneratedNameHierarchyPolicy.java
+++ b/sandbox_common/src/org/sandbox/jdt/cleanup/multifile/GeneratedNameHierarchyPolicy.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.cleanup.multifile;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.Modifier;
+
+/** Binding-based hierarchy checks for prospective generated nested type names. */
+public final class GeneratedNameHierarchyPolicy {
+
+	private GeneratedNameHierarchyPolicy() {
+	}
+
+	/**
+	 * Returns accessible inherited member types whose simple name would be hidden by
+	 * a newly generated nested type in {@code ownerBinding}.
+	 *
+	 * @param ownerBinding the prospective owner type
+	 * @param requestedName the generated nested type name
+	 * @return deterministic qualified collision descriptions
+	 */
+	public static List<String> inheritedMemberTypeCollisions(ITypeBinding ownerBinding, String requestedName) {
+		if (ownerBinding == null || requestedName == null || requestedName.isBlank()) {
+			return List.of();
+		}
+		ITypeBinding owner= ownerBinding.getTypeDeclaration();
+		Map<String, String> collisions= new TreeMap<>();
+		Set<String> visited= new HashSet<>();
+		collect(owner.getSuperclass(), owner, requestedName, visited, collisions);
+		for (ITypeBinding interfaceBinding : owner.getInterfaces()) {
+			collect(interfaceBinding, owner, requestedName, visited, collisions);
+		}
+		return List.copyOf(collisions.values());
+	}
+
+	private static void collect(ITypeBinding binding, ITypeBinding owner, String requestedName,
+			Set<String> visited, Map<String, String> collisions) {
+		if (binding == null) {
+			return;
+		}
+		ITypeBinding declaration= binding.getTypeDeclaration();
+		String identity= identity(declaration);
+		if (!visited.add(identity)) {
+			return;
+		}
+		for (ITypeBinding memberType : declaration.getDeclaredTypes()) {
+			ITypeBinding memberDeclaration= memberType.getTypeDeclaration();
+			if (requestedName.equals(memberDeclaration.getName()) && isAccessible(memberDeclaration, owner)) {
+				String memberName= qualifiedName(memberDeclaration);
+				String declaringName= qualifiedName(declaration);
+				collisions.put(memberName, memberName + " inherited from " + declaringName); //$NON-NLS-1$
+			}
+		}
+		collect(declaration.getSuperclass(), owner, requestedName, visited, collisions);
+		for (ITypeBinding interfaceBinding : declaration.getInterfaces()) {
+			collect(interfaceBinding, owner, requestedName, visited, collisions);
+		}
+	}
+
+	private static boolean isAccessible(ITypeBinding memberType, ITypeBinding owner) {
+		int modifiers= memberType.getModifiers();
+		if (Modifier.isPrivate(modifiers)) {
+			return false;
+		}
+		if (Modifier.isPublic(modifiers) || Modifier.isProtected(modifiers)) {
+			return true;
+		}
+		String memberPackage= packageName(memberType.getDeclaringClass());
+		String ownerPackage= packageName(owner);
+		return memberPackage.equals(ownerPackage);
+	}
+
+	private static String packageName(ITypeBinding binding) {
+		return binding == null || binding.getPackage() == null ? "" : binding.getPackage().getName(); //$NON-NLS-1$
+	}
+
+	private static String identity(ITypeBinding binding) {
+		String key= binding.getKey();
+		return key == null || key.isBlank() ? qualifiedName(binding) : key;
+	}
+
+	private static String qualifiedName(ITypeBinding binding) {
+		String qualifiedName= binding.getQualifiedName();
+		if (qualifiedName != null && !qualifiedName.isBlank()) {
+			return qualifiedName;
+		}
+		List<String> names= new ArrayList<>();
+		ITypeBinding current= binding;
+		while (current != null) {
+			names.add(0, current.getName());
+			current= current.getDeclaringClass();
+		}
+		String localName= String.join(".", names); //$NON-NLS-1$
+		String packageName= packageName(binding);
+		return packageName.isEmpty() ? localName : packageName + '.' + localName;
+	}
+}

--- a/sandbox_common/src/org/sandbox/jdt/internal/corext/util/NamingUtils.java
+++ b/sandbox_common/src/org/sandbox/jdt/internal/corext/util/NamingUtils.java
@@ -34,6 +34,7 @@ import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.sandbox.jdt.cleanup.multifile.GeneratedNameAllocator;
 import org.sandbox.jdt.cleanup.multifile.GeneratedNameAllocator.Allocation;
 import org.sandbox.jdt.cleanup.multifile.GeneratedNameAllocator.NestedTypeRequest;
+import org.sandbox.jdt.cleanup.multifile.GeneratedNameHierarchyPolicy;
 
 /**
  * Utility class for naming and string operations.
@@ -91,8 +92,8 @@ public final class NamingUtils {
 	 *
 	 * <p>The historical field-name/checksum convention is retained for stable
 	 * output, but the proposed name is now checked by the shared generated-name
-	 * allocator against type, member, local and import namespaces before any
-	 * rewrite is committed.</p>
+	 * services against type, member, local, import and inherited member-type
+	 * namespaces before any rewrite is committed.</p>
 	 *
 	 * @param anonymousClass the anonymous class declaration
 	 * @param baseName the base name from the field
@@ -127,6 +128,13 @@ public final class NamingUtils {
 			String detail= allocation == null ? "allocation result is missing" : allocation.diagnosticMessage(); //$NON-NLS-1$
 			throw new IllegalStateException("Generated nested helper name " + requestedName //$NON-NLS-1$
 					+ " is unavailable: " + detail); //$NON-NLS-1$
+		}
+		List<String> inheritedCollisions= GeneratedNameHierarchyPolicy
+				.inheritedMemberTypeCollisions(ownerDeclaration, requestedName);
+		if (!inheritedCollisions.isEmpty()) {
+			throw new IllegalStateException("Generated nested helper name " + requestedName //$NON-NLS-1$
+					+ " is unavailable: inherited member type (" //$NON-NLS-1$
+					+ String.join(", ", inheritedCollisions) + ")"); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 		return requestedName;
 	}

--- a/sandbox_common_test/src/org/sandbox/jdt/cleanup/multifile/GeneratedNameHierarchyPolicyTest.java
+++ b/sandbox_common_test/src/org/sandbox/jdt/cleanup/multifile/GeneratedNameHierarchyPolicyTest.java
@@ -11,53 +11,59 @@
 package org.sandbox.jdt.cleanup.multifile;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
-import org.eclipse.core.runtime.CoreException;
-
-import org.eclipse.jdt.core.ICompilationUnit;
-import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTParser;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 
-import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
-import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava22;
-
 /** Binding-level tests for inherited generated-name collisions. */
 class GeneratedNameHierarchyPolicyTest {
 
-	@RegisterExtension
-	AbstractEclipseJava context= new EclipseJava22();
-
 	@Test
-	void reportsInterfaceMemberTypesDeterministically() throws CoreException {
-		IPackageFragment pack= context.getSourceFolder().createPackageFragment("test", false, null); //$NON-NLS-1$
-		pack.createCompilationUnit("First.java", //$NON-NLS-1$
-				"package test; interface First { class Status {} }", false, null); //$NON-NLS-1$
-		pack.createCompilationUnit("Second.java", //$NON-NLS-1$
-				"package test; interface Second { class Status {} }", false, null); //$NON-NLS-1$
-		ICompilationUnit owner= pack.createCompilationUnit("Owner.java", //$NON-NLS-1$
-				"package test; class Owner implements Second, First {}", false, null); //$NON-NLS-1$
-		ITypeBinding ownerBinding= ownerBinding(owner);
+	void reportsInterfaceMemberTypesDeterministically() throws IOException {
+		ITypeBinding ownerBinding= ownerBinding(Map.of(
+				"First.java", "package test; interface First { class Status {} }", //$NON-NLS-1$ //$NON-NLS-2$
+				"Second.java", "package test; interface Second { class Status {} }", //$NON-NLS-1$ //$NON-NLS-2$
+				"Owner.java", "package test; class Owner implements Second, First {}")); //$NON-NLS-1$ //$NON-NLS-2$
 
+		assertNotNull(ownerBinding);
 		assertEquals(List.of(
 				"test.First.Status inherited from test.First", //$NON-NLS-1$
 				"test.Second.Status inherited from test.Second"), //$NON-NLS-1$
 				GeneratedNameHierarchyPolicy.inheritedMemberTypeCollisions(ownerBinding, "Status")); //$NON-NLS-1$
 	}
 
-	private static ITypeBinding ownerBinding(ICompilationUnit unit) {
+	private static ITypeBinding ownerBinding(Map<String, String> sources) throws IOException {
+		Path sourceRoot= Files.createTempDirectory("generated-hierarchy-bindings"); //$NON-NLS-1$
+		Path packageDirectory= Files.createDirectories(sourceRoot.resolve("test")); //$NON-NLS-1$
+		for (Map.Entry<String, String> entry : sources.entrySet()) {
+			Files.writeString(packageDirectory.resolve(entry.getKey()), entry.getValue(), StandardCharsets.UTF_8);
+		}
+		String ownerSource= sources.get("Owner.java"); //$NON-NLS-1$
 		ASTParser parser= ASTParser.newParser(AST.getJLSLatest());
-		parser.setSource(unit);
+		parser.setKind(ASTParser.K_COMPILATION_UNIT);
 		parser.setResolveBindings(true);
 		parser.setBindingsRecovery(true);
+		parser.setUnitName("test/Owner.java"); //$NON-NLS-1$
+		parser.setEnvironment(null, new String[] { sourceRoot.toString() },
+				new String[] { StandardCharsets.UTF_8.name() }, true);
+		Map<String, String> options= JavaCore.getOptions();
+		JavaCore.setComplianceOptions(JavaCore.VERSION_21, options);
+		parser.setCompilerOptions(options);
+		parser.setSource(ownerSource.toCharArray());
 		CompilationUnit root= (CompilationUnit) parser.createAST(null);
 		return ((TypeDeclaration) root.types().get(0)).resolveBinding();
 	}

--- a/sandbox_common_test/src/org/sandbox/jdt/cleanup/multifile/GeneratedNameHierarchyPolicyTest.java
+++ b/sandbox_common_test/src/org/sandbox/jdt/cleanup/multifile/GeneratedNameHierarchyPolicyTest.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.cleanup.multifile;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+
+import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
+import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava22;
+
+/** Binding-level tests for inherited generated-name collisions. */
+class GeneratedNameHierarchyPolicyTest {
+
+	@RegisterExtension
+	AbstractEclipseJava context= new EclipseJava22();
+
+	@Test
+	void reportsInterfaceMemberTypesDeterministically() throws CoreException {
+		IPackageFragment pack= context.getSourceFolder().createPackageFragment("test", false, null); //$NON-NLS-1$
+		pack.createCompilationUnit("First.java", //$NON-NLS-1$
+				"package test; interface First { class Status {} }", false, null); //$NON-NLS-1$
+		pack.createCompilationUnit("Second.java", //$NON-NLS-1$
+				"package test; interface Second { class Status {} }", false, null); //$NON-NLS-1$
+		ICompilationUnit owner= pack.createCompilationUnit("Owner.java", //$NON-NLS-1$
+				"package test; class Owner implements Second, First {}", false, null); //$NON-NLS-1$
+		ITypeBinding ownerBinding= ownerBinding(owner);
+
+		assertEquals(List.of(
+				"test.First.Status inherited from test.First", //$NON-NLS-1$
+				"test.Second.Status inherited from test.Second"), //$NON-NLS-1$
+				GeneratedNameHierarchyPolicy.inheritedMemberTypeCollisions(ownerBinding, "Status")); //$NON-NLS-1$
+	}
+
+	private static ITypeBinding ownerBinding(ICompilationUnit unit) {
+		ASTParser parser= ASTParser.newParser(AST.getJLSLatest());
+		parser.setSource(unit);
+		parser.setResolveBindings(true);
+		parser.setBindingsRecovery(true);
+		CompilationUnit root= (CompilationUnit) parser.createAST(null);
+		return ((TypeDeclaration) root.types().get(0)).resolveBinding();
+	}
+}

--- a/sandbox_common_test/src/org/sandbox/jdt/internal/corext/util/NamingUtilsGeneratedNameTest.java
+++ b/sandbox_common_test/src/org/sandbox/jdt/internal/corext/util/NamingUtilsGeneratedNameTest.java
@@ -14,27 +14,23 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
-import org.eclipse.core.runtime.CoreException;
-
-import org.eclipse.jdt.core.ICompilationUnit;
-import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTParser;
 import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.AnonymousClassDeclaration;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 
-import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
-import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava22;
-
 /** Tests shared collision validation for generated JUnit helper classes. */
 class NamingUtilsGeneratedNameTest {
-
-	@RegisterExtension
-	AbstractEclipseJava context= new EclipseJava22();
 
 	@Test
 	void retainsDeterministicFieldAndChecksumNameWhenAvailable() {
@@ -62,14 +58,12 @@ class NamingUtilsGeneratedNameTest {
 	}
 
 	@Test
-	void rejectsAccessibleInheritedMemberTypeWithGeneratedName() throws CoreException {
+	void rejectsAccessibleInheritedMemberTypeWithGeneratedName() throws IOException {
 		String generated= NamingUtils.generateUniqueNestedClassName(parseAnonymous(sourceWithoutCollision()),
 				"resource"); //$NON-NLS-1$
-		IPackageFragment pack= context.getSourceFolder().createPackageFragment("test", false, null); //$NON-NLS-1$
-		pack.createCompilationUnit("Base.java", //$NON-NLS-1$
-				"package test; class Base { protected static class " + generated + " {} }", false, null); //$NON-NLS-1$ //$NON-NLS-2$
-		ICompilationUnit owner= pack.createCompilationUnit("Owner.java", ownerSource("extends Base"), false, null); //$NON-NLS-1$ //$NON-NLS-2$
-		AnonymousClassDeclaration anonymous= parseAnonymous(owner);
+		AnonymousClassDeclaration anonymous= parseAnonymousWithSibling(
+				"package test; class Base { protected static class " + generated + " {} }", //$NON-NLS-1$ //$NON-NLS-2$
+				ownerSource("extends Base")); //$NON-NLS-1$
 
 		IllegalStateException exception= assertThrows(IllegalStateException.class,
 				() -> NamingUtils.generateUniqueNestedClassName(anonymous, "resource")); //$NON-NLS-1$
@@ -79,14 +73,12 @@ class NamingUtilsGeneratedNameTest {
 	}
 
 	@Test
-	void ignoresPrivateMemberTypeInSuperclass() throws CoreException {
+	void ignoresPrivateMemberTypeInSuperclass() throws IOException {
 		String generated= NamingUtils.generateUniqueNestedClassName(parseAnonymous(sourceWithoutCollision()),
 				"resource"); //$NON-NLS-1$
-		IPackageFragment pack= context.getSourceFolder().createPackageFragment("test", false, null); //$NON-NLS-1$
-		pack.createCompilationUnit("Base.java", //$NON-NLS-1$
-				"package test; class Base { private static class " + generated + " {} }", false, null); //$NON-NLS-1$ //$NON-NLS-2$
-		ICompilationUnit owner= pack.createCompilationUnit("Owner.java", ownerSource("extends Base"), false, null); //$NON-NLS-1$ //$NON-NLS-2$
-		AnonymousClassDeclaration anonymous= parseAnonymous(owner);
+		AnonymousClassDeclaration anonymous= parseAnonymousWithSibling(
+				"package test; class Base { private static class " + generated + " {} }", //$NON-NLS-1$ //$NON-NLS-2$
+				ownerSource("extends Base")); //$NON-NLS-1$
 
 		assertEquals(generated, NamingUtils.generateUniqueNestedClassName(anonymous, "resource")); //$NON-NLS-1$
 	}
@@ -98,12 +90,25 @@ class NamingUtilsGeneratedNameTest {
 		return findAnonymous((CompilationUnit) parser.createAST(null));
 	}
 
-	private static AnonymousClassDeclaration parseAnonymous(ICompilationUnit unit) {
+	private static AnonymousClassDeclaration parseAnonymousWithSibling(String baseSource, String ownerSource)
+			throws IOException {
+		Path sourceRoot= Files.createTempDirectory("generated-name-bindings"); //$NON-NLS-1$
+		Path packageDirectory= Files.createDirectories(sourceRoot.resolve("test")); //$NON-NLS-1$
+		Files.writeString(packageDirectory.resolve("Base.java"), baseSource, StandardCharsets.UTF_8); //$NON-NLS-1$
+		Files.writeString(packageDirectory.resolve("Owner.java"), ownerSource, StandardCharsets.UTF_8); //$NON-NLS-1$
+
 		ASTParser parser= ASTParser.newParser(AST.getJLSLatest());
-		parser.setSource(unit);
+		parser.setKind(ASTParser.K_COMPILATION_UNIT);
 		parser.setResolveBindings(true);
 		parser.setBindingsRecovery(true);
 		parser.setStatementsRecovery(true);
+		parser.setUnitName("test/Owner.java"); //$NON-NLS-1$
+		parser.setEnvironment(null, new String[] { sourceRoot.toString() },
+				new String[] { StandardCharsets.UTF_8.name() }, true);
+		Map<String, String> options= JavaCore.getOptions();
+		JavaCore.setComplianceOptions(JavaCore.VERSION_21, options);
+		parser.setCompilerOptions(options);
+		parser.setSource(ownerSource.toCharArray());
 		return findAnonymous((CompilationUnit) parser.createAST(null));
 	}
 

--- a/sandbox_common_test/src/org/sandbox/jdt/internal/corext/util/NamingUtilsGeneratedNameTest.java
+++ b/sandbox_common_test/src/org/sandbox/jdt/internal/corext/util/NamingUtilsGeneratedNameTest.java
@@ -15,15 +15,26 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTParser;
 import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.AnonymousClassDeclaration;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 
+import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
+import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava22;
+
 /** Tests shared collision validation for generated JUnit helper classes. */
 class NamingUtilsGeneratedNameTest {
+
+	@RegisterExtension
+	AbstractEclipseJava context= new EclipseJava22();
 
 	@Test
 	void retainsDeterministicFieldAndChecksumNameWhenAvailable() {
@@ -50,11 +61,53 @@ class NamingUtilsGeneratedNameTest {
 		assertTrue(exception.getMessage().contains("type declaration")); //$NON-NLS-1$
 	}
 
+	@Test
+	void rejectsAccessibleInheritedMemberTypeWithGeneratedName() throws CoreException {
+		String generated= NamingUtils.generateUniqueNestedClassName(parseAnonymous(sourceWithoutCollision()),
+				"resource"); //$NON-NLS-1$
+		IPackageFragment pack= context.getSourceFolder().createPackageFragment("test", false, null); //$NON-NLS-1$
+		pack.createCompilationUnit("Base.java", //$NON-NLS-1$
+				"package test; class Base { protected static class " + generated + " {} }", false, null); //$NON-NLS-1$ //$NON-NLS-2$
+		ICompilationUnit owner= pack.createCompilationUnit("Owner.java", ownerSource("extends Base"), false, null); //$NON-NLS-1$ //$NON-NLS-2$
+		AnonymousClassDeclaration anonymous= parseAnonymous(owner);
+
+		IllegalStateException exception= assertThrows(IllegalStateException.class,
+				() -> NamingUtils.generateUniqueNestedClassName(anonymous, "resource")); //$NON-NLS-1$
+
+		assertTrue(exception.getMessage().contains("inherited member type")); //$NON-NLS-1$
+		assertTrue(exception.getMessage().contains("test.Base." + generated)); //$NON-NLS-1$
+	}
+
+	@Test
+	void ignoresPrivateMemberTypeInSuperclass() throws CoreException {
+		String generated= NamingUtils.generateUniqueNestedClassName(parseAnonymous(sourceWithoutCollision()),
+				"resource"); //$NON-NLS-1$
+		IPackageFragment pack= context.getSourceFolder().createPackageFragment("test", false, null); //$NON-NLS-1$
+		pack.createCompilationUnit("Base.java", //$NON-NLS-1$
+				"package test; class Base { private static class " + generated + " {} }", false, null); //$NON-NLS-1$ //$NON-NLS-2$
+		ICompilationUnit owner= pack.createCompilationUnit("Owner.java", ownerSource("extends Base"), false, null); //$NON-NLS-1$ //$NON-NLS-2$
+		AnonymousClassDeclaration anonymous= parseAnonymous(owner);
+
+		assertEquals(generated, NamingUtils.generateUniqueNestedClassName(anonymous, "resource")); //$NON-NLS-1$
+	}
+
 	private static AnonymousClassDeclaration parseAnonymous(String source) {
 		ASTParser parser= ASTParser.newParser(AST.getJLSLatest());
 		parser.setKind(ASTParser.K_COMPILATION_UNIT);
 		parser.setSource(source.toCharArray());
-		CompilationUnit root= (CompilationUnit) parser.createAST(null);
+		return findAnonymous((CompilationUnit) parser.createAST(null));
+	}
+
+	private static AnonymousClassDeclaration parseAnonymous(ICompilationUnit unit) {
+		ASTParser parser= ASTParser.newParser(AST.getJLSLatest());
+		parser.setSource(unit);
+		parser.setResolveBindings(true);
+		parser.setBindingsRecovery(true);
+		parser.setStatementsRecovery(true);
+		return findAnonymous((CompilationUnit) parser.createAST(null));
+	}
+
+	private static AnonymousClassDeclaration findAnonymous(CompilationUnit root) {
 		AnonymousClassDeclaration[] result= new AnonymousClassDeclaration[1];
 		root.accept(new ASTVisitor() {
 			@Override
@@ -66,16 +119,20 @@ class NamingUtilsGeneratedNameTest {
 		return result[0];
 	}
 
-	private static String sourceWithoutCollision() {
+	private static String ownerSource(String inheritance) {
 		return """
 				package test;
 
-				class Owner {
+				class Owner __INHERITANCE__ {
 					Object resource = new Object() {
 						void before() {
 						}
 					};
 				}
-				""";
+				""".replace("__INHERITANCE__", inheritance); //$NON-NLS-1$
+	}
+
+	private static String sourceWithoutCollision() {
+		return ownerSource(""); //$NON-NLS-1$
 	}
 }

--- a/sandbox_common_test/src/org/sandbox/jdt/internal/corext/util/NamingUtilsGeneratedNameTest.java
+++ b/sandbox_common_test/src/org/sandbox/jdt/internal/corext/util/NamingUtilsGeneratedNameTest.java
@@ -46,8 +46,8 @@ class NamingUtilsGeneratedNameTest {
 	void rejectsExistingNestedTypeWithGeneratedName() {
 		AnonymousClassDeclaration initial= parseAnonymous(sourceWithoutCollision());
 		String generated= NamingUtils.generateUniqueNestedClassName(initial, "resource"); //$NON-NLS-1$
-		String source= sourceWithoutCollision().replace("class Owner {", //$NON-NLS-1$
-				"class Owner {\n\tstatic class " + generated + " {} "); //$NON-NLS-1$ //$NON-NLS-2$
+		String source= sourceWithoutCollision().replace("\tObject resource", //$NON-NLS-1$
+				"\tstatic class " + generated + " {}\n\tObject resource"); //$NON-NLS-1$ //$NON-NLS-2$
 		AnonymousClassDeclaration conflicting= parseAnonymous(source);
 
 		IllegalStateException exception= assertThrows(IllegalStateException.class,


### PR DESCRIPTION
## Problem

The shared generated-name allocator covers declarations, imports, members, locals and prospective reservations, but the JUnit helper-class path could still introduce a nested type that hides an accessible member type inherited from a superclass or interface.

## Change

- add a shared binding-based hierarchy policy in `sandbox_common`;
- traverse superclasses and interfaces with cycle protection and deterministic ordering;
- reject matching public, protected and package-visible inherited member types;
- ignore private member types that are not inherited/accessible;
- apply the policy before generated JUnit helper rewrites are committed;
- add Eclipse-project tests with resolved bindings for an accessible protected collision and a permitted private superclass type.

Int-to-Enum requires no additional call because its automatic closed-source mode already rejects inheritance before name allocation.

Closes #1225