### PR TITLE
Introduce a Sandbox repository service boundary

### DIFF
--- a/docs/adr/0002-adopt-released-jgit-storage-hibernate.md
+++ b/docs/adr/0002-adopt-released-jgit-storage-hibernate.md
@@ -36,9 +36,21 @@ Sandbox owns:
 
 The module consumes released version `0.1.13` from the anonymous static Maven repository documented by the external project. `JGitStorageLibraryBoundary` exposes the public `RepositoryName` and `CoreEntities` contracts to Sandbox code. New integration code must use this boundary or another explicitly reviewed public-library adapter; it must not add new dependencies on copied `org.eclipse.jgit.storage.hibernate` implementation classes.
 
+### Repository-service boundary slice
+
+Before changing the active storage backend, server repository lifecycle code is moved behind `SandboxRepositoryService`:
+
+- REST resources consume stable Sandbox metadata and public JGit `Repository` objects;
+- Smart HTTP delegates repository opening and process-owned handle management to the service;
+- default-repository provisioning uses the same boundary;
+- `CopiedHibernateRepositoryService` is the only application adapter allowed to construct or cache the copied `HibernateRepository` implementation;
+- Search and Java-analysis services may temporarily continue to use the legacy session-factory provider until their dedicated adoption slices.
+
+The resolver retains a deprecated generic compatibility method only so existing integration tests and callers compile during the staged transition. Its erased public contract is `Repository`; new application code must use `getRepositoryService()`. The compatibility method is removed when copied-backend integration tests move to the external Core factory.
+
 ### Subsequent slices
 
-1. Replace repository construction and lifecycle with `jgit-storage-hibernate-core`.
+1. Replace `CopiedHibernateRepositoryService` with a `jgit-storage-hibernate-core` factory adapter and migrate repository lifecycle data.
 2. Replace copied commit/history entities and indexers with `jgit-storage-hibernate-search`.
 3. Replace copied Java AST/history analysis with `jgit-storage-hibernate-java-analysis`.
 4. Move Sandbox-only embeddings and REST query composition behind application-owned interfaces.
@@ -50,6 +62,7 @@ Each slice must preserve repository data through the external migration/adoption
 ## Consequences
 
 - The first slice adds a released dependency without immediately deleting the copied implementation.
-- The temporary coexistence is explicit and bounded by this migration plan.
-- Public external APIs, not implementation packages, define the replacement contract.
+- The repository-service boundary makes the later factory cut-over local instead of requiring simultaneous REST, Smart HTTP and startup rewrites.
+- The temporary coexistence and deprecated compatibility method are explicit and bounded by this migration plan.
+- Public external APIs and application-owned interfaces, not implementation packages, define the replacement contract.
 - Database migration and service cut-over remain separate follow-up changes and cannot be represented as a package rename.

--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/config/RepositoryManagerConfig.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/config/RepositoryManagerConfig.java
@@ -17,73 +17,48 @@ import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.server.repository.CopiedHibernateRepositoryService;
+import org.eclipse.jgit.server.repository.SandboxRepositoryService;
 import org.eclipse.jgit.storage.hibernate.config.HibernateSessionFactoryProvider;
-import org.eclipse.jgit.storage.hibernate.repository.HibernateRepository;
-import org.eclipse.jgit.storage.hibernate.repository.HibernateRepositoryBuilder;
 
-/**
- * Manages automatic creation of default Git repositories on server startup.
- * <p>
- * Reads the {@code JGIT_DEFAULT_REPOS} environment variable (comma-separated
- * list of repository names) and ensures each one exists in the database.
- */
-public class RepositoryManagerConfig {
+/** Creates configured default repositories through the application boundary. */
+public final class RepositoryManagerConfig {
 
-	private static final Logger LOG = Logger
-			.getLogger(RepositoryManagerConfig.class.getName());
+	private static final Logger LOG= Logger.getLogger(RepositoryManagerConfig.class.getName());
 
 	private RepositoryManagerConfig() {
-		// utility class
 	}
 
-	/**
-	 * Initialize default repositories from a comma-separated list of names.
-	 * <p>
-	 * Each repository is created if it does not already exist. Existing
-	 * repositories are not modified.
-	 *
-	 * @param provider
-	 *            the session factory provider
-	 * @param repoList
-	 *            comma-separated list of repository names
-	 */
-	public static void initDefaultRepositories(
-			HibernateSessionFactoryProvider provider, String repoList) {
-		String[] repos = repoList.split(","); //$NON-NLS-1$
-		for (String repoName : repos) {
-			String name = repoName.trim();
-			if (!name.isEmpty()) {
-				try {
-					createRepositoryIfAbsent(provider, name);
-					LOG.log(Level.INFO,
-							"Initialized default repository: {0}", //$NON-NLS-1$
-							name);
-				} catch (IOException e) {
-					LOG.log(Level.WARNING,
-							"Failed to create default repository: " //$NON-NLS-1$
-									+ name,
-							e);
-				}
+	/** Initializes comma-separated repository identities through the shared service. */
+	public static void initDefaultRepositories(SandboxRepositoryService repositories, String repositoryList) {
+		for (String repositoryName : repositoryList.split(",")) { //$NON-NLS-1$
+			String name= repositoryName.strip();
+			if (name.isEmpty()) {
+				continue;
+			}
+			try {
+				repositories.openOrCreate(name);
+				LOG.log(Level.INFO, "Initialized default repository: {0}", name); //$NON-NLS-1$
+			} catch (IOException | RuntimeException exception) {
+				LOG.log(Level.WARNING, "Failed to create default repository: " + name, exception); //$NON-NLS-1$
 			}
 		}
 	}
 
 	/**
-	 * Create a repository if it doesn't already exist.
-	 *
-	 * @param provider
-	 *            the session factory provider
-	 * @param repositoryName
-	 *            the name of the repository to create
-	 * @return the repository (existing or newly created)
-	 * @throws IOException
-	 *             if creation fails
+	 * Compatibility entry point for standalone provisioning callers. The
+	 * temporary adapter is closed after all repository identities are persisted.
 	 */
-	public static HibernateRepository createRepositoryIfAbsent(
-			HibernateSessionFactoryProvider provider,
-			String repositoryName) throws IOException {
-		return new HibernateRepositoryBuilder()
-				.setSessionFactoryProvider(provider)
-				.setRepositoryName(repositoryName).build();
+	public static void initDefaultRepositories(HibernateSessionFactoryProvider provider, String repositoryList) {
+		try (CopiedHibernateRepositoryService repositories= new CopiedHibernateRepositoryService(provider)) {
+			initDefaultRepositories(repositories, repositoryList);
+		}
+	}
+
+	/** Opens or creates one repository through the application boundary. */
+	public static Repository createRepositoryIfAbsent(SandboxRepositoryService repositories, String repositoryName)
+			throws IOException {
+		return repositories.openOrCreate(repositoryName);
 	}
 }

--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/repository/CopiedHibernateRepositoryService.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/repository/CopiedHibernateRepositoryService.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jgit.server.repository;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.eclipse.jgit.internal.storage.dfs.DfsRepositoryDescription;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.storage.hibernate.config.HibernateSessionFactoryProvider;
+import org.eclipse.jgit.storage.hibernate.repository.HibernateRepository;
+import org.eclipse.jgit.storage.hibernate.repository.HibernateRepositoryBuilder;
+
+/**
+ * Temporary adapter for the copied Sandbox Hibernate backend.
+ *
+ * <p>All copied builder and concrete repository dependencies are deliberately
+ * confined to this class so the external Core factory can replace it without
+ * changing REST, startup or Smart HTTP code.</p>
+ */
+public final class CopiedHibernateRepositoryService implements SandboxRepositoryService {
+
+	private final HibernateSessionFactoryProvider sessionFactoryProvider;
+	private final Map<String, HibernateRepository> repositories= new ConcurrentHashMap<>();
+
+	/** Creates the temporary copied-backend adapter. */
+	public CopiedHibernateRepositoryService(HibernateSessionFactoryProvider sessionFactoryProvider) {
+		this.sessionFactoryProvider= Objects.requireNonNull(sessionFactoryProvider, "sessionFactoryProvider"); //$NON-NLS-1$
+	}
+
+	@Override
+	public Repository openOrCreate(String name) throws IOException {
+		return repository(name);
+	}
+
+	@Override
+	public SandboxRepositoryInfo info(String name) throws IOException {
+		String normalized= normalize(name);
+		HibernateRepository repository= repository(normalized);
+		return new SandboxRepositoryInfo(normalized, repository.getGitwebDescription());
+	}
+
+	@Override
+	public SandboxRepositoryInfo setDescription(String name, String description) throws IOException {
+		String normalized= normalize(name);
+		HibernateRepository repository= repository(normalized);
+		repository.setGitwebDescription(description);
+		return new SandboxRepositoryInfo(normalized, repository.getGitwebDescription());
+	}
+
+	@Override
+	public boolean isOpen(String name) {
+		return repositories.containsKey(normalize(name));
+	}
+
+	@Override
+	public void close() {
+		for (HibernateRepository repository : repositories.values()) {
+			repository.close();
+		}
+		repositories.clear();
+	}
+
+	private HibernateRepository repository(String name) throws IOException {
+		String normalized= normalize(name);
+		HibernateRepository existing= repositories.get(normalized);
+		if (existing != null) {
+			return existing;
+		}
+		HibernateRepository created= new HibernateRepositoryBuilder()
+				.setSessionFactoryProvider(sessionFactoryProvider)
+				.setRepositoryName(normalized)
+				.setRepositoryDescription(new DfsRepositoryDescription(normalized))
+				.build();
+		HibernateRepository raced= repositories.putIfAbsent(normalized, created);
+		if (raced != null) {
+			created.close();
+			return raced;
+		}
+		return created;
+	}
+
+	private static String normalize(String name) {
+		String normalized= Objects.requireNonNull(name, "name").strip(); //$NON-NLS-1$
+		if (normalized.startsWith("/")) { //$NON-NLS-1$
+			normalized= normalized.substring(1);
+		}
+		if (normalized.endsWith(".git")) { //$NON-NLS-1$
+			normalized= normalized.substring(0, normalized.length() - 4);
+		}
+		if (normalized.isEmpty()) {
+			throw new IllegalArgumentException("Repository name must not be blank."); //$NON-NLS-1$
+		}
+		return normalized;
+	}
+}

--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/repository/SandboxRepositoryInfo.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/repository/SandboxRepositoryInfo.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jgit.server.repository;
+
+import java.util.Objects;
+
+/** Stable application-owned repository metadata exposed to REST resources. */
+public record SandboxRepositoryInfo(String name, String description) {
+
+	/** Validates repository identity while allowing an absent description. */
+	public SandboxRepositoryInfo {
+		name= Objects.requireNonNull(name, "name").strip(); //$NON-NLS-1$
+		if (name.isEmpty()) {
+			throw new IllegalArgumentException("Repository name must not be blank."); //$NON-NLS-1$
+		}
+	}
+}

--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/repository/SandboxRepositoryService.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/repository/SandboxRepositoryService.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jgit.server.repository;
+
+import java.io.IOException;
+
+import org.eclipse.jgit.lib.Repository;
+
+/** Application-owned repository lifecycle boundary for REST and Smart HTTP. */
+public interface SandboxRepositoryService extends AutoCloseable {
+
+	/** Opens the supplied repository identity, normalizing and creating it when absent. */
+	Repository openOrCreate(String name) throws IOException;
+
+	/** Normalizes, opens or creates a repository and returns stable application metadata. */
+	SandboxRepositoryInfo info(String name) throws IOException;
+
+	/** Normalizes the identity and updates metadata without exposing a backend-specific repository. */
+	SandboxRepositoryInfo setDescription(String name, String description) throws IOException;
+
+	/** Returns whether this process already owns an open handle for the normalized identity. */
+	boolean isOpen(String name);
+
+	/** Closes all application-owned repository handles. */
+	@Override
+	void close();
+}

--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/resolver/HibernateRepositoryResolver.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/resolver/HibernateRepositoryResolver.java
@@ -14,115 +14,84 @@
 package org.eclipse.jgit.server.resolver;
 
 import java.io.IOException;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Objects;
 
-import org.eclipse.jgit.internal.storage.dfs.DfsRepositoryDescription;
 import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.server.repository.CopiedHibernateRepositoryService;
+import org.eclipse.jgit.server.repository.SandboxRepositoryService;
 import org.eclipse.jgit.storage.hibernate.config.HibernateSessionFactoryProvider;
-import org.eclipse.jgit.storage.hibernate.repository.HibernateRepository;
-import org.eclipse.jgit.storage.hibernate.repository.HibernateRepositoryBuilder;
 import org.eclipse.jgit.transport.resolver.RepositoryResolver;
 import org.eclipse.jgit.transport.resolver.ServiceNotEnabledException;
 
 import jakarta.servlet.http.HttpServletRequest;
 
-/**
- * Resolves Git repositories from the Hibernate database backend.
- * <p>
- * Repository instances are cached by name to avoid creating duplicate
- * connections to the same database-backed repository.
- */
+/** Resolves Smart HTTP repositories through the application-owned service boundary. */
 public class HibernateRepositoryResolver
 		implements RepositoryResolver<HttpServletRequest>, AutoCloseable {
 
 	private final HibernateSessionFactoryProvider sessionFactoryProvider;
+	private final SandboxRepositoryService repositories;
 
-	private final Map<String, HibernateRepository> cache = new ConcurrentHashMap<>();
+	/** Creates a resolver using the temporary copied-backend adapter. */
+	public HibernateRepositoryResolver(HibernateSessionFactoryProvider sessionFactoryProvider) {
+		this(sessionFactoryProvider, new CopiedHibernateRepositoryService(sessionFactoryProvider));
+	}
 
-	/**
-	 * Create a resolver backed by the given session factory provider.
-	 *
-	 * @param sessionFactoryProvider
-	 *            the Hibernate session factory provider
-	 */
-	public HibernateRepositoryResolver(
-			HibernateSessionFactoryProvider sessionFactoryProvider) {
-		this.sessionFactoryProvider = sessionFactoryProvider;
+	/** Creates a resolver for an application-owned repository service. */
+	public HibernateRepositoryResolver(SandboxRepositoryService repositories) {
+		this(null, repositories);
+	}
+
+	private HibernateRepositoryResolver(HibernateSessionFactoryProvider sessionFactoryProvider,
+			SandboxRepositoryService repositories) {
+		this.sessionFactoryProvider= sessionFactoryProvider;
+		this.repositories= Objects.requireNonNull(repositories, "repositories"); //$NON-NLS-1$
 	}
 
 	@Override
-	public Repository open(HttpServletRequest req, String name)
-			throws ServiceNotEnabledException {
-		String repoName = normalizeRepoName(name);
+	public Repository open(HttpServletRequest request, String name) throws ServiceNotEnabledException {
 		try {
-			return getOrCreateRepository(repoName);
-		} catch (IOException e) {
-			throw new ServiceNotEnabledException(e.getMessage());
+			return repositories.openOrCreate(name);
+		} catch (IOException | RuntimeException exception) {
+			throw new ServiceNotEnabledException(exception.getMessage());
 		}
 	}
 
 	/**
-	 * Get or create a repository by name.
-	 *
-	 * @param name
-	 *            the repository name
-	 * @return the repository
-	 * @throws IOException
-	 *             if repository creation fails
+	 * Transitional source-compatible access for existing server tests and callers.
+	 * New application code must use {@link #getRepositoryService()} and the public
+	 * {@link Repository} type. The generic return erases to {@code Repository} and
+	 * introduces no copied-backend type into this resolver.
 	 */
-	public HibernateRepository getOrCreateRepository(String name)
-			throws IOException {
-		return cache.computeIfAbsent(name, n -> {
-			try {
-				return new HibernateRepositoryBuilder()
-						.setSessionFactoryProvider(sessionFactoryProvider)
-						.setRepositoryName(n)
-						.setRepositoryDescription(
-								new DfsRepositoryDescription(n))
-						.build();
-			} catch (IOException e) {
-				throw new IllegalStateException(
-						"Failed to create repository: " + n, e); //$NON-NLS-1$
-			}
-		});
+	@Deprecated(forRemoval = true)
+	@SuppressWarnings("unchecked")
+	public <R extends Repository> R getOrCreateRepository(String name) throws IOException {
+		return (R) repositories.openOrCreate(name);
 	}
 
-	/**
-	 * Check if a repository with the given name exists in the cache.
-	 *
-	 * @param name
-	 *            the repository name
-	 * @return true if the repository is cached
-	 */
+	/** Returns whether this resolver already owns an open repository handle. */
 	public boolean hasRepository(String name) {
-		return cache.containsKey(normalizeRepoName(name));
+		return repositories.isOpen(name);
+	}
+
+	/** Returns the application-owned repository service used by REST resources. */
+	public SandboxRepositoryService getRepositoryService() {
+		return repositories;
 	}
 
 	/**
-	 * Get the session factory provider.
-	 *
-	 * @return the session factory provider
+	 * Returns the legacy provider while Search and analytics still use the copied
+	 * implementation. Repository lifecycle code must use {@link #getRepositoryService()}.
 	 */
 	public HibernateSessionFactoryProvider getSessionFactoryProvider() {
+		if (sessionFactoryProvider == null) {
+			throw new IllegalStateException("This resolver was created without a legacy session factory provider."); //$NON-NLS-1$
+		}
 		return sessionFactoryProvider;
 	}
 
 	@Override
 	public void close() {
-		for (HibernateRepository repo : cache.values()) {
-			repo.close();
-		}
-		cache.clear();
-	}
-
-	private static String normalizeRepoName(String name) {
-		if (name.startsWith("/")) { //$NON-NLS-1$
-			name = name.substring(1);
-		}
-		if (name.endsWith(".git")) { //$NON-NLS-1$
-			name = name.substring(0, name.length() - 4);
-		}
-		return name;
+		repositories.close();
 	}
 }

--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/rest/RepositoryResource.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/rest/RepositoryResource.java
@@ -19,9 +19,10 @@ import java.io.PrintWriter;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.eclipse.jgit.server.repository.SandboxRepositoryInfo;
+import org.eclipse.jgit.server.repository.SandboxRepositoryService;
 import org.eclipse.jgit.server.resolver.HibernateRepositoryResolver;
 import org.eclipse.jgit.storage.hibernate.config.HibernateSessionFactoryProvider;
-import org.eclipse.jgit.storage.hibernate.repository.HibernateRepository;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
@@ -31,142 +32,104 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-/**
- * REST endpoint for repository CRUD operations.
- * <ul>
- * <li>{@code POST /api/repos} — create a new repository (body:
- * {"name":"...","description":"..."})</li>
- * <li>{@code GET /api/repos/{name}} — get repository info</li>
- * </ul>
- */
+/** REST endpoint for repository creation and metadata lookup. */
 public class RepositoryResource extends HttpServlet {
 
-	private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID= 1L;
+	private static final Logger LOG= Logger.getLogger(RepositoryResource.class.getName());
 
-	private static final Logger LOG = Logger
-			.getLogger(RepositoryResource.class.getName());
+	private final SandboxRepositoryService repositories;
+	private final Gson gson= new Gson();
 
-	private final HibernateRepositoryResolver resolver;
-
-	private final Gson gson = new Gson();
+	/** Creates a resource using the application-owned repository boundary. */
+	public RepositoryResource(SandboxRepositoryService repositories) {
+		this.repositories= repositories;
+	}
 
 	/**
-	 * Create a repository resource endpoint.
-	 *
-	 * @param provider
-	 *            the session factory provider (reserved for future use)
-	 * @param resolver
-	 *            the repository resolver
+	 * Compatibility constructor while the application still wires the legacy
+	 * Hibernate provider separately for health, search and analytics.
 	 */
 	@SuppressWarnings("unused")
-	public RepositoryResource(HibernateSessionFactoryProvider provider,
-			HibernateRepositoryResolver resolver) {
-		this.resolver = resolver;
+	public RepositoryResource(HibernateSessionFactoryProvider provider, HibernateRepositoryResolver resolver) {
+		this(resolver.getRepositoryService());
 	}
 
 	@Override
-	protected void doPost(HttpServletRequest req, HttpServletResponse resp)
-			throws IOException {
-		resp.setContentType("application/json"); //$NON-NLS-1$
-		resp.setCharacterEncoding("UTF-8"); //$NON-NLS-1$
-
-		StringBuilder sb = new StringBuilder();
-		try (BufferedReader reader = req.getReader()) {
+	protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+		prepare(response);
+		StringBuilder input= new StringBuilder();
+		try (BufferedReader reader= request.getReader()) {
 			String line;
-			while ((line = reader.readLine()) != null) {
-				sb.append(line);
+			while ((line= reader.readLine()) != null) {
+				input.append(line);
 			}
 		}
 
 		try {
-			JsonObject body = JsonParser.parseString(sb.toString())
-					.getAsJsonObject();
-			String name = body.has("name") ? body.get("name").getAsString() //$NON-NLS-1$ //$NON-NLS-2$
-					: null;
-
-			if (name == null || name.trim().isEmpty()) {
-				resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-				try (PrintWriter w = resp.getWriter()) {
-					JsonObject error = new JsonObject();
-					error.addProperty("error", //$NON-NLS-1$
-							"Repository name is required"); //$NON-NLS-1$
-					w.write(gson.toJson(error));
-				}
+			JsonObject body= JsonParser.parseString(input.toString()).getAsJsonObject();
+			String name= body.has("name") ? body.get("name").getAsString() : null; //$NON-NLS-1$ //$NON-NLS-2$
+			if (name == null || name.isBlank()) {
+				writeError(response, HttpServletResponse.SC_BAD_REQUEST, "Repository name is required"); //$NON-NLS-1$
 				return;
 			}
-
-			HibernateRepository repo = resolver
-					.getOrCreateRepository(name.trim());
-			String description = body.has("description") //$NON-NLS-1$
-					? body.get("description").getAsString() //$NON-NLS-1$
-					: null;
-			if (description != null) {
-				repo.setGitwebDescription(description);
-			}
-
-			resp.setStatus(HttpServletResponse.SC_CREATED);
-			try (PrintWriter w = resp.getWriter()) {
-				JsonObject result = new JsonObject();
-				result.addProperty("name", name.trim()); //$NON-NLS-1$
-				result.addProperty("description", //$NON-NLS-1$
-						repo.getGitwebDescription());
-				w.write(gson.toJson(result));
-			}
-		} catch (Exception e) {
-			LOG.log(Level.WARNING, "Error creating repository", e); //$NON-NLS-1$
-			resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-			try (PrintWriter w = resp.getWriter()) {
-				JsonObject error = new JsonObject();
-				error.addProperty("error", //$NON-NLS-1$
-						e.getMessage());
-				w.write(gson.toJson(error));
-			}
+			String normalized= name.strip();
+			SandboxRepositoryInfo info= body.has("description") //$NON-NLS-1$
+					? repositories.setDescription(normalized, body.get("description").getAsString()) //$NON-NLS-1$
+					: repositories.info(normalized);
+			response.setStatus(HttpServletResponse.SC_CREATED);
+			writeInfo(response, info);
+		} catch (Exception exception) {
+			LOG.log(Level.WARNING, "Error creating repository", exception); //$NON-NLS-1$
+			writeError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, exception.getMessage());
 		}
 	}
 
 	@Override
-	protected void doGet(HttpServletRequest req, HttpServletResponse resp)
-			throws IOException {
-		resp.setContentType("application/json"); //$NON-NLS-1$
-		resp.setCharacterEncoding("UTF-8"); //$NON-NLS-1$
-
-		String pathInfo = req.getPathInfo();
+	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+		prepare(response);
+		String pathInfo= request.getPathInfo();
 		if (pathInfo == null || pathInfo.equals("/")) { //$NON-NLS-1$
-			resp.setStatus(HttpServletResponse.SC_OK);
-			try (PrintWriter w = resp.getWriter()) {
-				JsonObject msg = new JsonObject();
-				msg.addProperty("message", //$NON-NLS-1$
-						"Use POST to create repos or GET /repos/{name} for info"); //$NON-NLS-1$
-				w.write(gson.toJson(msg));
+			response.setStatus(HttpServletResponse.SC_OK);
+			try (PrintWriter writer= response.getWriter()) {
+				JsonObject message= new JsonObject();
+				message.addProperty("message", "Use POST to create repos or GET /repos/{name} for info"); //$NON-NLS-1$ //$NON-NLS-2$
+				writer.write(gson.toJson(message));
 			}
 			return;
 		}
 
-		String repoName = pathInfo.substring(1);
+		String repositoryName= pathInfo.substring(1);
 		try {
-			HibernateRepository repo = resolver
-					.getOrCreateRepository(repoName);
-
-			JsonObject result = new JsonObject();
-			result.addProperty("name", repoName); //$NON-NLS-1$
-			result.addProperty("description", //$NON-NLS-1$
-					repo.getGitwebDescription());
-
-			resp.setStatus(HttpServletResponse.SC_OK);
-			try (PrintWriter w = resp.getWriter()) {
-				w.write(gson.toJson(result));
-			}
-		} catch (Exception e) {
-			LOG.log(Level.WARNING, "Error retrieving repository: " //$NON-NLS-1$
-					+ repoName, e);
-			resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-			try (PrintWriter w = resp.getWriter()) {
-				JsonObject error = new JsonObject();
-				error.addProperty("error", //$NON-NLS-1$
-						e.getMessage());
-				w.write(gson.toJson(error));
-			}
+			SandboxRepositoryInfo info= repositories.info(repositoryName);
+			response.setStatus(HttpServletResponse.SC_OK);
+			writeInfo(response, info);
+		} catch (Exception exception) {
+			LOG.log(Level.WARNING, "Error retrieving repository: " + repositoryName, exception); //$NON-NLS-1$
+			writeError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, exception.getMessage());
 		}
 	}
 
+	private static void prepare(HttpServletResponse response) {
+		response.setContentType("application/json"); //$NON-NLS-1$
+		response.setCharacterEncoding("UTF-8"); //$NON-NLS-1$
+	}
+
+	private void writeInfo(HttpServletResponse response, SandboxRepositoryInfo info) throws IOException {
+		try (PrintWriter writer= response.getWriter()) {
+			JsonObject result= new JsonObject();
+			result.addProperty("name", info.name()); //$NON-NLS-1$
+			result.addProperty("description", info.description()); //$NON-NLS-1$
+			writer.write(gson.toJson(result));
+		}
+	}
+
+	private void writeError(HttpServletResponse response, int status, String message) throws IOException {
+		response.setStatus(status);
+		try (PrintWriter writer= response.getWriter()) {
+			JsonObject error= new JsonObject();
+			error.addProperty("error", message); //$NON-NLS-1$
+			writer.write(gson.toJson(error));
+		}
+	}
 }

--- a/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/repository/SandboxRepositoryServiceBoundaryTest.java
+++ b/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/repository/SandboxRepositoryServiceBoundaryTest.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jgit.server.repository;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.server.rest.RepositoryResource;
+import org.eclipse.jgit.server.resolver.HibernateRepositoryResolver;
+import org.junit.Test;
+
+/** Contract tests for the application-owned repository lifecycle boundary. */
+public class SandboxRepositoryServiceBoundaryTest {
+
+	@Test
+	public void exposesPublicJGitRepositoryContract() throws Exception {
+		Method open= SandboxRepositoryService.class.getMethod("openOrCreate", String.class); //$NON-NLS-1$
+
+		assertEquals(Repository.class, open.getReturnType());
+		assertNotNull(RepositoryResource.class.getConstructor(SandboxRepositoryService.class));
+		assertNotNull(HibernateRepositoryResolver.class.getConstructor(SandboxRepositoryService.class));
+	}
+
+	@Test
+	public void repositoryResourceHasNoCopiedBackendField() {
+		assertFalse(Arrays.stream(RepositoryResource.class.getDeclaredFields())
+				.map(Field::getType)
+				.map(Class::getName)
+				.anyMatch(name -> name.startsWith("org.eclipse.jgit.storage.hibernate"))); //$NON-NLS-1$
+	}
+
+	@Test
+	public void validatesApplicationMetadataIdentity() {
+		assertEquals("demo", new SandboxRepositoryInfo(" demo ", null).name()); //$NON-NLS-1$ //$NON-NLS-2$
+		assertThrows(IllegalArgumentException.class, () -> new SandboxRepositoryInfo(" ", null)); //$NON-NLS-1$
+	}
+}


### PR DESCRIPTION
## Problem

The server still constructs and exposes the copied `HibernateRepository` implementation directly from Smart HTTP, REST and startup configuration. That makes the next `jgit-storage-hibernate-core` adoption slice require simultaneous changes across unrelated application surfaces.

## Change

- introduce application-owned `SandboxRepositoryService` and `SandboxRepositoryInfo` contracts;
- confine `HibernateRepositoryBuilder` and concrete copied `HibernateRepository` usage to `CopiedHibernateRepositoryService`;
- route Smart HTTP repository opening and process-owned handle caching through the service;
- route REST creation, lookup and descriptions through stable application metadata;
- route default-repository provisioning through the same boundary;
- retain the legacy session-factory provider only for Search and Java-analysis slices that have not yet migrated;
- retain a deprecated, erased-to-`Repository` generic resolver method for temporary source compatibility with existing integration tests;
- add contract tests that keep the REST and resolver boundary on public JGit/application types;
- update ADR 0002 with the staged cut-over and removal plan.

## Scope

This PR deliberately does **not** switch the active backend or database schema. It makes the later external Core factory replacement local to one adapter and preserves one authoritative copied backend until the data migration slice is proven.

Refs #1303