### PR TITLE
Run dedicated JUnit rule migrations before generic fallback

### DIFF
--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/JUnitCleanUpFixCore.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/JUnitCleanUpFixCore.java
@@ -84,12 +84,14 @@ public enum JUnitCleanUpFixCore {
 	ASSERT_OPTIMIZATION(new AssertOptimizationJUnitPlugin()),
 	ASSUME(new AssumeJUnitPlugin()),
 	ASSUME_OPTIMIZATION(new AssumeOptimizationJUnitPlugin()),
-	RULEEXTERNALRESOURCE(new RuleExternalResourceJUnitPlugin()),
+	// Dedicated rule migrations must claim their types before the generic
+	// ExternalResource rule fallback sees the same field.
 	RULETESTNAME(new RuleTestnameJUnitPlugin()),
 	RULETEMPORARYFOLDER(new RuleTemporayFolderJUnitPlugin()),
 	RULETIMEOUT(new RuleTimeoutJUnitPlugin()),
 	RULEEXPECTEDEXCEPTION(new RuleExpectedExceptionJUnitPlugin()),
 	RULEERRORCOLLECTOR(new RuleErrorCollectorJUnitPlugin()),
+	RULEEXTERNALRESOURCE(new RuleExternalResourceJUnitPlugin()),
 	EXTERNALRESOURCE(new ExternalResourceJUnitPlugin()),
 	LOSTTESTS(new LostTestFinderJUnitPlugin()),
 	PARAMETERIZED(new ParameterizedTestJUnitPlugin()),

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/RuleExternalResourceJUnitPlugin.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/RuleExternalResourceJUnitPlugin.java
@@ -16,6 +16,7 @@ package org.sandbox.jdt.internal.corext.fix.helper;
 import static org.sandbox.jdt.internal.corext.fix.helper.lib.JUnitConstants.*;
 
 import java.util.List;
+import java.util.Set;
 
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
@@ -41,8 +42,15 @@ import org.sandbox.jdt.triggerpattern.api.PatternKind;
  *
  * @since 1.3.0
  */
-@CleanupPattern(value = "@Rule public $type $name", kind = PatternKind.FIELD, qualifiedType = ORG_JUNIT_RULES_EXTERNAL_RESOURCE, cleanupId = "cleanup.junit.ruleexternalresource", description = "Migrate @Rule ExternalResource to JUnit 5 extension", displayName = "JUnit 4 @Rule ExternalResource \u2192 JUnit 5 Extension")
+@CleanupPattern(value = "@Rule public $type $name", kind = PatternKind.FIELD, qualifiedType = ORG_JUNIT_RULES_EXTERNAL_RESOURCE, cleanupId = "cleanup.junit.ruleexternalresource", description = "Migrate @Rule ExternalResource to JUnit 5 extension", displayName = "JUnit 4 @Rule ExternalResource → JUnit 5 Extension")
 public class RuleExternalResourceJUnitPlugin extends TriggerPatternCleanupPlugin {
+
+	private static final Set<String> DEDICATED_RULE_TYPES= Set.of(
+			ORG_JUNIT_RULES_TEST_NAME,
+			ORG_JUNIT_RULES_TEMPORARY_FOLDER,
+			ORG_JUNIT_RULES_TIMEOUT,
+			ORG_JUNIT_RULES_EXPECTED_EXCEPTION,
+			ORG_JUNIT_RULES_ERROR_COLLECTOR);
 
 	/**
 	 * Override getPatterns() to match both @Rule and @ClassRule variants.
@@ -66,15 +74,24 @@ public class RuleExternalResourceJUnitPlugin extends TriggerPatternCleanupPlugin
 		if (binding == null) {
 			return null;
 		}
-		// Exclude specific rule types handled by dedicated plugins
-		String qualifiedName = binding.getQualifiedName();
-		if (ORG_JUNIT_RULES_TEST_NAME.equals(qualifiedName)
-				|| ORG_JUNIT_RULES_TEMPORARY_FOLDER.equals(qualifiedName)) {
+		String qualifiedName= binding.getErasure().getQualifiedName();
+		if (DEDICATED_RULE_TYPES.contains(qualifiedName) || !isExternalResourceHierarchy(binding)) {
 			return null;
 		}
 		JunitHolder holder = new JunitHolder();
 		holder.setMinv(fieldDecl);
 		return holder;
+	}
+
+	private static boolean isExternalResourceHierarchy(ITypeBinding binding) {
+		ITypeBinding current= binding.getErasure();
+		while (current != null) {
+			if (ORG_JUNIT_RULES_EXTERNAL_RESOURCE.equals(current.getQualifiedName())) {
+				return true;
+			}
+			current= current.getSuperclass();
+		}
+		return false;
 	}
 
 	@Override
@@ -112,6 +129,7 @@ public class RuleExternalResourceJUnitPlugin extends TriggerPatternCleanupPlugin
 							protected void afterEach() {
 							}
 						}
+					}
 					"""; //$NON-NLS-1$
 		}
 		return """
@@ -129,6 +147,7 @@ public class RuleExternalResourceJUnitPlugin extends TriggerPatternCleanupPlugin
 
 					@Rule
 					public ExternalResource er= new MyExternalResource();
+				}
 				"""; //$NON-NLS-1$
 	}
 

--- a/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/JUnitRuleCasesActivationTest.java
+++ b/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/JUnitRuleCasesActivationTest.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.quickfix.Java8;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.junit.JUnitCore;
+
+import org.sandbox.jdt.internal.corext.fix2.MYCleanUpConstants;
+import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
+import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava17;
+
+/** Re-runs the historical rule-case matrix as an active regression suite. */
+class JUnitRuleCasesActivationTest {
+
+	@RegisterExtension
+	AbstractEclipseJava context= new EclipseJava17();
+
+	IPackageFragmentRoot root;
+
+	@BeforeEach
+	void setup() throws CoreException {
+		root= context.createClasspathForJUnit(JUnitCore.JUNIT4_CONTAINER_PATH);
+	}
+
+	@ParameterizedTest
+	@EnumSource(MigrationRulesToExtensionsTest.RuleCases.class)
+	void migratesEveryDocumentedRuleCase(MigrationRulesToExtensionsTest.RuleCases testCase) throws CoreException {
+		IPackageFragment pack= root.createPackageFragment("test", true, null); //$NON-NLS-1$
+		ICompilationUnit unit= pack.createCompilationUnit("MyTest.java", testCase.given, true, null); //$NON-NLS-1$
+		context.enable(MYCleanUpConstants.JUNIT_CLEANUP);
+		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_4_TEST);
+		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_4_RULETEMPORARYFOLDER);
+		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_4_RULETESTNAME);
+		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_4_RULEEXTERNALRESOURCE);
+		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_4_RULETIMEOUT);
+		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_4_RULEERRORCOLLECTOR);
+		context.assertRefactoringResultAsExpected(new ICompilationUnit[] { unit },
+				new String[] { testCase.expected }, null);
+	}
+}

--- a/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/RuleCleanupPrecedenceTest.java
+++ b/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/RuleCleanupPrecedenceTest.java
@@ -1,0 +1,132 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.quickfix.Java8;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.junit.JUnitCore;
+
+import org.sandbox.jdt.internal.corext.fix2.MYCleanUpConstants;
+import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
+import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava17;
+
+/** Regression tests for precedence between dedicated and generic JUnit rule migrations. */
+public class RuleCleanupPrecedenceTest {
+
+	@RegisterExtension
+	AbstractEclipseJava context= new EclipseJava17();
+
+	@Test
+	public void migratesTemporaryFolderWhenGenericExternalResourceCleanupIsAlsoEnabled() throws CoreException {
+		IPackageFragment pack= createJUnit4And5Package();
+		ICompilationUnit unit= pack.createCompilationUnit("MyTest.java", //$NON-NLS-1$
+				"""
+				package test;
+				import java.io.File;
+				import org.junit.Rule;
+				import org.junit.Test;
+				import org.junit.rules.TemporaryFolder;
+
+				public class MyTest {
+					@Rule
+					public TemporaryFolder folder = new TemporaryFolder();
+
+					@Test
+					public void createsFile() throws Exception {
+						File file = folder.newFile("test.txt");
+					}
+				}
+				""", false, null); //$NON-NLS-1$
+
+		context.enable(MYCleanUpConstants.JUNIT_CLEANUP);
+		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_4_TEST);
+		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_4_RULEEXTERNALRESOURCE);
+		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_4_RULETEMPORARYFOLDER);
+
+		context.assertRefactoringResultAsExpected(new ICompilationUnit[] { unit }, new String[] {
+				"""
+				package test;
+				import java.io.File;
+				import java.nio.file.Files;
+				import java.nio.file.Path;
+
+				import org.junit.jupiter.api.Test;
+				import org.junit.jupiter.api.io.TempDir;
+
+				public class MyTest {
+					@TempDir
+					Path folder;
+					@Test
+					public void createsFile() throws Exception {
+						File file = Files.createFile(folder.resolve("test.txt")).toFile();
+					}
+				}
+				"""
+		}, null);
+	}
+
+	@Test
+	public void migratesTimeoutWhenGenericExternalResourceCleanupIsAlsoEnabled() throws CoreException {
+		IPackageFragment pack= createJUnit4And5Package();
+		ICompilationUnit unit= pack.createCompilationUnit("MyTest.java", //$NON-NLS-1$
+				"""
+				package test;
+				import org.junit.Rule;
+				import org.junit.Test;
+				import org.junit.rules.Timeout;
+
+				public class MyTest {
+					@Rule
+					public Timeout timeout = Timeout.seconds(5);
+
+					@Test
+					public void runs() {
+					}
+				}
+				""", false, null); //$NON-NLS-1$
+
+		context.enable(MYCleanUpConstants.JUNIT_CLEANUP);
+		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_4_TEST);
+		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_4_RULEEXTERNALRESOURCE);
+		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_4_RULETIMEOUT);
+
+		context.assertRefactoringResultAsExpected(new ICompilationUnit[] { unit }, new String[] {
+				"""
+				package test;
+				import java.util.concurrent.TimeUnit;
+
+				import org.junit.jupiter.api.Test;
+				import org.junit.jupiter.api.Timeout;
+
+				@Timeout(value = 5, unit = TimeUnit.SECONDS)
+				public class MyTest {
+					@Test
+					public void runs() {
+					}
+				}
+				"""
+		}, null);
+	}
+
+	private IPackageFragment createJUnit4And5Package() throws CoreException {
+		IPackageFragmentRoot root= context.createClasspathForJUnit(JUnitCore.JUNIT4_CONTAINER_PATH);
+		AbstractEclipseJava.addToClasspath(context.getJavaProject(),
+				JavaCore.newContainerEntry(JUnitCore.JUNIT5_CONTAINER_PATH));
+		return root.createPackageFragment("test", true, null); //$NON-NLS-1$
+	}
+}


### PR DESCRIPTION
## Problem

The generic `RuleExternalResourceJUnitPlugin` can see fields belonging to dedicated rule migrations. `TemporaryFolder` is an actual `ExternalResource` subtype; Timeout and ErrorCollector cases were also accepted by the broad pattern before the plugin validated their hierarchy. The generic plugin then either consumed the field before the dedicated plugin or tried to locate an ExternalResource source type and failed with `source not specified`.

## Change

- run every dedicated rule migration (`TestName`, `TemporaryFolder`, `Timeout`, `ExpectedException`, `ErrorCollector`) before the generic fallback;
- make the generic plugin independently require a real `ExternalResource` type hierarchy;
- explicitly exclude all dedicated rule types from the generic plugin;
- retain the isolated rewrite-operation data introduced by #1319;
- add combined TemporaryFolder and Timeout regression tests;
- reactivate the complete twelve-case historical rule migration matrix.

## Scope

This is a single commit directly on the current `main`. It fixes local rule-plugin interference; the broader coordinated multi-file roadmap remains tracked by #1217.

Refs #1217