### PR TITLE
Add public jgit-storage-hibernate factory adapter

### DIFF
--- a/docs/adr/0002-adopt-released-jgit-storage-hibernate.md
+++ b/docs/adr/0002-adopt-released-jgit-storage-hibernate.md
@@ -48,14 +48,21 @@ Before changing the active storage backend, server repository lifecycle code is 
 
 The resolver retains a deprecated generic compatibility method only so existing integration tests and callers compile during the staged transition. Its erased public contract is `Repository`; new application code must use `getRepositoryService()`. The compatibility method is removed when copied-backend integration tests move to the external Core factory.
 
+### Public factory-adapter slice
+
+`ExternalHibernateRepositoryService` adapts the released `HibernateRepositoryFactory` and owns the resulting `HibernateGitStorage` handles. It exposes only public JGit `Repository` instances and `SandboxRepositoryInfo` to the server. Unit tests use a fake implementation of the released factory contract, so the application-side lifecycle, identity normalization, caching, metadata and close semantics can be verified without importing the external implementation packages or requiring a database.
+
+This adapter is deliberately not made the production default in the same slice. The existing Sandbox `SessionFactory` still registers copied Core entity classes and owns a schema whose exact adoption state must be established before the external factory is allowed to write to it. Registering copied and external Core entities together would also create duplicate persistence mappings. Production wiring changes only after the external Core migration runbook, Hibernate validation and repository-level rollback test have succeeded on a restored database.
+
 ### Subsequent slices
 
-1. Replace `CopiedHibernateRepositoryService` with a `jgit-storage-hibernate-core` factory adapter and migrate repository lifecycle data.
-2. Replace copied commit/history entities and indexers with `jgit-storage-hibernate-search`.
-3. Replace copied Java AST/history analysis with `jgit-storage-hibernate-java-analysis`.
-4. Move Sandbox-only embeddings and REST query composition behind application-owned interfaces.
-5. Remove copied generic packages, migrations and dependencies.
-6. Add a build rule that rejects new source references to removed/copied implementation packages.
+1. Classify the existing Core schema, apply the matching `jgit-storage-hibernate-core` adoption/migration path and verify backup restoration.
+2. Construct a persistence context with external Core entities plus only the still-required Sandbox projection entities, then switch production wiring from `CopiedHibernateRepositoryService` to `ExternalHibernateRepositoryService`.
+3. Replace copied commit/history entities and indexers with `jgit-storage-hibernate-search`.
+4. Replace copied Java AST/history analysis with `jgit-storage-hibernate-java-analysis`.
+5. Move Sandbox-only embeddings and REST query composition behind application-owned interfaces.
+6. Remove copied generic packages, migrations and dependencies.
+7. Add a build rule that rejects new source references to removed/copied implementation packages.
 
 Each slice must preserve repository data through the external migration/adoption runbook and must keep one authoritative implementation active.
 
@@ -63,6 +70,7 @@ Each slice must preserve repository data through the external migration/adoption
 
 - The first slice adds a released dependency without immediately deleting the copied implementation.
 - The repository-service boundary makes the later factory cut-over local instead of requiring simultaneous REST, Smart HTTP and startup rewrites.
+- The public factory adapter completes the application-side cut-over point while leaving the persistence migration explicit and independently reversible.
 - The temporary coexistence and deprecated compatibility method are explicit and bounded by this migration plan.
 - Public external APIs and application-owned interfaces, not implementation packages, define the replacement contract.
 - Database migration and service cut-over remain separate follow-up changes and cannot be represented as a package rename.

--- a/docs/adr/0002-adopt-released-jgit-storage-hibernate.md
+++ b/docs/adr/0002-adopt-released-jgit-storage-hibernate.md
@@ -34,7 +34,7 @@ Sandbox owns:
 
 ### First slice
 
-The module consumes released version `0.1.13` from the anonymous static Maven repository documented by the external project. `JGitStorageLibraryBoundary` exposes the public `RepositoryName` and `CoreEntities` contracts to Sandbox code. New integration code must use this boundary or another explicitly reviewed public-library adapter; it must not add new dependencies on copied `org.eclipse.jgit.storage.hibernate` implementation classes.
+The module consumes released version `0.1.14` from the anonymous static Maven repository documented by the external project. The release preserves the supported public API of `0.1.13` while adding the migration, repository-lock and chunked-storage work needed by the later database cut-over. `JGitStorageLibraryBoundary` exposes the public `RepositoryName` and `CoreEntities` contracts to Sandbox code. New integration code must use this boundary or another explicitly reviewed public-library adapter; it must not add new dependencies on copied `org.eclipse.jgit.storage.hibernate` implementation classes.
 
 ### Repository-service boundary slice
 

--- a/sandbox-jgit-server-webapp/pom.xml
+++ b/sandbox-jgit-server-webapp/pom.xml
@@ -22,7 +22,7 @@
 		<!-- Keep the server's direct ORM dependency aligned with the storage module's Search mapper. -->
 		<hibernate.version>7.4.5.Final</hibernate.version>
 		<hibernate-search.version>8.4.0.Final</hibernate-search.version>
-		<jgit-storage-hibernate.version>0.1.13</jgit-storage-hibernate.version>
+		<jgit-storage-hibernate.version>0.1.14</jgit-storage-hibernate.version>
 	</properties>
 
 	<repositories>

--- a/sandbox-jgit-server-webapp/pom.xml
+++ b/sandbox-jgit-server-webapp/pom.xml
@@ -22,7 +22,21 @@
 		<!-- Keep the server's direct ORM dependency aligned with the storage module's Search mapper. -->
 		<hibernate.version>7.4.5.Final</hibernate.version>
 		<hibernate-search.version>8.4.0.Final</hibernate-search.version>
+		<jgit-storage-hibernate.version>0.1.13</jgit-storage-hibernate.version>
 	</properties>
+
+	<repositories>
+		<repository>
+			<id>jgit-storage-hibernate-public</id>
+			<url>https://raw.githubusercontent.com/carstenartur/jgit-storage-hibernate/maven-repository/</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
 
 	<dependencies>
 		<!-- JGit core -->
@@ -39,11 +53,16 @@
 			<version>${jgit.version}</version>
 		</dependency>
 
-		<!-- JGit Hibernate storage module -->
+		<!-- Sandbox integration and the released public repository factory contract -->
 		<dependency>
 			<groupId>org.sandbox</groupId>
 			<artifactId>sandbox-jgit-storage-hibernate</artifactId>
 			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.github.carstenartur</groupId>
+			<artifactId>jgit-storage-hibernate-core</artifactId>
+			<version>${jgit-storage-hibernate.version}</version>
 		</dependency>
 
 		<!-- Eclipse JDT Core needed by FileTypeStrategyRegistry at runtime -->

--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/repository/ExternalHibernateRepositoryService.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/repository/ExternalHibernateRepositoryService.java
@@ -67,10 +67,22 @@ public final class ExternalHibernateRepositoryService implements SandboxReposito
 
 	@Override
 	public void close() {
+		RuntimeException failure= null;
 		for (HibernateGitStorage storage : storages.values()) {
-			storage.close();
+			try {
+				storage.close();
+			} catch (RuntimeException exception) {
+				if (failure == null) {
+					failure= exception;
+				} else {
+					failure.addSuppressed(exception);
+				}
+			}
 		}
 		storages.clear();
+		if (failure != null) {
+			throw failure;
+		}
 	}
 
 	private HibernateGitStorage storage(String name) {

--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/repository/ExternalHibernateRepositoryService.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/repository/ExternalHibernateRepositoryService.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jgit.server.repository;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.eclipse.jgit.lib.Repository;
+
+import io.github.carstenartur.jgit.storage.hibernate.HibernateGitStorage;
+import io.github.carstenartur.jgit.storage.hibernate.HibernateRepositoryFactory;
+import io.github.carstenartur.jgit.storage.hibernate.RepositoryName;
+
+/**
+ * Adapts the released {@code jgit-storage-hibernate-core} factory to the
+ * application-owned repository service contract.
+ *
+ * <p>The adapter owns every storage handle it opens. Application and transport
+ * code receive only public JGit {@link Repository} instances and Sandbox
+ * metadata. The production cut-over can therefore replace the copied backend
+ * without changing REST or Smart HTTP callers.</p>
+ */
+public final class ExternalHibernateRepositoryService implements SandboxRepositoryService {
+
+	private final HibernateRepositoryFactory repositoryFactory;
+	private final Map<String, HibernateGitStorage> storages= new ConcurrentHashMap<>();
+
+	/** Creates an adapter for the released public repository factory. */
+	public ExternalHibernateRepositoryService(HibernateRepositoryFactory repositoryFactory) {
+		this.repositoryFactory= Objects.requireNonNull(repositoryFactory, "repositoryFactory"); //$NON-NLS-1$
+	}
+
+	@Override
+	public Repository openOrCreate(String name) throws IOException {
+		return storage(name).repository();
+	}
+
+	@Override
+	public SandboxRepositoryInfo info(String name) throws IOException {
+		String normalized= normalize(name);
+		Repository repository= storage(normalized).repository();
+		return new SandboxRepositoryInfo(normalized, repository.getGitwebDescription());
+	}
+
+	@Override
+	public SandboxRepositoryInfo setDescription(String name, String description) throws IOException {
+		String normalized= normalize(name);
+		Repository repository= storage(normalized).repository();
+		repository.setGitwebDescription(description);
+		return new SandboxRepositoryInfo(normalized, repository.getGitwebDescription());
+	}
+
+	@Override
+	public boolean isOpen(String name) {
+		return storages.containsKey(normalize(name));
+	}
+
+	@Override
+	public void close() {
+		for (HibernateGitStorage storage : storages.values()) {
+			storage.close();
+		}
+		storages.clear();
+	}
+
+	private HibernateGitStorage storage(String name) {
+		String normalized= normalize(name);
+		return storages.computeIfAbsent(normalized,
+				key -> repositoryFactory.open(new RepositoryName(key)));
+	}
+
+	private static String normalize(String name) {
+		String normalized= Objects.requireNonNull(name, "name").strip(); //$NON-NLS-1$
+		if (normalized.startsWith("/")) { //$NON-NLS-1$
+			normalized= normalized.substring(1);
+		}
+		if (normalized.endsWith(".git")) { //$NON-NLS-1$
+			normalized= normalized.substring(0, normalized.length() - 4);
+		}
+		if (normalized.isEmpty()) {
+			throw new IllegalArgumentException("Repository name must not be blank."); //$NON-NLS-1$
+		}
+		return normalized;
+	}
+}

--- a/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/repository/ExternalHibernateRepositoryServiceTest.java
+++ b/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/repository/ExternalHibernateRepositoryServiceTest.java
@@ -11,7 +11,9 @@
 package org.eclipse.jgit.server.repository;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.util.LinkedHashMap;
@@ -59,6 +61,23 @@ public class ExternalHibernateRepositoryServiceTest {
 		}
 	}
 
+	@Test
+	public void closesEveryStorageWhenOneCloseFails() throws Exception {
+		FakeFactory factory= new FakeFactory();
+		ExternalHibernateRepositoryService service= new ExternalHibernateRepositoryService(factory);
+		service.openOrCreate("first"); //$NON-NLS-1$
+		service.openOrCreate("second"); //$NON-NLS-1$
+		factory.storages.get("first").closeFailure= new IllegalStateException("first close failed"); //$NON-NLS-1$ //$NON-NLS-2$
+
+		IllegalStateException failure= assertThrows(IllegalStateException.class, service::close);
+
+		assertEquals("first close failed", failure.getMessage()); //$NON-NLS-1$
+		assertTrue(factory.storages.get("first").closed); //$NON-NLS-1$
+		assertTrue(factory.storages.get("second").closed); //$NON-NLS-1$
+		assertFalse(service.isOpen("first")); //$NON-NLS-1$
+		assertFalse(service.isOpen("second")); //$NON-NLS-1$
+	}
+
 	private static final class FakeFactory implements HibernateRepositoryFactory {
 
 		private final Map<String, FakeStorage> storages= new LinkedHashMap<>();
@@ -81,6 +100,7 @@ public class ExternalHibernateRepositoryServiceTest {
 
 		private final Repository repository;
 		private boolean closed;
+		private RuntimeException closeFailure;
 
 		private FakeStorage(Repository repository) {
 			this.repository= repository;
@@ -95,6 +115,9 @@ public class ExternalHibernateRepositoryServiceTest {
 		public void close() {
 			closed= true;
 			repository.close();
+			if (closeFailure != null) {
+				throw closeFailure;
+			}
 		}
 	}
 }

--- a/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/repository/ExternalHibernateRepositoryServiceTest.java
+++ b/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/repository/ExternalHibernateRepositoryServiceTest.java
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jgit.server.repository;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.eclipse.jgit.internal.storage.dfs.DfsRepositoryDescription;
+import org.eclipse.jgit.internal.storage.dfs.InMemoryRepository;
+import org.eclipse.jgit.lib.Repository;
+import org.junit.Test;
+
+import io.github.carstenartur.jgit.storage.hibernate.HibernateGitStorage;
+import io.github.carstenartur.jgit.storage.hibernate.HibernateRepositoryFactory;
+import io.github.carstenartur.jgit.storage.hibernate.RepositoryDeletionResult;
+import io.github.carstenartur.jgit.storage.hibernate.RepositoryName;
+
+/** Tests the application adapter against only the released public Core API. */
+public class ExternalHibernateRepositoryServiceTest {
+
+	@Test
+	public void normalizesAndCachesFactoryOwnedStorage() throws Exception {
+		FakeFactory factory= new FakeFactory();
+		ExternalHibernateRepositoryService service= new ExternalHibernateRepositoryService(factory);
+
+		Repository first= service.openOrCreate("/demo.git"); //$NON-NLS-1$
+		Repository second= service.openOrCreate("demo"); //$NON-NLS-1$
+
+		assertSame(first, second);
+		assertEquals(1, factory.storages.size());
+		assertTrue(factory.storages.containsKey("demo")); //$NON-NLS-1$
+		assertTrue(service.isOpen("demo.git")); //$NON-NLS-1$
+
+		service.close();
+		assertTrue(factory.storages.get("demo").closed); //$NON-NLS-1$
+	}
+
+	@Test
+	public void readsAndUpdatesDescriptionThroughPublicRepository() throws Exception {
+		FakeFactory factory= new FakeFactory();
+		try (ExternalHibernateRepositoryService service= new ExternalHibernateRepositoryService(factory)) {
+			SandboxRepositoryInfo updated= service.setDescription("demo", "Repository description"); //$NON-NLS-1$ //$NON-NLS-2$
+
+			assertEquals("demo", updated.name()); //$NON-NLS-1$
+			assertEquals("Repository description", updated.description()); //$NON-NLS-1$
+			assertEquals(updated, service.info("/demo.git")); //$NON-NLS-1$
+		}
+	}
+
+	private static final class FakeFactory implements HibernateRepositoryFactory {
+
+		private final Map<String, FakeStorage> storages= new LinkedHashMap<>();
+
+		@Override
+		public HibernateGitStorage open(RepositoryName repositoryName) {
+			FakeStorage storage= new FakeStorage(new InMemoryRepository(
+					new DfsRepositoryDescription(repositoryName.value())));
+			storages.put(repositoryName.value(), storage);
+			return storage;
+		}
+
+		@Override
+		public RepositoryDeletionResult deleteRepository(RepositoryName repositoryName) {
+			throw new UnsupportedOperationException(repositoryName.value());
+		}
+	}
+
+	private static final class FakeStorage implements HibernateGitStorage {
+
+		private final Repository repository;
+		private boolean closed;
+
+		private FakeStorage(Repository repository) {
+			this.repository= repository;
+		}
+
+		@Override
+		public Repository repository() {
+			return repository;
+		}
+
+		@Override
+		public void close() {
+			closed= true;
+			repository.close();
+		}
+	}
+}

--- a/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/repository/SandboxRepositoryServiceBoundaryTest.java
+++ b/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/repository/SandboxRepositoryServiceBoundaryTest.java
@@ -24,6 +24,8 @@ import org.eclipse.jgit.server.rest.RepositoryResource;
 import org.eclipse.jgit.server.resolver.HibernateRepositoryResolver;
 import org.junit.Test;
 
+import io.github.carstenartur.jgit.storage.hibernate.HibernateRepositoryFactory;
+
 /** Contract tests for the application-owned repository lifecycle boundary. */
 public class SandboxRepositoryServiceBoundaryTest {
 
@@ -34,11 +36,20 @@ public class SandboxRepositoryServiceBoundaryTest {
 		assertEquals(Repository.class, open.getReturnType());
 		assertNotNull(RepositoryResource.class.getConstructor(SandboxRepositoryService.class));
 		assertNotNull(HibernateRepositoryResolver.class.getConstructor(SandboxRepositoryService.class));
+		assertNotNull(ExternalHibernateRepositoryService.class.getConstructor(HibernateRepositoryFactory.class));
 	}
 
 	@Test
 	public void repositoryResourceHasNoCopiedBackendField() {
 		assertFalse(Arrays.stream(RepositoryResource.class.getDeclaredFields())
+				.map(Field::getType)
+				.map(Class::getName)
+				.anyMatch(name -> name.startsWith("org.eclipse.jgit.storage.hibernate"))); //$NON-NLS-1$
+	}
+
+	@Test
+	public void externalAdapterHasNoCopiedBackendField() {
+		assertFalse(Arrays.stream(ExternalHibernateRepositoryService.class.getDeclaredFields())
 				.map(Field::getType)
 				.map(Class::getName)
 				.anyMatch(name -> name.startsWith("org.eclipse.jgit.storage.hibernate"))); //$NON-NLS-1$

--- a/sandbox-jgit-storage-hibernate/pom.xml
+++ b/sandbox-jgit-storage-hibernate/pom.xml
@@ -23,7 +23,7 @@
 		<!-- Hibernate Search 8.4 targets Hibernate ORM 7.4; keep the mapper stack aligned. -->
 		<hibernate.version>7.4.5.Final</hibernate.version>
 		<hibernate-search.version>8.4.0.Final</hibernate-search.version>
-		<jgit-storage-hibernate.version>0.1.13</jgit-storage-hibernate.version>
+		<jgit-storage-hibernate.version>0.1.14</jgit-storage-hibernate.version>
 	</properties>
 
 	<repositories>

--- a/sandbox-jgit-storage-hibernate/tst/org/sandbox/jgit/storage/integration/JGitStorageLibraryBoundaryTest.java
+++ b/sandbox-jgit-storage-hibernate/tst/org/sandbox/jgit/storage/integration/JGitStorageLibraryBoundaryTest.java
@@ -39,7 +39,9 @@ class JGitStorageLibraryBoundaryTest {
 
 		assertEquals(List.of(
 				"io.github.carstenartur.jgit.storage.hibernate.entity.GitPackEntity", //$NON-NLS-1$
-				"io.github.carstenartur.jgit.storage.hibernate.entity.GitReflogEntity"), //$NON-NLS-1$
+				"io.github.carstenartur.jgit.storage.hibernate.entity.GitPackChunkEntity", //$NON-NLS-1$
+				"io.github.carstenartur.jgit.storage.hibernate.entity.GitReflogEntity", //$NON-NLS-1$
+				"io.github.carstenartur.jgit.storage.hibernate.entity.GitRepositoryLockEntity"), //$NON-NLS-1$
 				entities.stream().map(Class::getName).toList());
 		assertTrue(entities.stream().allMatch(type ->
 				type.getPackageName().startsWith("io.github.carstenartur.jgit.storage.hibernate"))); //$NON-NLS-1$


### PR DESCRIPTION
## Problem

The server-side `SandboxRepositoryService` boundary exists, but its only implementation still constructs the copied `org.eclipse.jgit.storage.hibernate` backend. Switching REST and Smart HTTP directly to the released Core implementation would otherwise mix application changes, persistence mappings and schema migration in one unsafe cut-over.

## Change

- pin both consuming modules to the released, `0.1.13`-compatible `jgit-storage-hibernate-core:0.1.14` artifact;
- add `ExternalHibernateRepositoryService`, backed only by the released public `HibernateRepositoryFactory`, `HibernateGitStorage` and `RepositoryName` contracts;
- keep storage-handle ownership, repository-name normalization, caching, metadata access and close semantics inside the application adapter;
- expose only public JGit `Repository` instances and `SandboxRepositoryInfo` to callers;
- ensure concurrent access opens at most one storage handle per normalized repository identity;
- close every owned storage handle during shutdown even when an earlier close fails, then propagate the collected failure;
- add active unit tests with a fake public factory and in-memory JGit repositories, including failed-close cleanup;
- extend the boundary contract test so the external adapter cannot acquire copied-backend fields;
- declare the external Core dependency and anonymous repository directly in the server module;
- document why production wiring and schema adoption remain a separate, reversible slice.

## Scope

This PR does **not** change the active production backend or register external and copied Core entities in the same `SessionFactory`. The next slice must classify the existing schema with the released read-only preflight, validate a supported PostgreSQL/HSQLDB adoption path on a restored database and only then replace `CopiedHibernateRepositoryService` in application startup.

Refs #1303