### PR TITLE
Activate Platform Status cleanup regression

### DIFF
--- a/sandbox_platform_helper/src/org/sandbox/jdt/internal/corext/fix/SimplifyPlatformStatusFixCore.java
+++ b/sandbox_platform_helper/src/org/sandbox/jdt/internal/corext/fix/SimplifyPlatformStatusFixCore.java
@@ -16,6 +16,7 @@ package org.sandbox.jdt.internal.corext.fix;
 import java.util.Set;
 
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ClassInstanceCreation;
 import org.eclipse.jdt.core.dom.CompilationUnit;
@@ -111,6 +112,9 @@ public enum SimplifyPlatformStatusFixCore {
 						cuRewrite);
 				cuRewrite.getASTRewrite().setTargetSourceRangeComputer(computer);
 				platformstatus.rewrite(SimplifyPlatformStatusFixCore.this, visited, cuRewrite, group, holder, preservePluginId);
+				if (SimplifyPlatformStatusFixCore.this != MULTISTATUS) {
+					cuRewrite.getImportRemover().registerAddedImport(Status.class.getName());
+				}
 			}
 		};
 	}

--- a/sandbox_platform_helper/src/org/sandbox/jdt/internal/corext/fix/helper/AbstractSimplifyPlatformStatus.java
+++ b/sandbox_platform_helper/src/org/sandbox/jdt/internal/corext/fix/helper/AbstractSimplifyPlatformStatus.java
@@ -95,7 +95,7 @@ public abstract class AbstractSimplifyPlatformStatus<T extends ASTNode> {
 					 * Transforms to: Status.info(message, throwable) / Status.warning(message, throwable) / Status.error(message, throwable)
 					 */
 					List<Expression> arguments= visited.arguments();
-
+					
 					// Safely check if argument at index 2 (code) is IStatus.OK
 					Expression codeArg= arguments.get(2);
 					if (!(codeArg instanceof QualifiedName)) {
@@ -105,7 +105,7 @@ public abstract class AbstractSimplifyPlatformStatus<T extends ASTNode> {
 					if (!"IStatus.OK".equals(codeQualifiedName.toString())) { //$NON-NLS-1$
 						return false;
 					}
-
+					
 					// Safely check if argument at index 0 (severity) matches expected status literal
 					Expression severityArg= arguments.get(0);
 					if (!(severityArg instanceof QualifiedName)) {
@@ -135,7 +135,6 @@ public abstract class AbstractSimplifyPlatformStatus<T extends ASTNode> {
 		ASTRewrite rewrite= cuRewrite.getASTRewrite();
 		AST ast= cuRewrite.getRoot().getAST();
 		ImportRemover remover= cuRewrite.getImportRemover();
-		remover.registerRemovedNode(visited);
 
 		/**
 		 * Create call to Status.warning(), Status.error(), or Status.info()
@@ -143,24 +142,24 @@ public abstract class AbstractSimplifyPlatformStatus<T extends ASTNode> {
 		// Add imports in alphabetical order to match expected test output
 		// IStatus comes before Status alphabetically
 		addImport("org.eclipse.core.runtime.IStatus", cuRewrite, ast);
-
+		
 		MethodInvocation staticCall= ast.newMethodInvocation();
 		Name statusName= addImport(Status.class.getName(), cuRewrite, ast);
 		staticCall.setExpression(statusName);
 		staticCall.setName(ast.newSimpleName(methodName));
-
+		
 		List<ASTNode> arguments= visited.arguments();
 		List<ASTNode> staticCallArguments= staticCall.arguments();
-
+		
 		// Note: preservePluginId parameter is not used for Status factory methods
 		// because the Eclipse Platform Status.error(), Status.warning(), and Status.info()
 		// methods only accept (message, exception) parameters, not plugin ID.
-
+		
 		// Add message argument (always at position 3 for 5-argument constructor)
 		int messagePosition= 3;
 		staticCallArguments.add(ASTNodes.createMoveTarget(rewrite,
 				ASTNodes.getUnparenthesedExpression(arguments.get(messagePosition))));
-
+		
 		// Add throwable argument if present (at position 4) and not null
 		ASTNode throwableArg= arguments.get(4);
 		// Add the exception parameter if it's not a null literal
@@ -168,8 +167,9 @@ public abstract class AbstractSimplifyPlatformStatus<T extends ASTNode> {
 		if (!(throwableArg instanceof NullLiteral)) {
 			staticCallArguments.add(ASTNodes.createMoveTarget(rewrite, ASTNodes.getUnparenthesedExpression(throwableArg)));
 		}
-
+		
 		ASTNodes.replaceButKeepComment(rewrite, visited, staticCall, group);
+		remover.registerRemovedNode(visited);
 		// Note: Do NOT call remover.applyRemoves(importRewrite) here
 		// ImportRewrite automatically manages import removal/addition throughout the transformation.
 		// The Status import is explicitly added via addImport() above, and IStatus is preserved from the variable declaration.

--- a/sandbox_platform_helper/src/org/sandbox/jdt/internal/corext/fix/helper/AbstractSimplifyPlatformStatus.java
+++ b/sandbox_platform_helper/src/org/sandbox/jdt/internal/corext/fix/helper/AbstractSimplifyPlatformStatus.java
@@ -95,7 +95,7 @@ public abstract class AbstractSimplifyPlatformStatus<T extends ASTNode> {
 					 * Transforms to: Status.info(message, throwable) / Status.warning(message, throwable) / Status.error(message, throwable)
 					 */
 					List<Expression> arguments= visited.arguments();
-					
+
 					// Safely check if argument at index 2 (code) is IStatus.OK
 					Expression codeArg= arguments.get(2);
 					if (!(codeArg instanceof QualifiedName)) {
@@ -105,7 +105,7 @@ public abstract class AbstractSimplifyPlatformStatus<T extends ASTNode> {
 					if (!"IStatus.OK".equals(codeQualifiedName.toString())) { //$NON-NLS-1$
 						return false;
 					}
-					
+
 					// Safely check if argument at index 0 (severity) matches expected status literal
 					Expression severityArg= arguments.get(0);
 					if (!(severityArg instanceof QualifiedName)) {
@@ -135,6 +135,7 @@ public abstract class AbstractSimplifyPlatformStatus<T extends ASTNode> {
 		ASTRewrite rewrite= cuRewrite.getASTRewrite();
 		AST ast= cuRewrite.getRoot().getAST();
 		ImportRemover remover= cuRewrite.getImportRemover();
+		remover.registerRemovedNode(visited);
 
 		/**
 		 * Create call to Status.warning(), Status.error(), or Status.info()
@@ -142,24 +143,24 @@ public abstract class AbstractSimplifyPlatformStatus<T extends ASTNode> {
 		// Add imports in alphabetical order to match expected test output
 		// IStatus comes before Status alphabetically
 		addImport("org.eclipse.core.runtime.IStatus", cuRewrite, ast);
-		
+
 		MethodInvocation staticCall= ast.newMethodInvocation();
 		Name statusName= addImport(Status.class.getName(), cuRewrite, ast);
 		staticCall.setExpression(statusName);
 		staticCall.setName(ast.newSimpleName(methodName));
-		
+
 		List<ASTNode> arguments= visited.arguments();
 		List<ASTNode> staticCallArguments= staticCall.arguments();
-		
+
 		// Note: preservePluginId parameter is not used for Status factory methods
 		// because the Eclipse Platform Status.error(), Status.warning(), and Status.info()
 		// methods only accept (message, exception) parameters, not plugin ID.
-		
+
 		// Add message argument (always at position 3 for 5-argument constructor)
 		int messagePosition= 3;
 		staticCallArguments.add(ASTNodes.createMoveTarget(rewrite,
 				ASTNodes.getUnparenthesedExpression(arguments.get(messagePosition))));
-		
+
 		// Add throwable argument if present (at position 4) and not null
 		ASTNode throwableArg= arguments.get(4);
 		// Add the exception parameter if it's not a null literal
@@ -167,9 +168,8 @@ public abstract class AbstractSimplifyPlatformStatus<T extends ASTNode> {
 		if (!(throwableArg instanceof NullLiteral)) {
 			staticCallArguments.add(ASTNodes.createMoveTarget(rewrite, ASTNodes.getUnparenthesedExpression(throwableArg)));
 		}
-		
+
 		ASTNodes.replaceButKeepComment(rewrite, visited, staticCall, group);
-		remover.registerRemovedNode(visited);
 		// Note: Do NOT call remover.applyRemoves(importRewrite) here
 		// ImportRewrite automatically manages import removal/addition throughout the transformation.
 		// The Status import is explicitly added via addImport() above, and IStatus is preserved from the variable declaration.

--- a/sandbox_platform_helper_test/src/org/sandbox/jdt/ui/tests/quickfix/PlatformStatusCleanupRegressionTest.java
+++ b/sandbox_platform_helper_test/src/org/sandbox/jdt/ui/tests/quickfix/PlatformStatusCleanupRegressionTest.java
@@ -1,0 +1,29 @@
+package org.sandbox.jdt.ui.tests.quickfix;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IPackageFragment;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import org.sandbox.jdt.internal.corext.fix2.MYCleanUpConstants;
+import org.sandbox.jdt.ui.tests.quickfix.Java9CleanUpTest.PlatformStatusPatterns;
+import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava9;
+
+public class PlatformStatusCleanupRegressionTest {
+
+	@RegisterExtension
+	EclipseJava9 context= new EclipseJava9();
+
+	@ParameterizedTest
+	@EnumSource(PlatformStatusPatterns.class)
+	public void simplifiesStatusConstructorAndKeepsImports(PlatformStatusPatterns test) throws CoreException {
+		IPackageFragment pack= context.getSourceFolder().createPackageFragment("test1", false, null); //$NON-NLS-1$
+		ICompilationUnit unit= pack.createCompilationUnit("E1.java", test.given, false, null); //$NON-NLS-1$
+		context.enable(MYCleanUpConstants.SIMPLIFY_STATUS_CLEANUP);
+		context.assertRefactoringResultAsExpected(new ICompilationUnit[] { unit }, new String[] { test.expected }, null);
+	}
+}


### PR DESCRIPTION
## Problem

The existing three-case `Status` constructor-to-factory matrix was disabled with an import-handling note. Once activated, all warning/error/info cases reproduced the same defect: the cleanup generated `Status.warning/error/info(...)` but `ImportRemover` deleted the still-required `org.eclipse.core.runtime.Status` import, leaving uncompilable output.

## Change

- add one active parameterized regression reusing `Java9CleanUpTest.PlatformStatusPatterns` directly;
- register the removed constructor node before adding imports for the replacement factory invocation, so the later `Status` import is retained;
- keep the existing expected warning/error/info output and `IStatus` variable declaration unchanged.

The production change is deliberately limited to import-rewrite ordering. The touched source contains historical mixed line endings, so Git reports a few adjacent line-ending-only changes in addition to the moved registration.

This is independent of the coordinated JUnit migration in #1217.