### PR TITLE
Fail closed on parameterized tests without a local provider

### DIFF
--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/ClosedParameterizedTestJUnitPlugin.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/ClosedParameterizedTestJUnitPlugin.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.corext.fix;
+
+import static org.sandbox.jdt.internal.corext.fix.helper.lib.JUnitConstants.ORG_JUNIT_RUNWITH;
+
+import org.eclipse.jdt.core.dom.Annotation;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+
+import org.sandbox.jdt.internal.corext.fix.helper.ParameterizedTestJUnitPlugin;
+import org.sandbox.jdt.internal.corext.fix.helper.lib.JunitHolder;
+import org.sandbox.jdt.triggerpattern.api.CleanupPattern;
+import org.sandbox.jdt.triggerpattern.api.Match;
+import org.sandbox.jdt.triggerpattern.api.PatternKind;
+
+/**
+ * Restricts the local Parameterized rewrite to the provider contract it can
+ * transform atomically.
+ */
+@CleanupPattern(value = "@RunWith($runner)", kind = PatternKind.ANNOTATION, qualifiedType = ORG_JUNIT_RUNWITH,
+		cleanupId = "cleanup.junit.parameterized",
+		description = "Migrate @RunWith(Parameterized.class) to @ParameterizedTest",
+		displayName = "JUnit 4 @RunWith(Parameterized) → JUnit 5 @ParameterizedTest")
+final class ClosedParameterizedTestJUnitPlugin extends ParameterizedTestJUnitPlugin {
+
+	private static final String PARAMETERS_ANNOTATION= "org.junit.runners.Parameterized.Parameters"; //$NON-NLS-1$
+
+	@Override
+	protected JunitHolder createHolder(Match match) {
+		JunitHolder holder= super.createHolder(match);
+		if (holder == null || !(holder.getAdditionalInfo() instanceof TypeDeclaration type)) {
+			return holder;
+		}
+		return hasLocalParametersProvider(type) ? holder : null;
+	}
+
+	private static boolean hasLocalParametersProvider(TypeDeclaration type) {
+		for (MethodDeclaration method : type.getMethods()) {
+			for (Object modifier : method.modifiers()) {
+				if (modifier instanceof Annotation annotation && isParametersAnnotation(annotation)) {
+					return true;
+				}
+		}
+		return false;
+	}
+
+	private static boolean isParametersAnnotation(Annotation annotation) {
+		ITypeBinding binding= annotation.resolveTypeBinding();
+		if (binding != null) {
+			return PARAMETERS_ANNOTATION.equals(binding.getQualifiedName());
+		}
+		String name= annotation.getTypeName().getFullyQualifiedName();
+		return "Parameters".equals(name) || PARAMETERS_ANNOTATION.equals(name); //$NON-NLS-1$
+	}
+}

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/ClosedParameterizedTestJUnitPlugin.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/ClosedParameterizedTestJUnitPlugin.java
@@ -50,6 +50,7 @@ final class ClosedParameterizedTestJUnitPlugin extends ParameterizedTestJUnitPlu
 				if (modifier instanceof Annotation annotation && isParametersAnnotation(annotation)) {
 					return true;
 				}
+			}
 		}
 		return false;
 	}

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/JUnitCleanUpFixCore.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/JUnitCleanUpFixCore.java
@@ -47,7 +47,6 @@ import org.sandbox.jdt.internal.corext.fix.helper.ExternalResourceJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.FixMethodOrderJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.IgnoreJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.LostTestFinderJUnitPlugin;
-import org.sandbox.jdt.internal.corext.fix.helper.ParameterizedTestJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.RuleErrorCollectorJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.RuleExpectedExceptionJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.RuleExternalResourceJUnitPlugin;
@@ -94,7 +93,7 @@ public enum JUnitCleanUpFixCore {
 	RULEEXTERNALRESOURCE(new RuleExternalResourceJUnitPlugin()),
 	EXTERNALRESOURCE(new ExternalResourceJUnitPlugin()),
 	LOSTTESTS(new LostTestFinderJUnitPlugin()),
-	PARAMETERIZED(new ParameterizedTestJUnitPlugin()),
+	PARAMETERIZED(new ClosedParameterizedTestJUnitPlugin()),
 	THROWINGRUNNABLE(new ThrowingRunnableJUnitPlugin());
 
 	AbstractTool<ReferenceHolder<Integer, JunitHolder>> junitfound;

--- a/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/ParameterizedMigrationContractTest.java
+++ b/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/ParameterizedMigrationContractTest.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.quickfix.Java8;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.junit.JUnitCore;
+
+import org.sandbox.jdt.internal.corext.fix2.MYCleanUpConstants;
+import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
+import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava17;
+
+/** Fail-closed contracts for JUnit 4 parameterized-test migration. */
+public class ParameterizedMigrationContractTest {
+
+	@RegisterExtension
+	AbstractEclipseJava context= new EclipseJava17();
+
+	private IPackageFragmentRoot root;
+
+	@BeforeEach
+	public void setup() throws CoreException {
+		root= context.createClasspathForJUnit(JUnitCore.JUNIT4_CONTAINER_PATH);
+	}
+
+	@Test
+	public void leavesRunnerUntouchedWithoutLocalParametersProvider() throws CoreException {
+		IPackageFragment pack= root.createPackageFragment("test", true, null); //$NON-NLS-1$
+		ICompilationUnit unit= pack.createCompilationUnit("MissingProviderTest.java", //$NON-NLS-1$
+				"""
+				package test;
+
+				import org.junit.Test;
+				import org.junit.runner.RunWith;
+				import org.junit.runners.Parameterized;
+
+				@RunWith(Parameterized.class)
+				public class MissingProviderTest {
+					private final int value;
+
+					public MissingProviderTest(int value) {
+						this.value = value;
+					}
+
+					@Test
+					public void verifiesValue() {
+						System.out.println(value);
+					}
+				}
+				""", false, null); //$NON-NLS-1$
+
+		context.enable(MYCleanUpConstants.JUNIT_CLEANUP);
+		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_4_PARAMETERIZED);
+		context.assertRefactoringHasNoChange(new ICompilationUnit[] { unit });
+	}
+}


### PR DESCRIPTION
## Problem

`ParameterizedTestJUnitPlugin` recognized `@RunWith(Parameterized.class)` before proving that the class contained the local `@Parameters` method needed by its rewrite. Without that provider it could remove the runner and generate `@MethodSource("data")`, producing a partial, uncompilable migration.

## Change

- register a small guarded wrapper around the existing parameterized transformation;
- delegate all supported transformations unchanged;
- reject the candidate when its containing class has no local resolved or syntactic `@Parameters` method;
- add an end-to-end regression requiring the unsupported class to remain byte-for-byte unchanged.

## Scope

This slice deliberately does not migrate inherited or external providers. Those require coordinated source-scope discovery and explicit diagnostics in a later #1217 stage. The safety improvement here is fail-closed behavior instead of inventing a provider contract.

Refs #1217.