### PR TITLE
Introduce server persistence context ownership boundary

### DIFF
--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/config/CopiedServerPersistenceContext.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/config/CopiedServerPersistenceContext.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jgit.server.config;
+
+import java.util.Objects;
+import java.util.Properties;
+
+import org.eclipse.jgit.storage.hibernate.config.HibernateSessionFactoryProvider;
+import org.hibernate.SessionFactory;
+
+/** Temporary ownership adapter for the copied Sandbox persistence bootstrap. */
+final class CopiedServerPersistenceContext implements ServerPersistenceContext {
+
+	private final HibernateSessionFactoryProvider owner;
+
+	CopiedServerPersistenceContext(Properties properties) {
+		this(new HibernateSessionFactoryProvider(Objects.requireNonNull(properties, "properties"))); //$NON-NLS-1$
+	}
+
+	CopiedServerPersistenceContext(HibernateSessionFactoryProvider owner) {
+		this.owner= Objects.requireNonNull(owner, "owner"); //$NON-NLS-1$
+	}
+
+	@Override
+	public SessionFactory sessionFactory() {
+		return owner.getSessionFactory();
+	}
+
+	@Override
+	public void close() {
+		owner.close();
+	}
+}

--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/config/HibernateConfig.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/config/HibernateConfig.java
@@ -24,7 +24,7 @@ import java.util.logging.Logger;
 import org.eclipse.jgit.storage.hibernate.config.HibernateSessionFactoryProvider;
 
 /**
- * Creates a Hibernate {@link HibernateSessionFactoryProvider} from environment
+ * Creates the application-owned Hibernate persistence context from environment
  * variables.
  * <p>
  * Supported environment variables:
@@ -51,10 +51,37 @@ public class HibernateConfig {
 	}
 
 	/**
-	 * Create a session factory provider configured from environment variables.
+	 * Create the application-owned persistence context from environment variables.
+	 *
+	 * @return the persistence context owning the native session factory
+	 */
+	public static ServerPersistenceContext createPersistenceContext() {
+		Properties props= buildProperties();
+		LOG.log(Level.INFO,
+				"Creating Hibernate persistence context with URL: {0}", //$NON-NLS-1$
+				props.getProperty("hibernate.connection.url")); //$NON-NLS-1$
+		return createPersistenceContext(props);
+	}
+
+	/**
+	 * Create the application-owned persistence context from explicit properties.
+	 *
+	 * @param properties
+	 *            Hibernate configuration properties
+	 * @return the persistence context owning the native session factory
+	 */
+	public static ServerPersistenceContext createPersistenceContext(Properties properties) {
+		return new CopiedServerPersistenceContext(properties);
+	}
+
+	/**
+	 * Create a copied session-factory provider configured from environment variables.
 	 *
 	 * @return the configured session factory provider
+	 * @deprecated application startup should own persistence through
+	 *             {@link #createPersistenceContext()}
 	 */
+	@Deprecated(forRemoval = true)
 	public static HibernateSessionFactoryProvider createSessionFactoryProvider() {
 		Properties props = buildProperties();
 		LOG.log(Level.INFO,
@@ -64,12 +91,15 @@ public class HibernateConfig {
 	}
 
 	/**
-	 * Create a session factory provider from explicit properties.
+	 * Create a copied session-factory provider from explicit properties.
 	 *
 	 * @param properties
 	 *            Hibernate configuration properties
 	 * @return the configured session factory provider
+	 * @deprecated application startup should own persistence through
+	 *             {@link #createPersistenceContext(Properties)}
 	 */
+	@Deprecated(forRemoval = true)
 	public static HibernateSessionFactoryProvider createSessionFactoryProvider(
 			Properties properties) {
 		return new HibernateSessionFactoryProvider(properties);

--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/config/ServerPersistenceContext.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/config/ServerPersistenceContext.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jgit.server.config;
+
+import org.hibernate.SessionFactory;
+
+/**
+ * Application-owned persistence context used by server resources and repository
+ * adapters.
+ *
+ * <p>The boundary exposes only the native Hibernate contract and lifecycle. It
+ * deliberately does not expose copied or released JGit storage implementation
+ * types, so entity registration can be replaced independently from callers.</p>
+ */
+public interface ServerPersistenceContext extends AutoCloseable {
+
+	/** Returns the application-owned native Hibernate session factory. */
+	SessionFactory sessionFactory();
+
+	/** Closes the owned session factory and its connection/search resources. */
+	@Override
+	void close();
+}

--- a/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/config/ServerPersistenceContextTest.java
+++ b/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/config/ServerPersistenceContextTest.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jgit.server.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Properties;
+
+import org.hibernate.SessionFactory;
+import org.junit.Test;
+
+/** Contracts for application-owned persistence lifecycle. */
+public class ServerPersistenceContextTest {
+
+	@Test
+	public void exposesOnlyNativeHibernateContract() throws Exception {
+		Method sessionFactory= ServerPersistenceContext.class.getMethod("sessionFactory"); //$NON-NLS-1$
+		assertEquals(SessionFactory.class, sessionFactory.getReturnType());
+		assertFalse(Modifier.isPublic(CopiedServerPersistenceContext.class.getModifiers()));
+		for (Method method : ServerPersistenceContext.class.getMethods()) {
+			assertFalse(isStorageImplementation(method.getReturnType()));
+			for (Class<?> parameterType : method.getParameterTypes()) {
+				assertFalse(isStorageImplementation(parameterType));
+			}
+			for (Class<?> exceptionType : method.getExceptionTypes()) {
+				assertFalse(isStorageImplementation(exceptionType));
+			}
+		}
+	}
+
+	@Test
+	public void ownsAndClosesNativeSessionFactory() {
+		Properties properties= new Properties();
+		properties.setProperty("hibernate.connection.url", //$NON-NLS-1$
+				"jdbc:h2:mem:server-persistence-context;DB_CLOSE_DELAY=-1"); //$NON-NLS-1$
+		properties.setProperty("hibernate.connection.driver_class", "org.h2.Driver"); //$NON-NLS-1$ //$NON-NLS-2$
+		properties.setProperty("hibernate.dialect", "org.hibernate.dialect.H2Dialect"); //$NON-NLS-1$ //$NON-NLS-2$
+		properties.setProperty("hibernate.hbm2ddl.auto", "create-drop"); //$NON-NLS-1$ //$NON-NLS-2$
+		properties.setProperty("hibernate.search.backend.directory.type", "local-heap"); //$NON-NLS-1$ //$NON-NLS-2$
+		properties.setProperty("hibernate.cache.use_second_level_cache", "false"); //$NON-NLS-1$ //$NON-NLS-2$
+		properties.setProperty("hibernate.connection.provider_class", //$NON-NLS-1$
+				"org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl"); //$NON-NLS-1$
+
+		ServerPersistenceContext context= HibernateConfig.createPersistenceContext(properties);
+		SessionFactory sessionFactory= context.sessionFactory();
+		assertSame(sessionFactory, context.sessionFactory());
+		assertFalse(sessionFactory.isClosed());
+
+		context.close();
+		assertTrue(sessionFactory.isClosed());
+		context.close();
+	}
+
+	private static boolean isStorageImplementation(Class<?> type) {
+		String name= type.getName();
+		return name.startsWith("org.eclipse.jgit.storage.hibernate") //$NON-NLS-1$
+				|| name.startsWith("io.github.carstenartur.jgit.storage.hibernate"); //$NON-NLS-1$
+	}
+}


### PR DESCRIPTION
## Problem

Server startup currently obtains and owns the copied `HibernateSessionFactoryProvider` directly. That couples application lifecycle to the copied Core/projection bootstrap and makes a later released-Core registration change affect every caller at once.

## Change

- introduce the public `ServerPersistenceContext` boundary exposing only the native `SessionFactory` and lifecycle;
- add a package-private copied-provider adapter as the current implementation;
- add `HibernateConfig.createPersistenceContext(...)` as the new application-owned creation path;
- retain the old provider factories as deprecated compatibility methods;
- add an H2 lifecycle regression proving stable factory identity, ownership, closure and idempotent close.

## Scope

This PR deliberately does not rewire `JGitServerApplication`, change entity registration or select the external repository backend. The next slice can move startup/resources to `ServerPersistenceContext.sessionFactory()` without exposing copied storage types, then independently replace the copied registration list.

Refs #1303.