### PR TITLE
Accept application-owned SessionFactory in copied repository adapter

### DIFF
--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/repository/CopiedHibernateRepositoryService.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/repository/CopiedHibernateRepositoryService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2026 Carsten Hammer.
+ * Copyright (c) 2026 Carsten Hammer and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -20,6 +20,7 @@ import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.storage.hibernate.config.HibernateSessionFactoryProvider;
 import org.eclipse.jgit.storage.hibernate.repository.HibernateRepository;
 import org.eclipse.jgit.storage.hibernate.repository.HibernateRepositoryBuilder;
+import org.hibernate.SessionFactory;
 
 /**
  * Temporary adapter for the copied Sandbox Hibernate backend.
@@ -33,7 +34,17 @@ public final class CopiedHibernateRepositoryService implements SandboxRepository
 	private final HibernateSessionFactoryProvider sessionFactoryProvider;
 	private final Map<String, HibernateRepository> repositories= new ConcurrentHashMap<>();
 
-	/** Creates the temporary copied-backend adapter. */
+	/** Creates the temporary adapter from an application-owned native factory. */
+	public CopiedHibernateRepositoryService(SessionFactory sessionFactory) {
+		this(new HibernateSessionFactoryProvider(Objects.requireNonNull(sessionFactory, "sessionFactory"))); //$NON-NLS-1$
+	}
+
+	/**
+	 * Creates the temporary copied-backend adapter.
+	 *
+	 * @deprecated application wiring should pass the native {@link SessionFactory}
+	 */
+	@Deprecated(forRemoval = true)
 	public CopiedHibernateRepositoryService(HibernateSessionFactoryProvider sessionFactoryProvider) {
 		this.sessionFactoryProvider= Objects.requireNonNull(sessionFactoryProvider, "sessionFactoryProvider"); //$NON-NLS-1$
 	}

--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/repository/CopiedHibernateRepositoryService.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/repository/CopiedHibernateRepositoryService.java
@@ -36,7 +36,7 @@ public final class CopiedHibernateRepositoryService implements SandboxRepository
 
 	/** Creates the temporary adapter from an application-owned native factory. */
 	public CopiedHibernateRepositoryService(SessionFactory sessionFactory) {
-		this(new HibernateSessionFactoryProvider(Objects.requireNonNull(sessionFactory, "sessionFactory"))); //$NON-NLS-1$
+		this(nonOwningProvider(sessionFactory));
 	}
 
 	/**
@@ -80,6 +80,16 @@ public final class CopiedHibernateRepositoryService implements SandboxRepository
 			repository.close();
 		}
 		repositories.clear();
+	}
+
+	static HibernateSessionFactoryProvider nonOwningProvider(SessionFactory sessionFactory) {
+		SessionFactory applicationOwnedFactory= Objects.requireNonNull(sessionFactory, "sessionFactory"); //$NON-NLS-1$
+		return new HibernateSessionFactoryProvider(applicationOwnedFactory) {
+			@Override
+			public void close() {
+				// The enclosing ServerPersistenceContext owns the native factory.
+			}
+		};
 	}
 
 	private HibernateRepository repository(String name) throws IOException {

--- a/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/repository/CopiedHibernateRepositoryServiceSessionFactoryTest.java
+++ b/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/repository/CopiedHibernateRepositoryServiceSessionFactoryTest.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jgit.server.repository;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Properties;
+
+import org.eclipse.jgit.server.config.HibernateConfig;
+import org.eclipse.jgit.server.config.ServerPersistenceContext;
+import org.hibernate.SessionFactory;
+import org.junit.Test;
+
+/** Verifies repository-handle ownership separately from persistence ownership. */
+public class CopiedHibernateRepositoryServiceSessionFactoryTest {
+
+	@Test
+	public void closesRepositoriesWithoutClosingApplicationSessionFactory() throws Exception {
+		Properties properties= new Properties();
+		properties.setProperty("hibernate.connection.url", //$NON-NLS-1$
+				"jdbc:h2:mem:copied-service-native-factory;DB_CLOSE_DELAY=-1"); //$NON-NLS-1$
+		properties.setProperty("hibernate.connection.driver_class", "org.h2.Driver"); //$NON-NLS-1$ //$NON-NLS-2$
+		properties.setProperty("hibernate.dialect", "org.hibernate.dialect.H2Dialect"); //$NON-NLS-1$ //$NON-NLS-2$
+		properties.setProperty("hibernate.hbm2ddl.auto", "create-drop"); //$NON-NLS-1$ //$NON-NLS-2$
+		properties.setProperty("hibernate.search.backend.directory.type", "local-heap"); //$NON-NLS-1$ //$NON-NLS-2$
+		properties.setProperty("hibernate.cache.use_second_level_cache", "false"); //$NON-NLS-1$ //$NON-NLS-2$
+
+		SessionFactory sessionFactory;
+		try (ServerPersistenceContext context= HibernateConfig.createPersistenceContext(properties)) {
+			sessionFactory= context.sessionFactory();
+			CopiedHibernateRepositoryService repositories= new CopiedHibernateRepositoryService(sessionFactory);
+			assertNotNull(repositories.openOrCreate("native-factory")); //$NON-NLS-1$
+
+			repositories.close();
+			assertFalse(sessionFactory.isClosed());
+		}
+		assertTrue(sessionFactory.isClosed());
+	}
+}

--- a/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/repository/CopiedHibernateRepositoryServiceSessionFactoryTest.java
+++ b/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/repository/CopiedHibernateRepositoryServiceSessionFactoryTest.java
@@ -12,12 +12,14 @@ package org.eclipse.jgit.server.repository;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Properties;
 
 import org.eclipse.jgit.server.config.HibernateConfig;
 import org.eclipse.jgit.server.config.ServerPersistenceContext;
+import org.eclipse.jgit.storage.hibernate.config.HibernateSessionFactoryProvider;
 import org.hibernate.SessionFactory;
 import org.junit.Test;
 
@@ -38,6 +40,11 @@ public class CopiedHibernateRepositoryServiceSessionFactoryTest {
 		SessionFactory sessionFactory;
 		try (ServerPersistenceContext context= HibernateConfig.createPersistenceContext(properties)) {
 			sessionFactory= context.sessionFactory();
+			HibernateSessionFactoryProvider provider= CopiedHibernateRepositoryService.nonOwningProvider(sessionFactory);
+			assertSame(sessionFactory, provider.getSessionFactory());
+			provider.close();
+			assertFalse(sessionFactory.isClosed());
+
 			CopiedHibernateRepositoryService repositories= new CopiedHibernateRepositoryService(sessionFactory);
 			assertNotNull(repositories.openOrCreate("native-factory")); //$NON-NLS-1$
 


### PR DESCRIPTION
## Problem

After #1326 introduces application-owned persistence lifecycle, the copied repository adapter still requires the copied `HibernateSessionFactoryProvider`. That prevents startup from passing the native `SessionFactory` without exposing provider ownership again.

## Change

- add a public `CopiedHibernateRepositoryService(SessionFactory)` constructor;
- create only a non-owning provider view internally for the copied repository builder;
- keep the provider constructor as deprecated compatibility;
- add an H2 regression proving repository-service shutdown closes repository handles but leaves the application-owned factory open;
- prove the enclosing `ServerPersistenceContext` remains the component that ultimately closes the factory.

## Scope

This stacked PR is based on #1326. It does not yet rewire `JGitServerApplication` or REST projection resources. That remains a separate small slice after the persistence ownership boundary merges.

Refs #1303.