### PR TITLE
Reject unsupported parameterized constructor shapes

### DIFF
--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/ClosedParameterizedTestJUnitPlugin.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/ClosedParameterizedTestJUnitPlugin.java
@@ -41,18 +41,27 @@ final class ClosedParameterizedTestJUnitPlugin extends ParameterizedTestJUnitPlu
 		if (holder == null || !(holder.getAdditionalInfo() instanceof TypeDeclaration type)) {
 			return holder;
 		}
-		return hasLocalParametersProvider(type) ? holder : null;
+		return hasSupportedLocalContract(type) ? holder : null;
 	}
 
-	private static boolean hasLocalParametersProvider(TypeDeclaration type) {
+	private static boolean hasSupportedLocalContract(TypeDeclaration type) {
+		int providers= 0;
+		int constructors= 0;
+		boolean parameterizedConstructor= false;
 		for (MethodDeclaration method : type.getMethods()) {
+			if (method.isConstructor()) {
+				constructors++;
+				parameterizedConstructor= !method.parameters().isEmpty();
+				continue;
+			}
 			for (Object modifier : method.modifiers()) {
 				if (modifier instanceof Annotation annotation && isParametersAnnotation(annotation)) {
-					return true;
+					providers++;
+					break;
 				}
 			}
 		}
-		return false;
+		return providers == 1 && constructors == 1 && parameterizedConstructor;
 	}
 
 	private static boolean isParametersAnnotation(Annotation annotation) {

--- a/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/ParameterizedMigrationContractTest.java
+++ b/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/ParameterizedMigrationContractTest.java
@@ -40,8 +40,7 @@ public class ParameterizedMigrationContractTest {
 
 	@Test
 	public void leavesRunnerUntouchedWithoutLocalParametersProvider() throws CoreException {
-		IPackageFragment pack= root.createPackageFragment("test", true, null); //$NON-NLS-1$
-		ICompilationUnit unit= pack.createCompilationUnit("MissingProviderTest.java", //$NON-NLS-1$
+		assertNoChange("MissingProviderTest.java", //$NON-NLS-1$
 				"""
 				package test;
 
@@ -62,8 +61,84 @@ public class ParameterizedMigrationContractTest {
 						System.out.println(value);
 					}
 				}
-				""", false, null); //$NON-NLS-1$
+				""");
+	}
 
+	@Test
+	public void leavesRunnerUntouchedWithMultipleConstructors() throws CoreException {
+		assertNoChange("MultipleConstructorsTest.java", //$NON-NLS-1$
+				"""
+				package test;
+
+				import java.util.Arrays;
+				import java.util.Collection;
+
+				import org.junit.Test;
+				import org.junit.runner.RunWith;
+				import org.junit.runners.Parameterized;
+				import org.junit.runners.Parameterized.Parameters;
+
+				@RunWith(Parameterized.class)
+				public class MultipleConstructorsTest {
+					private final int value;
+
+					public MultipleConstructorsTest(int value) {
+						this.value = value;
+					}
+
+					public MultipleConstructorsTest(String value) {
+						this(Integer.parseInt(value));
+					}
+
+					@Parameters
+					public static Collection<Object[]> data() {
+						return Arrays.asList(new Object[][] { { 1 }, { 2 } });
+					}
+
+					@Test
+					public void verifiesValue() {
+						System.out.println(value);
+					}
+				}
+				""");
+	}
+
+	@Test
+	public void leavesFieldInjectionUntouched() throws CoreException {
+		assertNoChange("FieldInjectionTest.java", //$NON-NLS-1$
+				"""
+				package test;
+
+				import java.util.Arrays;
+				import java.util.Collection;
+
+				import org.junit.Test;
+				import org.junit.runner.RunWith;
+				import org.junit.runners.Parameterized;
+				import org.junit.runners.Parameterized.Parameter;
+				import org.junit.runners.Parameterized.Parameters;
+
+				@RunWith(Parameterized.class)
+				public class FieldInjectionTest {
+					@Parameter
+					public int value;
+
+					@Parameters
+					public static Collection<Object[]> data() {
+						return Arrays.asList(new Object[][] { { 1 }, { 2 } });
+					}
+
+					@Test
+					public void verifiesValue() {
+						System.out.println(value);
+					}
+				}
+				""");
+	}
+
+	private void assertNoChange(String fileName, String source) throws CoreException {
+		IPackageFragment pack= root.createPackageFragment("test", true, null); //$NON-NLS-1$
+		ICompilationUnit unit= pack.createCompilationUnit(fileName, source, false, null);
 		context.enable(MYCleanUpConstants.JUNIT_CLEANUP);
 		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_4_PARAMETERIZED);
 		context.assertRefactoringHasNoChange(new ICompilationUnit[] { unit });


### PR DESCRIPTION
## Problem

The existing JUnit 4 Parameterized rewrite assumes one constructor-based parameter contract. With multiple constructors it accumulates parameters from every constructor but removes only the last constructor found. With `@Parameterized.Parameter` field injection it has no constructor parameters to propagate at all. Either case can produce a partial or uncompilable Jupiter migration.

## Change

- require exactly one local `@Parameters` provider;
- require exactly one explicit constructor with at least one parameter;
- leave multiple-constructor and field-injection classes unchanged;
- add end-to-end fail-closed regressions for both unsupported shapes;
- keep the supported single-provider/single-constructor transformation delegated unchanged.

## Scope

This PR is stacked on #1325. It does not attempt to migrate field injection or choose between overloaded constructors; those require a dedicated coordinated transformation and diagnostics.

Refs #1217.