### PR TITLE
Accept native SessionFactory in Smart HTTP resolver

### DIFF
--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/resolver/HibernateRepositoryResolver.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/resolver/HibernateRepositoryResolver.java
@@ -22,6 +22,7 @@ import org.eclipse.jgit.server.repository.SandboxRepositoryService;
 import org.eclipse.jgit.storage.hibernate.config.HibernateSessionFactoryProvider;
 import org.eclipse.jgit.transport.resolver.RepositoryResolver;
 import org.eclipse.jgit.transport.resolver.ServiceNotEnabledException;
+import org.hibernate.SessionFactory;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -32,7 +33,17 @@ public class HibernateRepositoryResolver
 	private final HibernateSessionFactoryProvider sessionFactoryProvider;
 	private final SandboxRepositoryService repositories;
 
-	/** Creates a resolver using the temporary copied-backend adapter. */
+	/** Creates a resolver from the application-owned native session factory. */
+	public HibernateRepositoryResolver(SessionFactory sessionFactory) {
+		this(null, new CopiedHibernateRepositoryService(sessionFactory));
+	}
+
+	/**
+	 * Creates a resolver using the temporary copied-backend adapter.
+	 *
+	 * @deprecated application wiring should pass the native {@link SessionFactory}
+	 */
+	@Deprecated(forRemoval = true)
 	public HibernateRepositoryResolver(HibernateSessionFactoryProvider sessionFactoryProvider) {
 		this(sessionFactoryProvider, new CopiedHibernateRepositoryService(sessionFactoryProvider));
 	}
@@ -83,6 +94,7 @@ public class HibernateRepositoryResolver
 	 * Returns the legacy provider while Search and analytics still use the copied
 	 * implementation. Repository lifecycle code must use {@link #getRepositoryService()}.
 	 */
+	@Deprecated(forRemoval = true)
 	public HibernateSessionFactoryProvider getSessionFactoryProvider() {
 		if (sessionFactoryProvider == null) {
 			throw new IllegalStateException("This resolver was created without a legacy session factory provider."); //$NON-NLS-1$

--- a/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/repository/SandboxRepositoryServiceBoundaryTest.java
+++ b/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/repository/SandboxRepositoryServiceBoundaryTest.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.server.rest.RepositoryResource;
 import org.eclipse.jgit.server.resolver.HibernateRepositoryResolver;
+import org.hibernate.SessionFactory;
 import org.junit.Test;
 
 import io.github.carstenartur.jgit.storage.hibernate.HibernateRepositoryFactory;
@@ -36,6 +37,7 @@ public class SandboxRepositoryServiceBoundaryTest {
 		assertEquals(Repository.class, open.getReturnType());
 		assertNotNull(RepositoryResource.class.getConstructor(SandboxRepositoryService.class));
 		assertNotNull(HibernateRepositoryResolver.class.getConstructor(SandboxRepositoryService.class));
+		assertNotNull(HibernateRepositoryResolver.class.getConstructor(SessionFactory.class));
 		assertNotNull(ExternalHibernateRepositoryService.class.getConstructor(HibernateRepositoryFactory.class));
 	}
 


### PR DESCRIPTION
## Problem

Even after the copied repository adapter accepts the application-owned native `SessionFactory`, `HibernateRepositoryResolver` still requires the copied `HibernateSessionFactoryProvider` for its convenience path. That keeps Smart HTTP wiring coupled to the copied bootstrap type.

## Change

- add `HibernateRepositoryResolver(SessionFactory)`;
- construct the temporary copied repository adapter through its native-factory boundary;
- keep the legacy provider constructor as deprecated compatibility;
- add a reflection contract proving the native constructor is part of the application boundary.

## Scope

This PR is stacked on #1327. It does not yet rewire `JGitServerApplication` or Search/Analytics. It only makes that later startup change possible without reintroducing provider ownership.

Refs #1303.