### PR TITLE
Accept native SessionFactory in health endpoint

### DIFF
--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/rest/HealthResource.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/rest/HealthResource.java
@@ -15,10 +15,12 @@ package org.eclipse.jgit.server.rest;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.Objects;
 
 import org.eclipse.jgit.storage.hibernate.config.HibernateSessionFactoryProvider;
 import org.eclipse.jgit.storage.hibernate.entity.GitCommitIndex;
 import org.hibernate.Session;
+import org.hibernate.SessionFactory;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 
@@ -38,16 +40,28 @@ public class HealthResource extends HttpServlet {
 
 	private static final long serialVersionUID = 1L;
 
-	private final HibernateSessionFactoryProvider provider;
+	private final SessionFactory sessionFactory;
 
 	/**
-	 * Create a health check endpoint.
+	 * Create a health check endpoint from the application-owned native factory.
+	 *
+	 * @param sessionFactory
+	 *            the native session factory for database and search health checks
+	 */
+	public HealthResource(SessionFactory sessionFactory) {
+		this.sessionFactory= Objects.requireNonNull(sessionFactory, "sessionFactory"); //$NON-NLS-1$
+	}
+
+	/**
+	 * Create a health check endpoint from the copied compatibility provider.
 	 *
 	 * @param provider
 	 *            the session factory provider for database health checks
+	 * @deprecated application wiring should pass the native {@link SessionFactory}
 	 */
+	@Deprecated(forRemoval = true)
 	public HealthResource(HibernateSessionFactoryProvider provider) {
-		this.provider = provider;
+		this(Objects.requireNonNull(provider, "provider").getSessionFactory()); //$NON-NLS-1$
 	}
 
 	@Override
@@ -62,7 +76,7 @@ public class HealthResource extends HttpServlet {
 		String searchError = null;
 
 		// Check database connectivity
-		try (Session session = provider.getSessionFactory().openSession()) {
+		try (Session session = sessionFactory.openSession()) {
 			session.createNativeQuery("SELECT 1", Integer.class) //$NON-NLS-1$
 					.uniqueResult();
 			dbOk = true;
@@ -71,7 +85,7 @@ public class HealthResource extends HttpServlet {
 		}
 
 		// Check search backend
-		try (Session session = provider.getSessionFactory().openSession()) {
+		try (Session session = sessionFactory.openSession()) {
 			SearchSession searchSession = Search.session(session);
 			searchSession.search(GitCommitIndex.class)
 					.where(f -> f.matchAll())

--- a/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/repository/SandboxRepositoryServiceBoundaryTest.java
+++ b/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/repository/SandboxRepositoryServiceBoundaryTest.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 
 import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.server.rest.HealthResource;
 import org.eclipse.jgit.server.rest.RepositoryResource;
 import org.eclipse.jgit.server.resolver.HibernateRepositoryResolver;
 import org.hibernate.SessionFactory;
@@ -38,28 +39,35 @@ public class SandboxRepositoryServiceBoundaryTest {
 		assertNotNull(RepositoryResource.class.getConstructor(SandboxRepositoryService.class));
 		assertNotNull(HibernateRepositoryResolver.class.getConstructor(SandboxRepositoryService.class));
 		assertNotNull(HibernateRepositoryResolver.class.getConstructor(SessionFactory.class));
+		assertNotNull(HealthResource.class.getConstructor(SessionFactory.class));
 		assertNotNull(ExternalHibernateRepositoryService.class.getConstructor(HibernateRepositoryFactory.class));
 	}
 
 	@Test
 	public void repositoryResourceHasNoCopiedBackendField() {
-		assertFalse(Arrays.stream(RepositoryResource.class.getDeclaredFields())
-				.map(Field::getType)
-				.map(Class::getName)
-				.anyMatch(name -> name.startsWith("org.eclipse.jgit.storage.hibernate"))); //$NON-NLS-1$
+		assertFalse(hasCopiedBackendField(RepositoryResource.class));
+	}
+
+	@Test
+	public void healthResourceHasNoCopiedBackendField() {
+		assertFalse(hasCopiedBackendField(HealthResource.class));
 	}
 
 	@Test
 	public void externalAdapterHasNoCopiedBackendField() {
-		assertFalse(Arrays.stream(ExternalHibernateRepositoryService.class.getDeclaredFields())
-				.map(Field::getType)
-				.map(Class::getName)
-				.anyMatch(name -> name.startsWith("org.eclipse.jgit.storage.hibernate"))); //$NON-NLS-1$
+		assertFalse(hasCopiedBackendField(ExternalHibernateRepositoryService.class));
 	}
 
 	@Test
 	public void validatesApplicationMetadataIdentity() {
 		assertEquals("demo", new SandboxRepositoryInfo(" demo ", null).name()); //$NON-NLS-1$ //$NON-NLS-2$
 		assertThrows(IllegalArgumentException.class, () -> new SandboxRepositoryInfo(" ", null)); //$NON-NLS-1$
+	}
+
+	private static boolean hasCopiedBackendField(Class<?> type) {
+		return Arrays.stream(type.getDeclaredFields())
+				.map(Field::getType)
+				.map(Class::getName)
+				.anyMatch(name -> name.startsWith("org.eclipse.jgit.storage.hibernate")); //$NON-NLS-1$
 	}
 }


### PR DESCRIPTION
## Problem

`HealthResource` still stores the copied `HibernateSessionFactoryProvider` even though it only needs the native Hibernate factory for database and Search health checks. This unnecessarily leaks the copied bootstrap type into server wiring.

## Change

- add `HealthResource(SessionFactory)` as the primary constructor;
- store only the native factory;
- retain the provider constructor as deprecated compatibility;
- verify the native constructor and that the resource has no copied-backend field;
- keep database and Search health behavior unchanged.

## Scope

This PR is stacked on #1329. It does not alter Search entity registration or backend support. It only removes provider ownership from the health endpoint.

Refs #1303.