### PR TITLE
Accept native SessionFactory in analytics endpoint

### DIFF
--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/rest/AnalyticsResource.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/rest/AnalyticsResource.java
@@ -16,12 +16,14 @@ package org.eclipse.jgit.server.rest;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.List;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.eclipse.jgit.storage.hibernate.config.HibernateSessionFactoryProvider;
 import org.eclipse.jgit.storage.hibernate.service.GitDatabaseQueryService;
 import org.eclipse.jgit.storage.hibernate.service.GitDatabaseQueryService.AuthorStats;
+import org.hibernate.SessionFactory;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
@@ -47,18 +49,30 @@ public class AnalyticsResource extends HttpServlet {
 	private static final Logger LOG = Logger
 			.getLogger(AnalyticsResource.class.getName());
 
-	private final HibernateSessionFactoryProvider provider;
+	private final SessionFactory sessionFactory;
 
 	private final Gson gson = new Gson();
 
 	/**
-	 * Create an analytics endpoint.
+	 * Create an analytics endpoint from the application-owned native factory.
+	 *
+	 * @param sessionFactory
+	 *            the native session factory
+	 */
+	public AnalyticsResource(SessionFactory sessionFactory) {
+		this.sessionFactory= Objects.requireNonNull(sessionFactory, "sessionFactory"); //$NON-NLS-1$
+	}
+
+	/**
+	 * Create an analytics endpoint from the copied compatibility provider.
 	 *
 	 * @param provider
 	 *            the session factory provider
+	 * @deprecated application wiring should pass the native {@link SessionFactory}
 	 */
+	@Deprecated(forRemoval = true)
 	public AnalyticsResource(HibernateSessionFactoryProvider provider) {
-		this.provider = provider;
+		this(Objects.requireNonNull(provider, "provider").getSessionFactory()); //$NON-NLS-1$
 	}
 
 	@Override
@@ -82,8 +96,7 @@ public class AnalyticsResource extends HttpServlet {
 		}
 
 		try {
-			GitDatabaseQueryService queryService = new GitDatabaseQueryService(
-					provider.getSessionFactory());
+			GitDatabaseQueryService queryService = new GitDatabaseQueryService(sessionFactory);
 
 			if (pathInfo.startsWith("/authors")) { //$NON-NLS-1$
 				handleAuthorStats(queryService, repo, resp);

--- a/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/repository/SandboxRepositoryServiceBoundaryTest.java
+++ b/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/repository/SandboxRepositoryServiceBoundaryTest.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 
 import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.server.rest.AnalyticsResource;
 import org.eclipse.jgit.server.rest.HealthResource;
 import org.eclipse.jgit.server.rest.RepositoryResource;
 import org.eclipse.jgit.server.resolver.HibernateRepositoryResolver;
@@ -40,6 +41,7 @@ public class SandboxRepositoryServiceBoundaryTest {
 		assertNotNull(HibernateRepositoryResolver.class.getConstructor(SandboxRepositoryService.class));
 		assertNotNull(HibernateRepositoryResolver.class.getConstructor(SessionFactory.class));
 		assertNotNull(HealthResource.class.getConstructor(SessionFactory.class));
+		assertNotNull(AnalyticsResource.class.getConstructor(SessionFactory.class));
 		assertNotNull(ExternalHibernateRepositoryService.class.getConstructor(HibernateRepositoryFactory.class));
 	}
 
@@ -51,6 +53,11 @@ public class SandboxRepositoryServiceBoundaryTest {
 	@Test
 	public void healthResourceHasNoCopiedBackendField() {
 		assertFalse(hasCopiedBackendField(HealthResource.class));
+	}
+
+	@Test
+	public void analyticsResourceHasNoCopiedBackendField() {
+		assertFalse(hasCopiedBackendField(AnalyticsResource.class));
 	}
 
 	@Test


### PR DESCRIPTION
## Problem

`AnalyticsResource` stores the copied `HibernateSessionFactoryProvider` although its query service only requires the native Hibernate factory. This keeps copied bootstrap ownership in REST wiring unnecessarily.

## Change

- add `AnalyticsResource(SessionFactory)` as the primary constructor;
- store only the native factory and pass it directly to `GitDatabaseQueryService`;
- retain the provider constructor as deprecated compatibility;
- verify the native constructor and that Analytics has no copied-backend field;
- keep all author, object and pack analytics behavior unchanged.

## Scope

This PR is stacked on #1330. It does not replace the copied query service or claim SQL Server Search support. It only removes provider ownership from the endpoint.

Refs #1303.