### PR TITLE
Accept native SessionFactory in admin endpoint

### DIFF
--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/rest/AdminResource.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/rest/AdminResource.java
@@ -17,11 +17,13 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.eclipse.jgit.storage.hibernate.config.HibernateSessionFactoryProvider;
 import org.eclipse.jgit.storage.hibernate.service.IndexMigrationService;
+import org.hibernate.SessionFactory;
 
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
@@ -41,16 +43,28 @@ public class AdminResource extends HttpServlet {
 	private static final Logger LOG = Logger
 			.getLogger(AdminResource.class.getName());
 
-	private final HibernateSessionFactoryProvider provider;
+	private final SessionFactory sessionFactory;
 
 	/**
-	 * Create an admin endpoint.
+	 * Create an admin endpoint from the application-owned native factory.
+	 *
+	 * @param sessionFactory
+	 *            the native session factory
+	 */
+	public AdminResource(SessionFactory sessionFactory) {
+		this.sessionFactory= Objects.requireNonNull(sessionFactory, "sessionFactory"); //$NON-NLS-1$
+	}
+
+	/**
+	 * Create an admin endpoint from the copied compatibility provider.
 	 *
 	 * @param provider
 	 *            the session factory provider
+	 * @deprecated application wiring should pass the native {@link SessionFactory}
 	 */
+	@Deprecated(forRemoval = true)
 	public AdminResource(HibernateSessionFactoryProvider provider) {
-		this.provider = provider;
+		this(Objects.requireNonNull(provider, "provider").getSessionFactory()); //$NON-NLS-1$
 	}
 
 	@Override
@@ -86,8 +100,7 @@ public class AdminResource extends HttpServlet {
 
 	private void handleReindex(HttpServletResponse resp) throws IOException {
 		try {
-			IndexMigrationService migrationService = new IndexMigrationService(
-					provider.getSessionFactory());
+			IndexMigrationService migrationService = new IndexMigrationService(sessionFactory);
 			migrationService.reindexAll();
 			resp.setStatus(HttpServletResponse.SC_OK);
 			try (PrintWriter w = resp.getWriter()) {

--- a/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/repository/SandboxRepositoryServiceBoundaryTest.java
+++ b/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/repository/SandboxRepositoryServiceBoundaryTest.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 
 import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.server.rest.AdminResource;
 import org.eclipse.jgit.server.rest.AnalyticsResource;
 import org.eclipse.jgit.server.rest.HealthResource;
 import org.eclipse.jgit.server.rest.RepositoryResource;
@@ -42,6 +43,7 @@ public class SandboxRepositoryServiceBoundaryTest {
 		assertNotNull(HibernateRepositoryResolver.class.getConstructor(SessionFactory.class));
 		assertNotNull(HealthResource.class.getConstructor(SessionFactory.class));
 		assertNotNull(AnalyticsResource.class.getConstructor(SessionFactory.class));
+		assertNotNull(AdminResource.class.getConstructor(SessionFactory.class));
 		assertNotNull(ExternalHibernateRepositoryService.class.getConstructor(HibernateRepositoryFactory.class));
 	}
 
@@ -58,6 +60,11 @@ public class SandboxRepositoryServiceBoundaryTest {
 	@Test
 	public void analyticsResourceHasNoCopiedBackendField() {
 		assertFalse(hasCopiedBackendField(AnalyticsResource.class));
+	}
+
+	@Test
+	public void adminResourceHasNoCopiedBackendField() {
+		assertFalse(hasCopiedBackendField(AdminResource.class));
 	}
 
 	@Test


### PR DESCRIPTION
## Problem

`AdminResource` stores the copied `HibernateSessionFactoryProvider` although re-indexing only needs the native Hibernate factory. This unnecessarily keeps copied bootstrap ownership in the administrative endpoint.

## Change

- add `AdminResource(SessionFactory)` as the primary constructor;
- store only the native factory and pass it directly to `IndexMigrationService`;
- retain the provider constructor as deprecated compatibility;
- verify the native constructor and that Admin has no copied-backend field;
- leave authorization and re-index behavior unchanged.

## Scope

This PR is stacked on #1331. It does not change Search mappings, authorization policy or database support. It only removes provider ownership from the endpoint.

Refs #1303.