### PR TITLE
Consolidate native SessionFactory server wiring

### DIFF
--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/JGitServerApplication.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/JGitServerApplication.java
@@ -13,7 +13,9 @@
  *******************************************************************************/
 package org.eclipse.jgit.server;
 
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -29,7 +31,10 @@ import org.eclipse.jgit.http.server.GitServlet;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.server.config.HibernateConfig;
 import org.eclipse.jgit.server.config.RepositoryManagerConfig;
+import org.eclipse.jgit.server.config.ServerPersistenceContext;
+import org.eclipse.jgit.server.repository.SandboxRepositoryService;
 import org.eclipse.jgit.server.resolver.HibernateRepositoryResolver;
+import org.eclipse.jgit.server.rest.AdminResource;
 import org.eclipse.jgit.server.rest.AnalyticsResource;
 import org.eclipse.jgit.server.rest.CorsFilter;
 import org.eclipse.jgit.server.rest.HealthResource;
@@ -38,394 +43,261 @@ import org.eclipse.jgit.server.rest.SearchResource;
 import org.eclipse.jgit.storage.hibernate.config.HibernateSessionFactoryProvider;
 import org.eclipse.jgit.transport.ReceivePack;
 import org.eclipse.jgit.transport.resolver.ReceivePackFactory;
+import org.hibernate.SessionFactory;
 
+import jakarta.servlet.DispatcherType;
 import jakarta.servlet.http.HttpServletRequest;
 
-/**
- * Main application entry point for the JGit database-backed server.
- * <p>
- * Starts an embedded Jetty server with:
- * <ul>
- * <li>Git Smart HTTP protocol on port 8443 (configurable)</li>
- * <li>REST API on port 8080 (configurable)</li>
- * </ul>
- * Configuration is read from environment variables.
- */
+/** Main application entry point for the JGit database-backed server. */
 public class JGitServerApplication {
 
-	private static final Logger LOG = Logger
-			.getLogger(JGitServerApplication.class.getName());
-
+	private static final Logger LOG = Logger.getLogger(JGitServerApplication.class.getName());
 	private static final int DEFAULT_REST_PORT = 8080;
-
 	private static final int DEFAULT_GIT_PORT = 8443;
 
 	private Server server;
-
-	private HibernateSessionFactoryProvider sessionFactoryProvider;
-
+	private ServerPersistenceContext persistenceContext;
 	private HibernateRepositoryResolver repositoryResolver;
 
-	/**
-	 * Main entry point.
-	 *
-	 * @param args
-	 *            command line arguments (unused)
-	 * @throws Exception
-	 *             if server startup fails
-	 */
 	public static void main(String[] args) throws Exception {
 		JGitServerApplication app = new JGitServerApplication();
 		app.start();
 		app.join();
 	}
 
-	/**
-	 * Start the server.
-	 *
-	 * @throws Exception
-	 *             if server startup fails
-	 */
+	/** Starts the configured production server. */
 	public void start() throws Exception {
-		sessionFactoryProvider = HibernateConfig
-				.createSessionFactoryProvider();
-		repositoryResolver = new HibernateRepositoryResolver(
-				sessionFactoryProvider);
-
-		// Auto-create default repositories
-		String defaultRepos = System.getenv("JGIT_DEFAULT_REPOS"); //$NON-NLS-1$
-		if (defaultRepos != null && !defaultRepos.isEmpty()) {
-			RepositoryManagerConfig.initDefaultRepositories(
-					sessionFactoryProvider, defaultRepos);
-		}
-
-		int restPort = getIntEnv("JGIT_REST_PORT", DEFAULT_REST_PORT); //$NON-NLS-1$
-		int gitPort = getIntEnv("JGIT_GIT_PORT", DEFAULT_GIT_PORT); //$NON-NLS-1$
-
-		server = new Server();
-
-		// REST API connector
-		ServerConnector restConnector = new ServerConnector(server);
-		restConnector.setPort(restPort);
-		restConnector.setName("rest"); //$NON-NLS-1$
-
-		// Git HTTP connector
-		ServerConnector gitConnector = new ServerConnector(server);
-		gitConnector.setPort(gitPort);
-		gitConnector.setName("git"); //$NON-NLS-1$
-
-		server.addConnector(restConnector);
-		server.addConnector(gitConnector);
-
-		ContextHandlerCollection contexts = new ContextHandlerCollection();
-
-		// REST API context
-		ServletContextHandler restContext = new ServletContextHandler(
-				ServletContextHandler.SESSIONS);
-		restContext.setContextPath("/api"); //$NON-NLS-1$
-		restContext.setVirtualHosts(List.of("@rest")); //$NON-NLS-1$
-
-		// CORS filter
-		String corsOrigins = System.getenv("JGIT_CORS_ORIGINS"); //$NON-NLS-1$
-		if (corsOrigins != null && !corsOrigins.isEmpty()) {
-			restContext.addFilter(
-					new FilterHolder(new CorsFilter(corsOrigins)),
-					"/*", //$NON-NLS-1$
-					java.util.EnumSet
-							.allOf(jakarta.servlet.DispatcherType.class));
-		}
-
-		restContext.addServlet(new ServletHolder("health", //$NON-NLS-1$
-				new HealthResource(sessionFactoryProvider)), "/health"); //$NON-NLS-1$
-		restContext.addServlet(
-				new ServletHolder("repos", //$NON-NLS-1$
-						new RepositoryResource(sessionFactoryProvider,
-								repositoryResolver)),
-				"/repos/*"); //$NON-NLS-1$
-		restContext.addServlet(
-				new ServletHolder("search", //$NON-NLS-1$
-						new SearchResource(sessionFactoryProvider)),
-				"/search/*"); //$NON-NLS-1$
-		restContext.addServlet(
-				new ServletHolder("analytics", //$NON-NLS-1$
-						new AnalyticsResource(sessionFactoryProvider)),
-				"/analytics/*"); //$NON-NLS-1$
-
-		// Git Smart HTTP context
-		ServletContextHandler gitContext = new ServletContextHandler(
-				ServletContextHandler.SESSIONS);
-		gitContext.setContextPath("/git"); //$NON-NLS-1$
-		gitContext.setVirtualHosts(List.of("@git")); //$NON-NLS-1$
-
-		gitContext.addServlet(
-				new ServletHolder(createGitServlet(repositoryResolver)),
-				"/*"); //$NON-NLS-1$
-
-		contexts.addHandler(restContext);
-
-		// Also serve /api/v1/* for forward-compatible API versioning
-		ServletContextHandler v1Context = new ServletContextHandler(
-				ServletContextHandler.SESSIONS);
-		v1Context.setContextPath("/api/v1"); //$NON-NLS-1$
-		v1Context.setVirtualHosts(List.of("@rest")); //$NON-NLS-1$
-		if (corsOrigins != null && !corsOrigins.isEmpty()) {
-			v1Context.addFilter(
-					new FilterHolder(new CorsFilter(corsOrigins)),
-					"/*", //$NON-NLS-1$
-					java.util.EnumSet
-							.allOf(jakarta.servlet.DispatcherType.class));
-		}
-		v1Context.addServlet(new ServletHolder("health", //$NON-NLS-1$
-				new HealthResource(sessionFactoryProvider)), "/health"); //$NON-NLS-1$
-		v1Context.addServlet(
-				new ServletHolder("repos", //$NON-NLS-1$
-						new RepositoryResource(sessionFactoryProvider,
-								repositoryResolver)),
-				"/repos/*"); //$NON-NLS-1$
-		v1Context.addServlet(
-				new ServletHolder("search", //$NON-NLS-1$
-						new SearchResource(sessionFactoryProvider)),
-				"/search/*"); //$NON-NLS-1$
-		v1Context.addServlet(
-				new ServletHolder("analytics", //$NON-NLS-1$
-						new AnalyticsResource(sessionFactoryProvider)),
-				"/analytics/*"); //$NON-NLS-1$
-		contexts.addHandler(v1Context);
-
-		contexts.addHandler(gitContext);
-		GzipHandler gzip = new GzipHandler();
-		gzip.setHandler(contexts);
-		server.setHandler(gzip);
-
-		server.start();
-		LOG.log(Level.INFO, "JGit Server started"); //$NON-NLS-1$
-		LOG.log(Level.INFO, "  REST API: http://0.0.0.0:{0}/api/", //$NON-NLS-1$
-				Integer.toString(restPort));
-		LOG.log(Level.INFO, "  REST API v1: http://0.0.0.0:{0}/api/v1/", //$NON-NLS-1$
-				Integer.toString(restPort));
-		LOG.log(Level.INFO,
-				"  Git HTTP: http://0.0.0.0:{0}/git/", //$NON-NLS-1$
-				Integer.toString(gitPort));
+		start(HibernateConfig.createPersistenceContext(),
+				getIntEnv("JGIT_REST_PORT", DEFAULT_REST_PORT), //$NON-NLS-1$
+				getIntEnv("JGIT_GIT_PORT", DEFAULT_GIT_PORT), //$NON-NLS-1$
+				System.getenv("JGIT_CORS_ORIGINS"), //$NON-NLS-1$
+				System.getenv("JGIT_DEFAULT_REPOS"), true); //$NON-NLS-1$
 	}
 
-	/**
-	 * Start the server with explicit Hibernate properties and ports.
-	 * <p>
-	 * Useful for integration testing with Testcontainers where the database
-	 * connection URL and ports are determined at runtime.
-	 *
-	 * @param hibernateProperties
-	 *            Hibernate configuration properties
-	 * @param restPort
-	 *            REST API port (0 for dynamic allocation)
-	 * @param gitPort
-	 *            Git HTTP port (0 for dynamic allocation)
-	 * @throws Exception
-	 *             if server startup fails
-	 */
-	public void start(Properties hibernateProperties, int restPort,
-			int gitPort) throws Exception {
-		sessionFactoryProvider = HibernateConfig
-				.createSessionFactoryProvider(hibernateProperties);
-		repositoryResolver = new HibernateRepositoryResolver(
-				sessionFactoryProvider);
+	/** Starts a test server from explicit Hibernate properties and dynamic ports. */
+	public void start(Properties hibernateProperties, int restPort, int gitPort) throws Exception {
+		start(HibernateConfig.createPersistenceContext(hibernateProperties), restPort, gitPort, null, null, false);
+	}
 
-		server = new Server();
+	private void start(ServerPersistenceContext context, int restPort, int gitPort,
+			String corsOrigins, String defaultRepositories, boolean exposeVersionedApi) throws Exception {
+		persistenceContext= Objects.requireNonNull(context, "context"); //$NON-NLS-1$
+		try {
+			SessionFactory sessionFactory= persistenceContext.sessionFactory();
+			repositoryResolver= new HibernateRepositoryResolver(sessionFactory);
+			SandboxRepositoryService repositories= repositoryResolver.getRepositoryService();
+			if (defaultRepositories != null && !defaultRepositories.isBlank()) {
+				RepositoryManagerConfig.initDefaultRepositories(repositories, defaultRepositories);
+			}
 
-		// REST API connector
-		ServerConnector restConnector = new ServerConnector(server);
-		restConnector.setPort(restPort);
-		restConnector.setName("rest"); //$NON-NLS-1$
+			server= new Server();
+			ServerConnector restConnector= connector("rest", restPort); //$NON-NLS-1$
+			ServerConnector gitConnector= connector("git", gitPort); //$NON-NLS-1$
+			server.addConnector(restConnector);
+			server.addConnector(gitConnector);
 
-		// Git HTTP connector
-		ServerConnector gitConnector = new ServerConnector(server);
-		gitConnector.setPort(gitPort);
-		gitConnector.setName("git"); //$NON-NLS-1$
+			ContextHandlerCollection contexts= new ContextHandlerCollection();
+			contexts.addHandler(createRestContext("/api", corsOrigins, sessionFactory, repositories)); //$NON-NLS-1$
+			if (exposeVersionedApi) {
+				contexts.addHandler(createRestContext("/api/v1", corsOrigins, sessionFactory, repositories)); //$NON-NLS-1$
+			}
+			contexts.addHandler(createGitContext());
+			GzipHandler gzip= new GzipHandler();
+			gzip.setHandler(contexts);
+			server.setHandler(gzip);
+			server.start();
+		} catch (Exception failure) {
+			closeAfterFailedStart(failure);
+			throw failure;
+		}
 
-		server.addConnector(restConnector);
-		server.addConnector(gitConnector);
-
-		ContextHandlerCollection contexts = new ContextHandlerCollection();
-
-		// REST API context
-		ServletContextHandler restContext = new ServletContextHandler(
-				ServletContextHandler.SESSIONS);
-		restContext.setContextPath("/api"); //$NON-NLS-1$
-		restContext.setVirtualHosts(List.of("@rest")); //$NON-NLS-1$
-
-		restContext.addServlet(new ServletHolder("health", //$NON-NLS-1$
-				new HealthResource(sessionFactoryProvider)), "/health"); //$NON-NLS-1$
-		restContext.addServlet(
-				new ServletHolder("repos", //$NON-NLS-1$
-						new RepositoryResource(sessionFactoryProvider,
-								repositoryResolver)),
-				"/repos/*"); //$NON-NLS-1$
-		restContext.addServlet(
-				new ServletHolder("search", //$NON-NLS-1$
-						new SearchResource(sessionFactoryProvider)),
-				"/search/*"); //$NON-NLS-1$
-		restContext.addServlet(
-				new ServletHolder("analytics", //$NON-NLS-1$
-						new AnalyticsResource(sessionFactoryProvider)),
-				"/analytics/*"); //$NON-NLS-1$
-
-		// Git Smart HTTP context
-		ServletContextHandler gitContext = new ServletContextHandler(
-				ServletContextHandler.SESSIONS);
-		gitContext.setContextPath("/git"); //$NON-NLS-1$
-		gitContext.setVirtualHosts(List.of("@git")); //$NON-NLS-1$
-
-		gitContext.addServlet(
-				new ServletHolder(createGitServlet(repositoryResolver)),
-				"/*"); //$NON-NLS-1$
-
-		contexts.addHandler(restContext);
-		contexts.addHandler(gitContext);
-		GzipHandler gzip = new GzipHandler();
-		gzip.setHandler(contexts);
-		server.setHandler(gzip);
-
-		server.start();
-		LOG.log(Level.INFO, "JGit Server started (test mode)"); //$NON-NLS-1$
+		LOG.log(Level.INFO, "JGit Server started"); //$NON-NLS-1$
 		LOG.log(Level.INFO, "  REST API: http://0.0.0.0:{0}/api/", //$NON-NLS-1$
 				Integer.toString(getRestPort()));
-		LOG.log(Level.INFO,
-				"  Git HTTP: http://0.0.0.0:{0}/git/", //$NON-NLS-1$
+		if (exposeVersionedApi) {
+			LOG.log(Level.INFO, "  REST API v1: http://0.0.0.0:{0}/api/v1/", //$NON-NLS-1$
+					Integer.toString(getRestPort()));
+		}
+		LOG.log(Level.INFO, "  Git HTTP: http://0.0.0.0:{0}/git/", //$NON-NLS-1$
 				Integer.toString(getGitPort()));
 	}
 
-	/**
-	 * Wait for the server to stop.
-	 *
-	 * @throws InterruptedException
-	 *             if interrupted while waiting
-	 */
+	private ServerConnector connector(String name, int port) {
+		ServerConnector connector= new ServerConnector(server);
+		connector.setPort(port);
+		connector.setName(name);
+		return connector;
+	}
+
+	private ServletContextHandler createRestContext(String contextPath, String corsOrigins,
+			SessionFactory sessionFactory, SandboxRepositoryService repositories) {
+		ServletContextHandler context= new ServletContextHandler(ServletContextHandler.SESSIONS);
+		context.setContextPath(contextPath);
+		context.setVirtualHosts(List.of("@rest")); //$NON-NLS-1$
+		if (corsOrigins != null && !corsOrigins.isBlank()) {
+			context.addFilter(new FilterHolder(new CorsFilter(corsOrigins)), "/*", //$NON-NLS-1$
+					EnumSet.allOf(DispatcherType.class));
+		}
+
+		// Search remains the one copied projection/query boundary. The compatibility
+		// provider cannot close the application-owned native factory.
+		HibernateSessionFactoryProvider searchCompatibility= new HibernateSessionFactoryProvider(sessionFactory) {
+			@Override
+			public void close() {
+				// The enclosing ServerPersistenceContext owns the native factory.
+			}
+		};
+		context.addServlet(new ServletHolder("health", new HealthResource(sessionFactory)), "/health"); //$NON-NLS-1$ //$NON-NLS-2$
+		context.addServlet(new ServletHolder("repos", new RepositoryResource(repositories)), "/repos/*"); //$NON-NLS-1$ //$NON-NLS-2$
+		context.addServlet(new ServletHolder("search", new SearchResource(searchCompatibility)), "/search/*"); //$NON-NLS-1$ //$NON-NLS-2$
+		context.addServlet(new ServletHolder("analytics", new AnalyticsResource(sessionFactory)), "/analytics/*"); //$NON-NLS-1$ //$NON-NLS-2$
+		context.addServlet(new ServletHolder("admin", new AdminResource(sessionFactory)), "/admin/*"); //$NON-NLS-1$ //$NON-NLS-2$
+		return context;
+	}
+
+	private ServletContextHandler createGitContext() {
+		ServletContextHandler context= new ServletContextHandler(ServletContextHandler.SESSIONS);
+		context.setContextPath("/git"); //$NON-NLS-1$
+		context.setVirtualHosts(List.of("@git")); //$NON-NLS-1$
+		context.addServlet(new ServletHolder(createGitServlet(repositoryResolver)), "/*"); //$NON-NLS-1$
+		return context;
+	}
+
+	/** Waits for the server to stop. */
 	public void join() throws InterruptedException {
 		if (server != null) {
 			server.join();
 		}
 	}
 
-	/**
-	 * Stop the server and release resources.
-	 *
-	 * @throws Exception
-	 *             if an error occurs during shutdown
-	 */
+	/** Stops the server and closes repository handles before the owned factory. */
 	public void stop() throws Exception {
-		if (server != null) {
-			server.stop();
+		Exception failure= null;
+		try {
+			if (server != null) {
+				server.stop();
+			}
+		} catch (Exception exception) {
+			failure= exception;
 		}
-		if (repositoryResolver != null) {
-			repositoryResolver.close();
+		try {
+			if (repositoryResolver != null) {
+				repositoryResolver.close();
+			}
+		} catch (RuntimeException exception) {
+			if (failure == null) {
+				failure= exception;
+			} else {
+				failure.addSuppressed(exception);
+			}
 		}
-		if (sessionFactoryProvider != null) {
-			sessionFactoryProvider.close();
+		try {
+			if (persistenceContext != null) {
+				persistenceContext.close();
+			}
+		} catch (RuntimeException exception) {
+			if (failure == null) {
+				failure= exception;
+			} else {
+				failure.addSuppressed(exception);
+			}
+		} finally {
+			server= null;
+			repositoryResolver= null;
+			persistenceContext= null;
+		}
+		if (failure != null) {
+			throw failure;
 		}
 	}
 
-	/**
-	 * Get the REST API port the server is listening on.
-	 *
-	 * @return the REST port, or -1 if not started
-	 */
+	private void closeAfterFailedStart(Exception failure) {
+		try {
+			stop();
+		} catch (Exception cleanupFailure) {
+			failure.addSuppressed(cleanupFailure);
+		}
+	}
+
+	/** Returns the REST port, or -1 while not started. */
 	public int getRestPort() {
-		if (server != null) {
-			for (var connector : server.getConnectors()) {
-				if (connector instanceof ServerConnector sc
-						&& "rest".equals(sc.getName())) { //$NON-NLS-1$
-					return sc.getLocalPort();
-				}
-			}
-		}
-		return -1;
+		return getPort("rest"); //$NON-NLS-1$
 	}
 
-	/**
-	 * Get the Git HTTP port the server is listening on.
-	 *
-	 * @return the Git port, or -1 if not started
-	 */
+	/** Returns the Git Smart HTTP port, or -1 while not started. */
 	public int getGitPort() {
+		return getPort("git"); //$NON-NLS-1$
+	}
+
+	private int getPort(String connectorName) {
 		if (server != null) {
 			for (var connector : server.getConnectors()) {
-				if (connector instanceof ServerConnector sc
-						&& "git".equals(sc.getName())) { //$NON-NLS-1$
-					return sc.getLocalPort();
+				if (connector instanceof ServerConnector serverConnector
+						&& connectorName.equals(serverConnector.getName())) {
+					return serverConnector.getLocalPort();
 				}
 			}
 		}
 		return -1;
 	}
 
-	/**
-	 * Get the repository resolver.
-	 *
-	 * @return the resolver
-	 */
+	/** Returns the repository resolver used by the running application. */
 	public HibernateRepositoryResolver getRepositoryResolver() {
 		return repositoryResolver;
 	}
 
+	/** Returns the application-owned native Hibernate factory. */
+	public SessionFactory getSessionFactory() {
+		if (persistenceContext == null) {
+			throw new IllegalStateException("Server persistence context is not started"); //$NON-NLS-1$
+		}
+		return persistenceContext.sessionFactory();
+	}
+
 	private static int getIntEnv(String name, int defaultValue) {
-		String val = System.getenv(name);
-		if (val != null && !val.isEmpty()) {
+		String value= System.getenv(name);
+		if (value != null && !value.isEmpty()) {
 			try {
-				return Integer.parseInt(val);
-			} catch (NumberFormatException e) {
-				LOG.log(Level.WARNING,
-						"Invalid integer for {0}: {1}, using default {2}", //$NON-NLS-1$
-						new Object[] { name, val,
-								Integer.toString(defaultValue) });
+				return Integer.parseInt(value);
+			} catch (NumberFormatException exception) {
+				LOG.log(Level.WARNING, "Invalid integer for {0}: {1}, using default {2}", //$NON-NLS-1$
+						new Object[] { name, value, Integer.toString(defaultValue) });
 			}
 		}
 		return defaultValue;
 	}
 
-	/**
-	 * Create a ReceivePackFactory that allows anonymous push operations.
-	 *
-	 * @return a factory that creates ReceivePack instances without requiring
-	 *         authentication
-	 */
 	private static ReceivePackFactory<HttpServletRequest> createReceivePackFactory() {
-		return (HttpServletRequest req, Repository db) -> {
-			ReceivePack rp = new ReceivePack(db);
-			// Default 3 MiB limit is too low for repositories with many refs.
-			// Allow override via env var; default to 50 MiB.
-			long maxCmdBytes = 50L << 20;
-			String envVal = System.getenv("JGIT_RECEIVE_MAX_COMMAND_BYTES"); //$NON-NLS-1$
-			if (envVal != null && !envVal.isEmpty()) {
+		return (request, repository) -> {
+			ReceivePack receivePack= new ReceivePack(repository);
+			long maxCommandBytes= 50L << 20;
+			String configured= System.getenv("JGIT_RECEIVE_MAX_COMMAND_BYTES"); //$NON-NLS-1$
+			if (configured != null && !configured.isEmpty()) {
 				try {
-					maxCmdBytes = Long.parseLong(envVal);
-				} catch (NumberFormatException e) {
+					maxCommandBytes= Long.parseLong(configured);
+				} catch (NumberFormatException exception) {
 					LOG.log(Level.WARNING,
 							"Invalid JGIT_RECEIVE_MAX_COMMAND_BYTES value: {0}, using default 50 MiB", //$NON-NLS-1$
-							envVal);
+							configured);
 				}
 			}
-			rp.setMaxCommandBytes(maxCmdBytes);
-			return rp;
+			receivePack.setMaxCommandBytes(maxCommandBytes);
+			return receivePack;
 		};
 	}
 
-	private static GitServlet createGitServlet(
-			HibernateRepositoryResolver resolver) {
-		GitServlet gitServlet = new GitServlet();
+	private static GitServlet createGitServlet(HibernateRepositoryResolver resolver) {
+		GitServlet gitServlet= new GitServlet();
 		gitServlet.setRepositoryResolver(resolver);
 		gitServlet.setReceivePackFactory(createReceivePackFactory());
-		gitServlet.setReceivePackErrorHandler(
-				(req, rsp, r) -> {
-					try {
-						r.receive();
-					} catch (Exception e) {
-						LOG.log(Level.SEVERE,
-								"ReceivePack error for " //$NON-NLS-1$
-										+ req.getRequestURI(),
-								e);
-						throw e;
-					}
-				});
+		gitServlet.setReceivePackErrorHandler((request, response, receivePack) -> {
+			try {
+				receivePack.receive();
+			} catch (Exception exception) {
+				LOG.log(Level.SEVERE, "ReceivePack error for " + request.getRequestURI(), exception); //$NON-NLS-1$
+				throw exception;
+			}
+		});
 		return gitServlet;
 	}
 }

--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/resolver/HibernateRepositoryResolver.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/resolver/HibernateRepositoryResolver.java
@@ -22,6 +22,7 @@ import org.eclipse.jgit.server.repository.SandboxRepositoryService;
 import org.eclipse.jgit.storage.hibernate.config.HibernateSessionFactoryProvider;
 import org.eclipse.jgit.transport.resolver.RepositoryResolver;
 import org.eclipse.jgit.transport.resolver.ServiceNotEnabledException;
+import org.hibernate.SessionFactory;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -32,7 +33,17 @@ public class HibernateRepositoryResolver
 	private final HibernateSessionFactoryProvider sessionFactoryProvider;
 	private final SandboxRepositoryService repositories;
 
-	/** Creates a resolver using the temporary copied-backend adapter. */
+	/** Creates a resolver from the application-owned native session factory. */
+	public HibernateRepositoryResolver(SessionFactory sessionFactory) {
+		this(null, new CopiedHibernateRepositoryService(sessionFactory));
+	}
+
+	/**
+	 * Creates a resolver using the temporary copied-backend adapter.
+	 *
+	 * @deprecated application wiring should pass the native {@link SessionFactory}
+	 */
+	@Deprecated(forRemoval = true)
 	public HibernateRepositoryResolver(HibernateSessionFactoryProvider sessionFactoryProvider) {
 		this(sessionFactoryProvider, new CopiedHibernateRepositoryService(sessionFactoryProvider));
 	}
@@ -83,6 +94,7 @@ public class HibernateRepositoryResolver
 	 * Returns the legacy provider while Search and analytics still use the copied
 	 * implementation. Repository lifecycle code must use {@link #getRepositoryService()}.
 	 */
+	@Deprecated(forRemoval = true)
 	public HibernateSessionFactoryProvider getSessionFactoryProvider() {
 		if (sessionFactoryProvider == null) {
 			throw new IllegalStateException("This resolver was created without a legacy session factory provider."); //$NON-NLS-1$

--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/rest/AdminResource.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/rest/AdminResource.java
@@ -17,63 +17,52 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.eclipse.jgit.storage.hibernate.config.HibernateSessionFactoryProvider;
 import org.eclipse.jgit.storage.hibernate.service.IndexMigrationService;
+import org.hibernate.SessionFactory;
 
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-/**
- * REST endpoint for administrative operations.
- * <ul>
- * <li>{@code POST /api/admin/reindex} — trigger full re-indexing of all
- * Hibernate Search entities</li>
- * </ul>
- */
+/** REST endpoint for administrative operations. */
 public class AdminResource extends HttpServlet {
 
 	private static final long serialVersionUID = 1L;
+	private static final Logger LOG = Logger.getLogger(AdminResource.class.getName());
+	private final SessionFactory sessionFactory;
 
-	private static final Logger LOG = Logger
-			.getLogger(AdminResource.class.getName());
+	/** Creates an admin endpoint from the application-owned native factory. */
+	public AdminResource(SessionFactory sessionFactory) {
+		this.sessionFactory= Objects.requireNonNull(sessionFactory, "sessionFactory"); //$NON-NLS-1$
+	}
 
-	private final HibernateSessionFactoryProvider provider;
-
-	/**
-	 * Create an admin endpoint.
-	 *
-	 * @param provider
-	 *            the session factory provider
-	 */
+	/** @deprecated application wiring should pass the native {@link SessionFactory}. */
+	@Deprecated(forRemoval = true)
 	public AdminResource(HibernateSessionFactoryProvider provider) {
-		this.provider = provider;
+		this(Objects.requireNonNull(provider, "provider").getSessionFactory()); //$NON-NLS-1$
 	}
 
 	@Override
-	protected void doPost(HttpServletRequest req, HttpServletResponse resp)
-			throws IOException {
+	protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
 		resp.setContentType("application/json"); //$NON-NLS-1$
 		resp.setCharacterEncoding("UTF-8"); //$NON-NLS-1$
-
 		if (!isAuthorized(req)) {
 			resp.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-			resp.setHeader("WWW-Authenticate", //$NON-NLS-1$
-					"Bearer realm=\"admin\""); //$NON-NLS-1$
+			resp.setHeader("WWW-Authenticate", "Bearer realm=\"admin\""); //$NON-NLS-1$ //$NON-NLS-2$
 			try (PrintWriter w = resp.getWriter()) {
 				w.write("{\"error\":\"Unauthorized. Set JGIT_ADMIN_TOKEN and pass as Bearer token.\"}"); //$NON-NLS-1$
 			}
 			return;
 		}
-
 		String pathInfo = req.getPathInfo();
 		if (pathInfo == null) {
 			pathInfo = "/"; //$NON-NLS-1$
 		}
-
 		if (pathInfo.startsWith("/reindex")) { //$NON-NLS-1$
 			handleReindex(resp);
 		} else {
@@ -86,8 +75,7 @@ public class AdminResource extends HttpServlet {
 
 	private void handleReindex(HttpServletResponse resp) throws IOException {
 		try {
-			IndexMigrationService migrationService = new IndexMigrationService(
-					provider.getSessionFactory());
+			IndexMigrationService migrationService = new IndexMigrationService(sessionFactory);
 			migrationService.reindexAll();
 			resp.setStatus(HttpServletResponse.SC_OK);
 			try (PrintWriter w = resp.getWriter()) {
@@ -96,51 +84,31 @@ public class AdminResource extends HttpServlet {
 		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
 			LOG.log(Level.WARNING, "Re-indexing interrupted", e); //$NON-NLS-1$
-			resp.setStatus(
-					HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+			resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
 			try (PrintWriter w = resp.getWriter()) {
 				w.write("{\"error\":\"Re-indexing was interrupted\"}"); //$NON-NLS-1$
 			}
 		} catch (Exception e) {
 			LOG.log(Level.WARNING, "Re-indexing failed", e); //$NON-NLS-1$
-			resp.setStatus(
-					HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+			resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
 			try (PrintWriter w = resp.getWriter()) {
 				w.write("{\"error\":\"Re-indexing failed\"}"); //$NON-NLS-1$
 			}
 		}
 	}
 
-	/**
-	 * Check if the request is authorized for admin operations.
-	 * <p>
-	 * The {@code JGIT_ADMIN_TOKEN} environment variable must be set to a
-	 * non-empty value; all admin access is denied when the variable is absent
-	 * or empty.  Requests must include an
-	 * {@code Authorization: Bearer <token>} header whose value matches that
-	 * variable.
-	 * </p>
-	 *
-	 * @param req
-	 *            the HTTP request
-	 * @return {@code true} if the request is authorized
-	 */
 	private static boolean isAuthorized(HttpServletRequest req) {
 		String expectedToken = System.getenv("JGIT_ADMIN_TOKEN"); //$NON-NLS-1$
 		if (expectedToken == null || expectedToken.isEmpty()) {
-			LOG.log(Level.WARNING,
-					"Admin access denied: JGIT_ADMIN_TOKEN is not set"); //$NON-NLS-1$
+			LOG.log(Level.WARNING, "Admin access denied: JGIT_ADMIN_TOKEN is not set"); //$NON-NLS-1$
 			return false;
 		}
 		String authHeader = req.getHeader("Authorization"); //$NON-NLS-1$
-		if (authHeader == null
-				|| !authHeader.startsWith("Bearer ")) { //$NON-NLS-1$
+		if (authHeader == null || !authHeader.startsWith("Bearer ")) { //$NON-NLS-1$
 			return false;
 		}
-		String token = authHeader
-				.substring("Bearer ".length()).trim(); //$NON-NLS-1$
-		return MessageDigest.isEqual(
-				expectedToken.getBytes(StandardCharsets.UTF_8),
+		String token = authHeader.substring("Bearer ".length()).trim(); //$NON-NLS-1$
+		return MessageDigest.isEqual(expectedToken.getBytes(StandardCharsets.UTF_8),
 				token.getBytes(StandardCharsets.UTF_8));
 	}
 }

--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/rest/AnalyticsResource.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/rest/AnalyticsResource.java
@@ -16,12 +16,14 @@ package org.eclipse.jgit.server.rest;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.List;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.eclipse.jgit.storage.hibernate.config.HibernateSessionFactoryProvider;
 import org.eclipse.jgit.storage.hibernate.service.GitDatabaseQueryService;
 import org.eclipse.jgit.storage.hibernate.service.GitDatabaseQueryService.AuthorStats;
+import org.hibernate.SessionFactory;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
@@ -31,47 +33,33 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-/**
- * REST endpoint for repository analytics.
- * <ul>
- * <li>{@code GET /api/analytics/authors?repo=...} — author commit
- * statistics</li>
- * <li>{@code GET /api/analytics/objects?repo=...} — object type counts</li>
- * <li>{@code GET /api/analytics/packs?repo=...} — pack file statistics</li>
- * </ul>
- */
+/** REST endpoint for repository analytics. */
 public class AnalyticsResource extends HttpServlet {
 
 	private static final long serialVersionUID = 1L;
-
-	private static final Logger LOG = Logger
-			.getLogger(AnalyticsResource.class.getName());
-
-	private final HibernateSessionFactoryProvider provider;
-
+	private static final Logger LOG = Logger.getLogger(AnalyticsResource.class.getName());
+	private final SessionFactory sessionFactory;
 	private final Gson gson = new Gson();
 
-	/**
-	 * Create an analytics endpoint.
-	 *
-	 * @param provider
-	 *            the session factory provider
-	 */
+	/** Creates an analytics endpoint from the application-owned native factory. */
+	public AnalyticsResource(SessionFactory sessionFactory) {
+		this.sessionFactory= Objects.requireNonNull(sessionFactory, "sessionFactory"); //$NON-NLS-1$
+	}
+
+	/** @deprecated application wiring should pass the native {@link SessionFactory}. */
+	@Deprecated(forRemoval = true)
 	public AnalyticsResource(HibernateSessionFactoryProvider provider) {
-		this.provider = provider;
+		this(Objects.requireNonNull(provider, "provider").getSessionFactory()); //$NON-NLS-1$
 	}
 
 	@Override
-	protected void doGet(HttpServletRequest req, HttpServletResponse resp)
-			throws IOException {
+	protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
 		resp.setContentType("application/json"); //$NON-NLS-1$
 		resp.setCharacterEncoding("UTF-8"); //$NON-NLS-1$
-
 		String pathInfo = req.getPathInfo();
 		if (pathInfo == null) {
 			pathInfo = "/"; //$NON-NLS-1$
 		}
-
 		String repo = req.getParameter("repo"); //$NON-NLS-1$
 		if (repo == null || repo.isEmpty()) {
 			resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
@@ -80,11 +68,8 @@ public class AnalyticsResource extends HttpServlet {
 			}
 			return;
 		}
-
 		try {
-			GitDatabaseQueryService queryService = new GitDatabaseQueryService(
-					provider.getSessionFactory());
-
+			GitDatabaseQueryService queryService = new GitDatabaseQueryService(sessionFactory);
 			if (pathInfo.startsWith("/authors")) { //$NON-NLS-1$
 				handleAuthorStats(queryService, repo, resp);
 			} else if (pathInfo.startsWith("/objects")) { //$NON-NLS-1$
@@ -106,13 +91,11 @@ public class AnalyticsResource extends HttpServlet {
 		}
 	}
 
-	private void handleAuthorStats(GitDatabaseQueryService queryService,
-			String repo, HttpServletResponse resp) throws IOException {
+	private void handleAuthorStats(GitDatabaseQueryService queryService, String repo,
+			HttpServletResponse resp) throws IOException {
 		List<AuthorStats> stats = queryService.getAuthorStatistics(repo);
-
 		JsonObject response = new JsonObject();
 		response.addProperty("repository", repo); //$NON-NLS-1$
-
 		JsonArray authors = new JsonArray();
 		for (AuthorStats as : stats) {
 			JsonObject author = new JsonObject();
@@ -122,44 +105,34 @@ public class AnalyticsResource extends HttpServlet {
 			authors.add(author);
 		}
 		response.add("authors", authors); //$NON-NLS-1$
-
 		resp.setStatus(HttpServletResponse.SC_OK);
 		try (PrintWriter w = resp.getWriter()) {
 			w.write(gson.toJson(response));
 		}
 	}
 
-	private void handleObjectStats(GitDatabaseQueryService queryService,
-			String repo, HttpServletResponse resp) throws IOException {
+	private void handleObjectStats(GitDatabaseQueryService queryService, String repo,
+			HttpServletResponse resp) throws IOException {
 		JsonObject response = new JsonObject();
 		response.addProperty("repository", repo); //$NON-NLS-1$
-
 		JsonObject counts = new JsonObject();
-		counts.addProperty("commits", //$NON-NLS-1$
-				queryService.countObjectsByType(repo, 1));
-		counts.addProperty("trees", //$NON-NLS-1$
-				queryService.countObjectsByType(repo, 2));
-		counts.addProperty("blobs", //$NON-NLS-1$
-				queryService.countObjectsByType(repo, 3));
-		counts.addProperty("tags", //$NON-NLS-1$
-				queryService.countObjectsByType(repo, 4));
+		counts.addProperty("commits", queryService.countObjectsByType(repo, 1)); //$NON-NLS-1$
+		counts.addProperty("trees", queryService.countObjectsByType(repo, 2)); //$NON-NLS-1$
+		counts.addProperty("blobs", queryService.countObjectsByType(repo, 3)); //$NON-NLS-1$
+		counts.addProperty("tags", queryService.countObjectsByType(repo, 4)); //$NON-NLS-1$
 		response.add("objectCounts", counts); //$NON-NLS-1$
-
 		resp.setStatus(HttpServletResponse.SC_OK);
 		try (PrintWriter w = resp.getWriter()) {
 			w.write(gson.toJson(response));
 		}
 	}
 
-	private void handlePackStats(GitDatabaseQueryService queryService,
-			String repo, HttpServletResponse resp) throws IOException {
+	private void handlePackStats(GitDatabaseQueryService queryService, String repo,
+			HttpServletResponse resp) throws IOException {
 		JsonObject response = new JsonObject();
 		response.addProperty("repository", repo); //$NON-NLS-1$
-		response.addProperty("packCount", //$NON-NLS-1$
-				queryService.countPacks(repo));
-		response.addProperty("totalSizeBytes", //$NON-NLS-1$
-				queryService.getTotalPackSize(repo));
-
+		response.addProperty("packCount", queryService.countPacks(repo)); //$NON-NLS-1$
+		response.addProperty("totalSizeBytes", queryService.getTotalPackSize(repo)); //$NON-NLS-1$
 		resp.setStatus(HttpServletResponse.SC_OK);
 		try (PrintWriter w = resp.getWriter()) {
 			w.write(gson.toJson(response));

--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/rest/HealthResource.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/rest/HealthResource.java
@@ -15,10 +15,12 @@ package org.eclipse.jgit.server.rest;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.Objects;
 
 import org.eclipse.jgit.storage.hibernate.config.HibernateSessionFactoryProvider;
 import org.eclipse.jgit.storage.hibernate.entity.GitCommitIndex;
 import org.hibernate.Session;
+import org.hibernate.SessionFactory;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 
@@ -38,16 +40,28 @@ public class HealthResource extends HttpServlet {
 
 	private static final long serialVersionUID = 1L;
 
-	private final HibernateSessionFactoryProvider provider;
+	private final SessionFactory sessionFactory;
 
 	/**
-	 * Create a health check endpoint.
+	 * Create a health check endpoint from the application-owned native factory.
+	 *
+	 * @param sessionFactory
+	 *            the native session factory for database and search health checks
+	 */
+	public HealthResource(SessionFactory sessionFactory) {
+		this.sessionFactory= Objects.requireNonNull(sessionFactory, "sessionFactory"); //$NON-NLS-1$
+	}
+
+	/**
+	 * Create a health check endpoint from the copied compatibility provider.
 	 *
 	 * @param provider
 	 *            the session factory provider for database health checks
+	 * @deprecated application wiring should pass the native {@link SessionFactory}
 	 */
+	@Deprecated(forRemoval = true)
 	public HealthResource(HibernateSessionFactoryProvider provider) {
-		this.provider = provider;
+		this(Objects.requireNonNull(provider, "provider").getSessionFactory()); //$NON-NLS-1$
 	}
 
 	@Override
@@ -62,7 +76,7 @@ public class HealthResource extends HttpServlet {
 		String searchError = null;
 
 		// Check database connectivity
-		try (Session session = provider.getSessionFactory().openSession()) {
+		try (Session session = sessionFactory.openSession()) {
 			session.createNativeQuery("SELECT 1", Integer.class) //$NON-NLS-1$
 					.uniqueResult();
 			dbOk = true;
@@ -71,7 +85,7 @@ public class HealthResource extends HttpServlet {
 		}
 
 		// Check search backend
-		try (Session session = provider.getSessionFactory().openSession()) {
+		try (Session session = sessionFactory.openSession()) {
 			SearchSession searchSession = Search.session(session);
 			searchSession.search(GitCommitIndex.class)
 					.where(f -> f.matchAll())

--- a/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/JGitServerApplicationLifecycleTest.java
+++ b/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/JGitServerApplicationLifecycleTest.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jgit.server;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.jgit.server.config.ServerPersistenceContext;
+import org.hibernate.SessionFactory;
+import org.junit.Test;
+
+/** Lifecycle regressions for application-owned persistence startup. */
+public class JGitServerApplicationLifecycleTest {
+
+	@Test
+	public void closesPersistenceContextWhenNativeFactoryAccessFails() throws Exception {
+		AtomicBoolean closed= new AtomicBoolean();
+		ServerPersistenceContext context= new ServerPersistenceContext() {
+			@Override
+			public SessionFactory sessionFactory() {
+				throw new IllegalStateException("factory unavailable"); //$NON-NLS-1$
+			}
+
+			@Override
+			public void close() {
+				closed.set(true);
+			}
+		};
+		JGitServerApplication application= new JGitServerApplication();
+		Method start= JGitServerApplication.class.getDeclaredMethod("start", //$NON-NLS-1$
+				ServerPersistenceContext.class, int.class, int.class, String.class, String.class, boolean.class);
+		start.setAccessible(true);
+
+		InvocationTargetException failure= assertThrows(InvocationTargetException.class,
+				() -> start.invoke(application, context, 0, 0, null, null, false));
+		assertEquals("factory unavailable", failure.getCause().getMessage()); //$NON-NLS-1$
+		assertTrue("The application-owned persistence context must be closed", closed.get()); //$NON-NLS-1$
+		assertThrows(IllegalStateException.class, application::getSessionFactory);
+	}
+}

--- a/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/e2e/EndToEndH2Test.java
+++ b/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/e2e/EndToEndH2Test.java
@@ -27,6 +27,7 @@ import java.util.Properties;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.internal.storage.dfs.DfsBlockCache;
 import org.eclipse.jgit.internal.storage.dfs.DfsBlockCacheConfig;
+import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.server.JGitServerApplication;
 import org.eclipse.jgit.storage.hibernate.entity.GitCommitIndex;
@@ -39,69 +40,34 @@ import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
 
-/**
- * End-to-end integration test for the JGit server webapp.
- * <p>
- * This test exercises the full flow:
- * <ol>
- * <li>REST API health check, repository CRUD</li>
- * <li>JGit client clone and push via Git Smart HTTP</li>
- * <li>JDBC verification of commit data in the database</li>
- * <li>REST API search and analytics queries</li>
- * </ol>
- * <p>
- * By default runs with H2 in-memory (no Docker required). When the
- * {@code -Pe2e-tests} Maven profile is active, a MSSQL Testcontainer variant
- * is also included.
- */
+/** End-to-end integration test for the JGit server webapp. */
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class EndToEndH2Test {
 
 	private static JGitServerApplication server;
-
 	private static String restBaseUrl;
-
 	private static String gitBaseUrl;
-
 	private static String pushedCommitSha;
 
-	/**
-	 * Start the JGit server with H2 in-memory database.
-	 *
-	 * @throws Exception
-	 *             on startup failure
-	 */
 	@BeforeClass
 	public static void startServer() throws Exception {
 		DfsBlockCache.reconfigure(new DfsBlockCacheConfig());
-
 		Properties props = new Properties();
 		String jdbcUrl = "jdbc:h2:mem:e2e-test;DB_CLOSE_DELAY=-1"; //$NON-NLS-1$
-
 		props.put("hibernate.connection.url", jdbcUrl); //$NON-NLS-1$
 		props.put("hibernate.connection.username", "sa"); //$NON-NLS-1$ //$NON-NLS-2$
 		props.put("hibernate.connection.password", ""); //$NON-NLS-1$ //$NON-NLS-2$
-		props.put("hibernate.connection.driver_class", //$NON-NLS-1$
-				"org.h2.Driver"); //$NON-NLS-1$
-		props.put("hibernate.dialect", //$NON-NLS-1$
-				"org.hibernate.dialect.H2Dialect"); //$NON-NLS-1$
+		props.put("hibernate.connection.driver_class", "org.h2.Driver"); //$NON-NLS-1$ //$NON-NLS-2$
+		props.put("hibernate.dialect", "org.hibernate.dialect.H2Dialect"); //$NON-NLS-1$ //$NON-NLS-2$
 		props.put("hibernate.hbm2ddl.auto", "create"); //$NON-NLS-1$ //$NON-NLS-2$
 		props.put("hibernate.show_sql", "false"); //$NON-NLS-1$ //$NON-NLS-2$
 		props.put("hibernate.search.backend.directory.type", "local-heap"); //$NON-NLS-1$ //$NON-NLS-2$
-
 		server = new JGitServerApplication();
 		server.start(props, 0, 0);
-
 		restBaseUrl = "http://localhost:" + server.getRestPort(); //$NON-NLS-1$
 		gitBaseUrl = "http://localhost:" + server.getGitPort(); //$NON-NLS-1$
 	}
 
-	/**
-	 * Stop the JGit server.
-	 *
-	 * @throws Exception
-	 *             on shutdown failure
-	 */
 	@AfterClass
 	public static void stopServer() throws Exception {
 		if (server != null) {
@@ -109,119 +75,64 @@ public class EndToEndH2Test {
 		}
 	}
 
-	/**
-	 * Verify health endpoint returns UP with database connected.
-	 *
-	 * @throws Exception
-	 *             on failure
-	 */
 	@Test
 	public void test01_HealthEndpoint() throws Exception {
-		HttpURLConnection conn = TestHelper.openGet(restBaseUrl,
-				"/api/health"); //$NON-NLS-1$
+		HttpURLConnection conn = TestHelper.openGet(restBaseUrl, "/api/health"); //$NON-NLS-1$
 		assertEquals(200, conn.getResponseCode());
 		String body = TestHelper.readBody(conn);
-		assertTrue("Should contain UP status", //$NON-NLS-1$
-				body.contains("\"status\":\"UP\"")); //$NON-NLS-1$
+		assertTrue("Should contain UP status", body.contains("\"status\":\"UP\"")); //$NON-NLS-1$ //$NON-NLS-2$
 		assertTrue("Should indicate database connected", //$NON-NLS-1$
 				body.contains("\"database\":{\"status\":\"UP\"}")); //$NON-NLS-1$
 	}
 
-	/**
-	 * Create a repository via REST API.
-	 *
-	 * @throws Exception
-	 *             on failure
-	 */
 	@Test
 	public void test02_CreateRepo() throws Exception {
-		HttpURLConnection conn = TestHelper.openPost(restBaseUrl,
-				"/api/repos", //$NON-NLS-1$
+		HttpURLConnection conn = TestHelper.openPost(restBaseUrl, "/api/repos", //$NON-NLS-1$
 				"{\"name\":\"e2e-test\",\"description\":\"E2E Test Repo\"}"); //$NON-NLS-1$
 		assertEquals(201, conn.getResponseCode());
 		String body = TestHelper.readBody(conn);
-		assertTrue("Should contain repo name", //$NON-NLS-1$
-				body.contains("\"name\":\"e2e-test\"")); //$NON-NLS-1$
-
-		// Enable receive-pack for anonymous push
-		org.eclipse.jgit.storage.hibernate.repository.HibernateRepository repo = server
-				.getRepositoryResolver()
-				.getOrCreateRepository("e2e-test"); //$NON-NLS-1$
+		assertTrue("Should contain repo name", body.contains("\"name\":\"e2e-test\"")); //$NON-NLS-1$ //$NON-NLS-2$
+		Repository repo = server.getRepositoryResolver().getOrCreateRepository("e2e-test"); //$NON-NLS-1$
 		org.eclipse.jgit.lib.StoredConfig cfg = repo.getConfig();
 		cfg.setBoolean("http", null, "receivepack", true); //$NON-NLS-1$ //$NON-NLS-2$
 		cfg.save();
 	}
 
-	/**
-	 * Get a repository via REST API.
-	 *
-	 * @throws Exception
-	 *             on failure
-	 */
 	@Test
 	public void test03_GetRepo() throws Exception {
-		HttpURLConnection conn = TestHelper.openGet(restBaseUrl,
-				"/api/repos/e2e-test"); //$NON-NLS-1$
+		HttpURLConnection conn = TestHelper.openGet(restBaseUrl, "/api/repos/e2e-test"); //$NON-NLS-1$
 		assertEquals(200, conn.getResponseCode());
 		String body = TestHelper.readBody(conn);
-		assertTrue("Should contain repo name", //$NON-NLS-1$
-				body.contains("\"name\":\"e2e-test\"")); //$NON-NLS-1$
+		assertTrue("Should contain repo name", body.contains("\"name\":\"e2e-test\"")); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
-	/**
-	 * Clone an empty repository via Git Smart HTTP.
-	 *
-	 * @throws Exception
-	 *             on failure
-	 */
 	@Test
 	public void test04_CloneEmptyRepo() throws Exception {
-		File localDir = Files.createTempDirectory("jgit-e2e-clone") //$NON-NLS-1$
-				.toFile();
-		try (Git git = Git.cloneRepository()
-				.setURI(gitBaseUrl + "/git/e2e-test.git") //$NON-NLS-1$
+		File localDir = Files.createTempDirectory("jgit-e2e-clone").toFile(); //$NON-NLS-1$
+		try (Git git = Git.cloneRepository().setURI(gitBaseUrl + "/git/e2e-test.git") //$NON-NLS-1$
 				.setDirectory(localDir).call()) {
-			assertNotNull("Cloned repository should not be null", //$NON-NLS-1$
-					git.getRepository());
+			assertNotNull("Cloned repository should not be null", git.getRepository()); //$NON-NLS-1$
 		} finally {
 			deleteRecursive(localDir);
 		}
 	}
 
-	/**
-	 * Commit a file and push it via Git Smart HTTP.
-	 *
-	 * @throws Exception
-	 *             on failure
-	 */
 	@Test
 	public void test05_CommitAndPush() throws Exception {
-		File localDir = Files.createTempDirectory("jgit-e2e-push") //$NON-NLS-1$
-				.toFile();
-		try (Git git = Git.cloneRepository()
-				.setURI(gitBaseUrl + "/git/e2e-test.git") //$NON-NLS-1$
+		File localDir = Files.createTempDirectory("jgit-e2e-push").toFile(); //$NON-NLS-1$
+		try (Git git = Git.cloneRepository().setURI(gitBaseUrl + "/git/e2e-test.git") //$NON-NLS-1$
 				.setDirectory(localDir).call()) {
-
-			// Create a file and commit
 			File testFile = new File(localDir, "README.md"); //$NON-NLS-1$
-			Files.writeString(testFile.toPath(),
-					"# E2E Test\nHello from Testcontainers!"); //$NON-NLS-1$
+			Files.writeString(testFile.toPath(), "# E2E Test\nHello from Testcontainers!"); //$NON-NLS-1$
 			git.add().addFilepattern("README.md").call(); //$NON-NLS-1$
-			RevCommit commit = git.commit()
-					.setMessage("Initial e2e commit: add README") //$NON-NLS-1$
-					.setAuthor("E2E Test", "e2e@test.org") //$NON-NLS-1$ //$NON-NLS-2$
-					.call();
-
+			RevCommit commit = git.commit().setMessage("Initial e2e commit: add README") //$NON-NLS-1$
+					.setAuthor("E2E Test", "e2e@test.org").call(); //$NON-NLS-1$ //$NON-NLS-2$
 			assertNotNull("Commit should not be null", commit); //$NON-NLS-1$
 			pushedCommitSha = commit.getName();
-
-			// Push
 			Iterable<PushResult> results = git.push().call();
-			for (PushResult pr : results) {
-				for (RemoteRefUpdate ru : pr.getRemoteUpdates()) {
-					assertEquals(
-							"Push should succeed", //$NON-NLS-1$
-							RemoteRefUpdate.Status.OK, ru.getStatus());
+			for (PushResult result : results) {
+				for (RemoteRefUpdate update : result.getRemoteUpdates()) {
+					assertEquals("Push should succeed", RemoteRefUpdate.Status.OK, update.getStatus()); //$NON-NLS-1$
 				}
 			}
 		} finally {
@@ -229,57 +140,29 @@ public class EndToEndH2Test {
 		}
 	}
 
-	/**
-	 * Verify the pushed commit is searchable via Hibernate Search.
-	 *
-	 * @throws Exception
-	 *             on failure
-	 */
 	@Test
 	public void test06_VerifyCommitInDatabase() throws Exception {
-		assertNotNull("pushedCommitSha should be set by test05", //$NON-NLS-1$
-				pushedCommitSha);
-		// Index the commit (Hibernate Search auto-indexes on persist)
-		org.eclipse.jgit.storage.hibernate.service.CommitIndexer indexer = new org.eclipse.jgit.storage.hibernate.service.CommitIndexer(
-				server.getRepositoryResolver().getSessionFactoryProvider()
-						.getSessionFactory(),
-				"e2e-test"); //$NON-NLS-1$
-		org.eclipse.jgit.storage.hibernate.repository.HibernateRepository repo = server
-				.getRepositoryResolver().getOrCreateRepository("e2e-test"); //$NON-NLS-1$
-		org.eclipse.jgit.lib.ObjectId tipId = repo
-				.exactRef("refs/heads/master") != null //$NON-NLS-1$
-						? repo.exactRef("refs/heads/master").getObjectId() //$NON-NLS-1$
-						: null;
+		assertNotNull("pushedCommitSha should be set by test05", pushedCommitSha); //$NON-NLS-1$
+		org.eclipse.jgit.storage.hibernate.service.CommitIndexer indexer =
+				new org.eclipse.jgit.storage.hibernate.service.CommitIndexer(
+						server.getSessionFactory(), "e2e-test"); //$NON-NLS-1$
+		Repository repo = server.getRepositoryResolver().getOrCreateRepository("e2e-test"); //$NON-NLS-1$
+		org.eclipse.jgit.lib.ObjectId tipId = repo.exactRef("refs/heads/master") != null //$NON-NLS-1$
+				? repo.exactRef("refs/heads/master").getObjectId() : null; //$NON-NLS-1$
 		if (tipId == null) {
 			tipId = repo.exactRef("refs/heads/main") != null //$NON-NLS-1$
-					? repo.exactRef("refs/heads/main").getObjectId() //$NON-NLS-1$
-					: null;
+					? repo.exactRef("refs/heads/main").getObjectId() : null; //$NON-NLS-1$
 		}
 		assertNotNull("Should have a HEAD ref", tipId); //$NON-NLS-1$
 		indexer.indexCommit(repo, tipId);
-
-		// Verify via Hibernate Search through GitDatabaseQueryService
-		GitDatabaseQueryService queryService = new GitDatabaseQueryService(
-				server.getRepositoryResolver().getSessionFactoryProvider()
-						.getSessionFactory());
-		List<GitCommitIndex> results = queryService
-				.searchCommitMessages("e2e-test", "README"); //$NON-NLS-1$ //$NON-NLS-2$
-		assertFalse("Should find at least one commit", //$NON-NLS-1$
-				results.isEmpty());
-		assertEquals("Initial e2e commit: add README", //$NON-NLS-1$
-				results.get(0).getCommitMessage());
-		assertEquals("E2E Test", //$NON-NLS-1$
-				results.get(0).getAuthorName());
-		assertEquals("e2e@test.org", //$NON-NLS-1$
-				results.get(0).getAuthorEmail());
+		GitDatabaseQueryService queryService = new GitDatabaseQueryService(server.getSessionFactory());
+		List<GitCommitIndex> results = queryService.searchCommitMessages("e2e-test", "README"); //$NON-NLS-1$ //$NON-NLS-2$
+		assertFalse("Should find at least one commit", results.isEmpty()); //$NON-NLS-1$
+		assertEquals("Initial e2e commit: add README", results.get(0).getCommitMessage()); //$NON-NLS-1$
+		assertEquals("E2E Test", results.get(0).getAuthorName()); //$NON-NLS-1$
+		assertEquals("e2e@test.org", results.get(0).getAuthorEmail()); //$NON-NLS-1$
 	}
 
-	/**
-	 * Search commits via REST API.
-	 *
-	 * @throws Exception
-	 *             on failure
-	 */
 	@Test
 	public void test07_SearchCommitsViaRest() throws Exception {
 		HttpURLConnection conn = TestHelper.openGet(restBaseUrl,
@@ -287,187 +170,112 @@ public class EndToEndH2Test {
 		assertEquals(200, conn.getResponseCode());
 		String body = TestHelper.readBody(conn);
 		assertFalse("Search body should not be empty", body.isEmpty()); //$NON-NLS-1$
-		assertTrue("Should contain results array", //$NON-NLS-1$
-				body.contains("\"results\"")); //$NON-NLS-1$
+		assertTrue("Should contain results array", body.contains("\"results\"")); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
-	/**
-	 * Search paths via REST API.
-	 *
-	 * @throws Exception
-	 *             on failure
-	 */
 	@Test
 	public void test08_SearchPathsViaRest() throws Exception {
 		HttpURLConnection conn = TestHelper.openGet(restBaseUrl,
 				"/api/search/paths?repo=e2e-test&q=README"); //$NON-NLS-1$
 		assertEquals(200, conn.getResponseCode());
 		String body = TestHelper.readBody(conn);
-		assertFalse("Search paths body should not be empty", //$NON-NLS-1$
-				body.isEmpty());
-		assertTrue("Should contain results array", //$NON-NLS-1$
-				body.contains("\"results\"")); //$NON-NLS-1$
+		assertFalse("Search paths body should not be empty", body.isEmpty()); //$NON-NLS-1$
+		assertTrue("Should contain results array", body.contains("\"results\"")); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
-	/**
-	 * Query author analytics via REST API.
-	 *
-	 * @throws Exception
-	 *             on failure
-	 */
 	@Test
 	public void test09_AnalyticsAuthorsViaRest() throws Exception {
 		HttpURLConnection conn = TestHelper.openGet(restBaseUrl,
 				"/api/analytics/authors?repo=e2e-test"); //$NON-NLS-1$
 		assertEquals(200, conn.getResponseCode());
 		String body = TestHelper.readBody(conn);
-		assertTrue("Should contain authors key", //$NON-NLS-1$
-				body.contains("\"authors\"")); //$NON-NLS-1$
+		assertTrue("Should contain authors key", body.contains("\"authors\"")); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
-	/**
-	 * Query object count analytics via REST API.
-	 *
-	 * @throws Exception
-	 *             on failure
-	 */
 	@Test
 	public void test10_AnalyticsObjectsViaRest() throws Exception {
 		HttpURLConnection conn = TestHelper.openGet(restBaseUrl,
 				"/api/analytics/objects?repo=e2e-test"); //$NON-NLS-1$
 		assertEquals(200, conn.getResponseCode());
 		String body = TestHelper.readBody(conn);
-		assertTrue("Should contain objectCounts key", //$NON-NLS-1$
-				body.contains("\"objectCounts\"")); //$NON-NLS-1$
+		assertTrue("Should contain objectCounts key", body.contains("\"objectCounts\"")); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
-	/**
-	 * Query pack analytics via REST API.
-	 *
-	 * @throws Exception
-	 *             on failure
-	 */
 	@Test
 	public void test11_AnalyticsPacksViaRest() throws Exception {
 		HttpURLConnection conn = TestHelper.openGet(restBaseUrl,
 				"/api/analytics/packs?repo=e2e-test"); //$NON-NLS-1$
 		assertEquals(200, conn.getResponseCode());
 		String body = TestHelper.readBody(conn);
-		assertTrue("Should contain packCount key", //$NON-NLS-1$
-				body.contains("\"packCount\"")); //$NON-NLS-1$
+		assertTrue("Should contain packCount key", body.contains("\"packCount\"")); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
-	/**
-	 * Push a Java file, index it, and search by type via REST API.
-	 *
-	 * @throws Exception
-	 *             on failure
-	 */
-	/**
-	 * Index Java blobs and search by type via REST API.
-	 *
-	 * @throws Exception
-	 *             on failure
-	 */
 	@Test
 	public void test12_PushJavaFileAndSearchByType() throws Exception {
-		// Get the server-side repository and insert a Java file directly
-		org.eclipse.jgit.storage.hibernate.repository.HibernateRepository repo = server
-				.getRepositoryResolver()
-				.getOrCreateRepository("e2e-test"); //$NON-NLS-1$
-
+		Repository repo = server.getRepositoryResolver().getOrCreateRepository("e2e-test"); //$NON-NLS-1$
 		org.eclipse.jgit.lib.ObjectId commitId;
-		try (org.eclipse.jgit.lib.ObjectInserter inserter = repo
-				.newObjectInserter()) {
+		try (org.eclipse.jgit.lib.ObjectInserter inserter = repo.newObjectInserter()) {
 			byte[] src = ("package org.example;\n\n" //$NON-NLS-1$
 					+ "public class HelloWorld {\n" //$NON-NLS-1$
 					+ "    public static void main(String[] args) {\n" //$NON-NLS-1$
 					+ "        System.out.println(\"Hello\");\n" //$NON-NLS-1$
-					+ "    }\n}\n") //$NON-NLS-1$
-							.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+					+ "    }\n}\n").getBytes(java.nio.charset.StandardCharsets.UTF_8); //$NON-NLS-1$
 			org.eclipse.jgit.lib.ObjectId blobId = inserter.insert(
 					org.eclipse.jgit.lib.Constants.OBJ_BLOB, src);
-
 			org.eclipse.jgit.lib.TreeFormatter tree = new org.eclipse.jgit.lib.TreeFormatter();
-			tree.append("HelloWorld.java", //$NON-NLS-1$
-					org.eclipse.jgit.lib.FileMode.REGULAR_FILE, blobId);
+			tree.append("HelloWorld.java", org.eclipse.jgit.lib.FileMode.REGULAR_FILE, blobId); //$NON-NLS-1$
 			org.eclipse.jgit.lib.ObjectId treeId = inserter.insert(tree);
-
-			org.eclipse.jgit.lib.CommitBuilder cb = new org.eclipse.jgit.lib.CommitBuilder();
-			cb.setTreeId(treeId);
-			cb.setAuthor(new org.eclipse.jgit.lib.PersonIdent(
-					"E2E Test", "e2e@test.org")); //$NON-NLS-1$ //$NON-NLS-2$
-			cb.setCommitter(new org.eclipse.jgit.lib.PersonIdent(
-					"E2E Test", "e2e@test.org")); //$NON-NLS-1$ //$NON-NLS-2$
-			cb.setMessage("Add HelloWorld.java"); //$NON-NLS-1$
-			commitId = inserter.insert(cb);
+			org.eclipse.jgit.lib.CommitBuilder commit = new org.eclipse.jgit.lib.CommitBuilder();
+			commit.setTreeId(treeId);
+			commit.setAuthor(new org.eclipse.jgit.lib.PersonIdent("E2E Test", "e2e@test.org")); //$NON-NLS-1$ //$NON-NLS-2$
+			commit.setCommitter(new org.eclipse.jgit.lib.PersonIdent("E2E Test", "e2e@test.org")); //$NON-NLS-1$ //$NON-NLS-2$
+			commit.setMessage("Add HelloWorld.java"); //$NON-NLS-1$
+			commitId = inserter.insert(commit);
 			inserter.flush();
 		}
-
-		// Index the Java blobs
-		org.eclipse.jgit.storage.hibernate.service.BlobIndexer blobIndexer = new org.eclipse.jgit.storage.hibernate.service.BlobIndexer(
-				server.getRepositoryResolver().getSessionFactoryProvider()
-						.getSessionFactory(),
-				"e2e-test"); //$NON-NLS-1$
+		org.eclipse.jgit.storage.hibernate.service.BlobIndexer blobIndexer =
+				new org.eclipse.jgit.storage.hibernate.service.BlobIndexer(
+						server.getSessionFactory(), "e2e-test"); //$NON-NLS-1$
 		blobIndexer.indexCommitBlobs(repo, commitId);
-
-		// Search by type via REST API
 		HttpURLConnection conn = TestHelper.openGet(restBaseUrl,
 				"/api/search/types?repo=e2e-test&q=HelloWorld"); //$NON-NLS-1$
 		assertEquals(200, conn.getResponseCode());
 		String body = TestHelper.readBody(conn);
-		assertTrue("Should contain results", //$NON-NLS-1$
-				body.contains("\"results\"")); //$NON-NLS-1$
-		assertTrue("Should find HelloWorld", //$NON-NLS-1$
-				body.contains("HelloWorld")); //$NON-NLS-1$
+		assertTrue("Should contain results", body.contains("\"results\"")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertTrue("Should find HelloWorld", body.contains("HelloWorld")); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
-	/**
-	 * Search by method name via REST API.
-	 *
-	 * @throws Exception
-	 *             on failure
-	 */
 	@Test
 	public void test13_SearchBySymbolViaRest() throws Exception {
 		HttpURLConnection conn = TestHelper.openGet(restBaseUrl,
 				"/api/search/symbols?repo=e2e-test&q=main"); //$NON-NLS-1$
 		assertEquals(200, conn.getResponseCode());
 		String body = TestHelper.readBody(conn);
-		assertTrue("Should contain results", //$NON-NLS-1$
-				body.contains("\"results\"")); //$NON-NLS-1$
+		assertTrue("Should contain results", body.contains("\"results\"")); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
-	/**
-	 * Search source content via REST API.
-	 *
-	 * @throws Exception
-	 *             on failure
-	 */
 	@Test
 	public void test14_SearchSourceViaRest() throws Exception {
 		HttpURLConnection conn = TestHelper.openGet(restBaseUrl,
 				"/api/search/source?repo=e2e-test&q=println"); //$NON-NLS-1$
 		assertEquals(200, conn.getResponseCode());
 		String body = TestHelper.readBody(conn);
-		assertTrue("Should contain results", //$NON-NLS-1$
-				body.contains("\"results\"")); //$NON-NLS-1$
+		assertTrue("Should contain results", body.contains("\"results\"")); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
-	/**
-	 * Search hierarchy via REST API.
-	 *
-	 * @throws Exception
-	 *             on failure
-	 */
 	@Test
 	public void test15_SearchHierarchyViaRest() throws Exception {
 		HttpURLConnection conn = TestHelper.openGet(restBaseUrl,
 				"/api/search/hierarchy?repo=e2e-test&q=Object"); //$NON-NLS-1$
 		assertEquals(200, conn.getResponseCode());
 		String body = TestHelper.readBody(conn);
-		assertTrue("Should contain results", //$NON-NLS-1$
-				body.contains("\"results\"")); //$NON-NLS-1$
+		assertTrue("Should contain results", body.contains("\"results\"")); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	@Test
+	public void test16_AdminEndpointRequiresToken() throws Exception {
+		HttpURLConnection conn = TestHelper.openPost(restBaseUrl, "/api/admin/reindex", "{}"); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals(401, conn.getResponseCode());
 	}
 
 	private static void deleteRecursive(File file) {

--- a/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/repository/SandboxRepositoryServiceBoundaryTest.java
+++ b/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/repository/SandboxRepositoryServiceBoundaryTest.java
@@ -20,8 +20,13 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 
 import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.server.JGitServerApplication;
+import org.eclipse.jgit.server.rest.AdminResource;
+import org.eclipse.jgit.server.rest.AnalyticsResource;
+import org.eclipse.jgit.server.rest.HealthResource;
 import org.eclipse.jgit.server.rest.RepositoryResource;
 import org.eclipse.jgit.server.resolver.HibernateRepositoryResolver;
+import org.hibernate.SessionFactory;
 import org.junit.Test;
 
 import io.github.carstenartur.jgit.storage.hibernate.HibernateRepositoryFactory;
@@ -32,32 +37,38 @@ public class SandboxRepositoryServiceBoundaryTest {
 	@Test
 	public void exposesPublicJGitRepositoryContract() throws Exception {
 		Method open= SandboxRepositoryService.class.getMethod("openOrCreate", String.class); //$NON-NLS-1$
-
 		assertEquals(Repository.class, open.getReturnType());
 		assertNotNull(RepositoryResource.class.getConstructor(SandboxRepositoryService.class));
 		assertNotNull(HibernateRepositoryResolver.class.getConstructor(SandboxRepositoryService.class));
+		assertNotNull(HibernateRepositoryResolver.class.getConstructor(SessionFactory.class));
+		assertNotNull(HealthResource.class.getConstructor(SessionFactory.class));
+		assertNotNull(AnalyticsResource.class.getConstructor(SessionFactory.class));
+		assertNotNull(AdminResource.class.getConstructor(SessionFactory.class));
 		assertNotNull(ExternalHibernateRepositoryService.class.getConstructor(HibernateRepositoryFactory.class));
+		assertEquals(SessionFactory.class,
+				JGitServerApplication.class.getMethod("getSessionFactory").getReturnType()); //$NON-NLS-1$
 	}
 
 	@Test
-	public void repositoryResourceHasNoCopiedBackendField() {
-		assertFalse(Arrays.stream(RepositoryResource.class.getDeclaredFields())
-				.map(Field::getType)
-				.map(Class::getName)
-				.anyMatch(name -> name.startsWith("org.eclipse.jgit.storage.hibernate"))); //$NON-NLS-1$
-	}
-
-	@Test
-	public void externalAdapterHasNoCopiedBackendField() {
-		assertFalse(Arrays.stream(ExternalHibernateRepositoryService.class.getDeclaredFields())
-				.map(Field::getType)
-				.map(Class::getName)
-				.anyMatch(name -> name.startsWith("org.eclipse.jgit.storage.hibernate"))); //$NON-NLS-1$
+	public void applicationAndNativeResourcesHaveNoCopiedBackendField() {
+		assertFalse(hasCopiedBackendField(JGitServerApplication.class));
+		assertFalse(hasCopiedBackendField(RepositoryResource.class));
+		assertFalse(hasCopiedBackendField(HealthResource.class));
+		assertFalse(hasCopiedBackendField(AnalyticsResource.class));
+		assertFalse(hasCopiedBackendField(AdminResource.class));
+		assertFalse(hasCopiedBackendField(ExternalHibernateRepositoryService.class));
 	}
 
 	@Test
 	public void validatesApplicationMetadataIdentity() {
 		assertEquals("demo", new SandboxRepositoryInfo(" demo ", null).name()); //$NON-NLS-1$ //$NON-NLS-2$
 		assertThrows(IllegalArgumentException.class, () -> new SandboxRepositoryInfo(" ", null)); //$NON-NLS-1$
+	}
+
+	private static boolean hasCopiedBackendField(Class<?> type) {
+		return Arrays.stream(type.getDeclaredFields())
+				.map(Field::getType)
+				.map(Class::getName)
+				.anyMatch(name -> name.startsWith("org.eclipse.jgit.storage.hibernate")); //$NON-NLS-1$
 	}
 }


### PR DESCRIPTION
## Problem

After #1327 gives the copied repository adapter a non-owning native `SessionFactory` boundary, the server still stores and passes the copied `HibernateSessionFactoryProvider` through its resolver and REST wiring. The former stacked PRs #1329–#1332 addressed individual constructors but were intentionally closed so the actual application cut-over could be reviewed as one coherent slice.

## Change

- make `JGitServerApplication` own one `ServerPersistenceContext` and expose only its native `SessionFactory` to application components;
- construct the Smart HTTP resolver, health, analytics and admin endpoints from that native factory;
- initialize default repositories through the public `SandboxRepositoryService` boundary;
- share one REST-context builder across `/api`, `/api/v1` and test startup instead of maintaining three provider-based wiring copies;
- register the existing fail-closed admin endpoint under `/admin/*`;
- keep Search as the one explicit copied projection/query compatibility boundary through a local provider view whose `close()` is a no-op and which is never stored as application ownership;
- close Jetty, repository handles and the owned persistence context in that order;
- include resolver creation, default-repository initialization and Jetty setup in the same failed-start cleanup boundary;
- update boundary and H2 E2E tests to use the native application factory and verify unauthenticated admin requests fail closed with HTTP 401;
- add an early-startup regression proving the owned persistence context is closed even when native factory access itself fails.

## Review result

The consolidated diff preserves all 15 pre-existing H2 E2E scenarios. The large line reduction is from removing duplicated REST wiring and repetitive test Javadocs, not from removing endpoint, clone, push, indexing, search or analytics behavior. The native resolver, Health, Analytics and Admin constructor changes from closed #1329–#1332 are represented in this slice.

## Scope

This PR is stacked on #1327. It does not migrate copied Search entities, query services, embedding behavior or database schemas. Those remain the next architectural cut-over under #1303.

The PR remains Draft until the release sequence completes, #1327 is merged, this branch is rebased onto the resulting `main`, all review threads are resolved, and Java CI with Maven, Distribution Smoke Test, CodeQL and Codacy are green on the rebased head.

Refs #1303, #1327, #1329, #1330, #1331 and #1332.