### PR TITLE
Preserve release build evidence before timeout

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -182,8 +182,10 @@ jobs:
           echo "RELEASE_COMMIT=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
 
       - name: Maven distribution build and verification
+        timeout-minutes: 150
         run: |
           set -euo pipefail
+          mkdir -p target/distribution-verification
           test_args=()
           if [[ "$SKIP_TESTS" == 'true' ]]; then
             test_args=(-DskipTests)
@@ -192,7 +194,8 @@ jobs:
             -Pdistribution,cli-dist,maven-plugin,benchmark \
             --batch-mode \
             -Dtycho.localArtifacts=ignore \
-            clean verify "${test_args[@]}"
+            clean verify "${test_args[@]}" 2>&1 \
+            | tee target/distribution-verification/maven-release.log
 
       - name: Create and inspect immutable source archives
         run: |


### PR DESCRIPTION
## Problem

The fail-closed 1.3.3 release workflow has twice reached the 180-minute job timeout before publishing. The complete Maven distribution build currently has no step-level timeout and the `if: always()` evidence upload is scheduled only after it. A hard job cancellation therefore prevents the diagnostic artifact itself from running.

## Change

- bound the Maven distribution step to 150 minutes inside the existing 180-minute job;
- create the distribution-verification directory before the build;
- pipe Maven stdout/stderr through `tee` into `target/distribution-verification/maven-release.log`;
- retain `set -euo pipefail`, so a Maven failure or timed-out build still fails closed despite the log pipeline;
- leave all version, source identity, p2, tag, draft release, rollback and main-promotion gates unchanged.

This reserves roughly 30 minutes for the existing `if: always()` artifact upload and job cleanup. A subsequent release request should be made only after this workflow fix is merged.

Refs #1285.