### PR TITLE
Isolate legacy Search provider compatibility

### DIFF
--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/JGitServerApplication.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/JGitServerApplication.java
@@ -38,9 +38,8 @@ import org.eclipse.jgit.server.rest.AdminResource;
 import org.eclipse.jgit.server.rest.AnalyticsResource;
 import org.eclipse.jgit.server.rest.CorsFilter;
 import org.eclipse.jgit.server.rest.HealthResource;
+import org.eclipse.jgit.server.rest.NativeSearchResource;
 import org.eclipse.jgit.server.rest.RepositoryResource;
-import org.eclipse.jgit.server.rest.SearchResource;
-import org.eclipse.jgit.storage.hibernate.config.HibernateSessionFactoryProvider;
 import org.eclipse.jgit.transport.ReceivePack;
 import org.eclipse.jgit.transport.resolver.ReceivePackFactory;
 import org.hibernate.SessionFactory;
@@ -139,17 +138,9 @@ public class JGitServerApplication {
 					EnumSet.allOf(DispatcherType.class));
 		}
 
-		// Search remains the one copied projection/query boundary. The compatibility
-		// provider cannot close the application-owned native factory.
-		HibernateSessionFactoryProvider searchCompatibility= new HibernateSessionFactoryProvider(sessionFactory) {
-			@Override
-			public void close() {
-				// The enclosing ServerPersistenceContext owns the native factory.
-			}
-		};
 		context.addServlet(new ServletHolder("health", new HealthResource(sessionFactory)), "/health"); //$NON-NLS-1$ //$NON-NLS-2$
 		context.addServlet(new ServletHolder("repos", new RepositoryResource(repositories)), "/repos/*"); //$NON-NLS-1$ //$NON-NLS-2$
-		context.addServlet(new ServletHolder("search", new SearchResource(searchCompatibility)), "/search/*"); //$NON-NLS-1$ //$NON-NLS-2$
+		context.addServlet(new ServletHolder("search", new NativeSearchResource(sessionFactory)), "/search/*"); //$NON-NLS-1$ //$NON-NLS-2$
 		context.addServlet(new ServletHolder("analytics", new AnalyticsResource(sessionFactory)), "/analytics/*"); //$NON-NLS-1$ //$NON-NLS-2$
 		context.addServlet(new ServletHolder("admin", new AdminResource(sessionFactory)), "/admin/*"); //$NON-NLS-1$ //$NON-NLS-2$
 		return context;

--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/internal/NonOwningHibernateSessionFactoryProvider.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/internal/NonOwningHibernateSessionFactoryProvider.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jgit.server.internal;
+
+import java.util.Objects;
+
+import org.eclipse.jgit.storage.hibernate.config.HibernateSessionFactoryProvider;
+import org.hibernate.SessionFactory;
+
+/** Creates temporary copied-backend views without transferring factory ownership. */
+public final class NonOwningHibernateSessionFactoryProvider {
+
+	private NonOwningHibernateSessionFactoryProvider() {
+	}
+
+	/**
+	 * Returns a provider view whose {@code close()} deliberately leaves the native
+	 * application-owned factory open.
+	 */
+	public static HibernateSessionFactoryProvider view(SessionFactory sessionFactory) {
+		SessionFactory applicationOwnedFactory= Objects.requireNonNull(sessionFactory, "sessionFactory"); //$NON-NLS-1$
+		return new HibernateSessionFactoryProvider(applicationOwnedFactory) {
+			@Override
+			public void close() {
+				// The enclosing ServerPersistenceContext owns the native factory.
+			}
+		};
+	}
+}

--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/repository/CopiedHibernateRepositoryService.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/repository/CopiedHibernateRepositoryService.java
@@ -17,6 +17,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.jgit.internal.storage.dfs.DfsRepositoryDescription;
 import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.server.internal.NonOwningHibernateSessionFactoryProvider;
 import org.eclipse.jgit.storage.hibernate.config.HibernateSessionFactoryProvider;
 import org.eclipse.jgit.storage.hibernate.repository.HibernateRepository;
 import org.eclipse.jgit.storage.hibernate.repository.HibernateRepositoryBuilder;
@@ -36,7 +37,7 @@ public final class CopiedHibernateRepositoryService implements SandboxRepository
 
 	/** Creates the temporary adapter from an application-owned native factory. */
 	public CopiedHibernateRepositoryService(SessionFactory sessionFactory) {
-		this(nonOwningProvider(sessionFactory));
+		this(NonOwningHibernateSessionFactoryProvider.view(sessionFactory));
 	}
 
 	/**
@@ -80,16 +81,6 @@ public final class CopiedHibernateRepositoryService implements SandboxRepository
 			repository.close();
 		}
 		repositories.clear();
-	}
-
-	static HibernateSessionFactoryProvider nonOwningProvider(SessionFactory sessionFactory) {
-		SessionFactory applicationOwnedFactory= Objects.requireNonNull(sessionFactory, "sessionFactory"); //$NON-NLS-1$
-		return new HibernateSessionFactoryProvider(applicationOwnedFactory) {
-			@Override
-			public void close() {
-				// The enclosing ServerPersistenceContext owns the native factory.
-			}
-		};
 	}
 
 	private HibernateRepository repository(String name) throws IOException {

--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/rest/NativeSearchResource.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/rest/NativeSearchResource.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jgit.server.rest;
+
+import org.eclipse.jgit.server.internal.NonOwningHibernateSessionFactoryProvider;
+import org.hibernate.SessionFactory;
+
+/**
+ * Native-factory entry point for the legacy copied Search projection endpoint.
+ *
+ * <p>The superclass still accepts the copied provider type. This adapter keeps
+ * that compatibility detail inside the Search boundary and deliberately does
+ * not own or close the application-owned {@link SessionFactory}.</p>
+ */
+public final class NativeSearchResource extends SearchResource {
+
+	private static final long serialVersionUID = 1L;
+
+	/** Creates a Search endpoint backed by an application-owned native factory. */
+	public NativeSearchResource(SessionFactory sessionFactory) {
+		super(NonOwningHibernateSessionFactoryProvider.view(sessionFactory));
+	}
+}

--- a/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/repository/CopiedHibernateRepositoryServiceSessionFactoryTest.java
+++ b/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/repository/CopiedHibernateRepositoryServiceSessionFactoryTest.java
@@ -19,6 +19,7 @@ import java.util.Properties;
 
 import org.eclipse.jgit.server.config.HibernateConfig;
 import org.eclipse.jgit.server.config.ServerPersistenceContext;
+import org.eclipse.jgit.server.internal.NonOwningHibernateSessionFactoryProvider;
 import org.eclipse.jgit.storage.hibernate.config.HibernateSessionFactoryProvider;
 import org.hibernate.SessionFactory;
 import org.junit.Test;
@@ -40,7 +41,8 @@ public class CopiedHibernateRepositoryServiceSessionFactoryTest {
 		SessionFactory sessionFactory;
 		try (ServerPersistenceContext context= HibernateConfig.createPersistenceContext(properties)) {
 			sessionFactory= context.sessionFactory();
-			HibernateSessionFactoryProvider provider= CopiedHibernateRepositoryService.nonOwningProvider(sessionFactory);
+			HibernateSessionFactoryProvider provider=
+					NonOwningHibernateSessionFactoryProvider.view(sessionFactory);
 			assertSame(sessionFactory, provider.getSessionFactory());
 			provider.close();
 			assertFalse(sessionFactory.isClosed());

--- a/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/repository/SandboxRepositoryServiceBoundaryTest.java
+++ b/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/repository/SandboxRepositoryServiceBoundaryTest.java
@@ -21,11 +21,12 @@ import java.util.Arrays;
 
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.server.JGitServerApplication;
+import org.eclipse.jgit.server.resolver.HibernateRepositoryResolver;
 import org.eclipse.jgit.server.rest.AdminResource;
 import org.eclipse.jgit.server.rest.AnalyticsResource;
 import org.eclipse.jgit.server.rest.HealthResource;
+import org.eclipse.jgit.server.rest.NativeSearchResource;
 import org.eclipse.jgit.server.rest.RepositoryResource;
-import org.eclipse.jgit.server.resolver.HibernateRepositoryResolver;
 import org.hibernate.SessionFactory;
 import org.junit.Test;
 
@@ -42,6 +43,7 @@ public class SandboxRepositoryServiceBoundaryTest {
 		assertNotNull(HibernateRepositoryResolver.class.getConstructor(SandboxRepositoryService.class));
 		assertNotNull(HibernateRepositoryResolver.class.getConstructor(SessionFactory.class));
 		assertNotNull(HealthResource.class.getConstructor(SessionFactory.class));
+		assertNotNull(NativeSearchResource.class.getConstructor(SessionFactory.class));
 		assertNotNull(AnalyticsResource.class.getConstructor(SessionFactory.class));
 		assertNotNull(AdminResource.class.getConstructor(SessionFactory.class));
 		assertNotNull(ExternalHibernateRepositoryService.class.getConstructor(HibernateRepositoryFactory.class));
@@ -54,6 +56,7 @@ public class SandboxRepositoryServiceBoundaryTest {
 		assertFalse(hasCopiedBackendField(JGitServerApplication.class));
 		assertFalse(hasCopiedBackendField(RepositoryResource.class));
 		assertFalse(hasCopiedBackendField(HealthResource.class));
+		assertFalse(hasCopiedBackendField(NativeSearchResource.class));
 		assertFalse(hasCopiedBackendField(AnalyticsResource.class));
 		assertFalse(hasCopiedBackendField(AdminResource.class));
 		assertFalse(hasCopiedBackendField(ExternalHibernateRepositoryService.class));

--- a/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/rest/NativeSearchResourceTest.java
+++ b/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/rest/NativeSearchResourceTest.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jgit.server.rest;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.jgit.storage.hibernate.config.HibernateSessionFactoryProvider;
+import org.hibernate.SessionFactory;
+import org.junit.Test;
+
+/** Lifecycle contract for the native Search compatibility adapter. */
+public class NativeSearchResourceTest {
+
+	@Test
+	public void compatibilityProviderDoesNotOwnNativeFactory() throws Exception {
+		AtomicBoolean closed= new AtomicBoolean();
+		SessionFactory sessionFactory= proxySessionFactory(closed);
+		NativeSearchResource resource= new NativeSearchResource(sessionFactory);
+
+		Field providerField= SearchResource.class.getDeclaredField("provider"); //$NON-NLS-1$
+		providerField.setAccessible(true);
+		HibernateSessionFactoryProvider provider=
+				(HibernateSessionFactoryProvider) providerField.get(resource);
+
+		assertSame(sessionFactory, provider.getSessionFactory());
+		provider.close();
+		assertFalse("Search compatibility must not close the application-owned factory", closed.get()); //$NON-NLS-1$
+	}
+
+	private static SessionFactory proxySessionFactory(AtomicBoolean closed) {
+		return (SessionFactory) Proxy.newProxyInstance(SessionFactory.class.getClassLoader(),
+				new Class<?>[] { SessionFactory.class }, (proxy, method, arguments) -> {
+					switch (method.getName()) {
+					case "close": //$NON-NLS-1$
+						closed.set(true);
+						return null;
+					case "isClosed": //$NON-NLS-1$
+						return Boolean.valueOf(closed.get());
+					case "equals": //$NON-NLS-1$
+						return Boolean.valueOf(proxy == argument(arguments, 0));
+					case "hashCode": //$NON-NLS-1$
+						return Integer.valueOf(System.identityHashCode(proxy));
+					case "toString": //$NON-NLS-1$
+						return "TestSessionFactory"; //$NON-NLS-1$
+					default:
+						return defaultValue(method.getReturnType());
+					}
+				});
+	}
+
+	private static Object argument(Object[] arguments, int index) {
+		return arguments != null && index >= 0 && index < arguments.length ? arguments[index] : null;
+	}
+
+	private static Object defaultValue(Class<?> type) {
+		if (!type.isPrimitive() || type == void.class) {
+			return null;
+		}
+		if (type == boolean.class) {
+			return Boolean.FALSE;
+		}
+		if (type == char.class) {
+			return Character.valueOf('\0');
+		}
+		if (type == byte.class) {
+			return Byte.valueOf((byte) 0);
+		}
+		if (type == short.class) {
+			return Short.valueOf((short) 0);
+		}
+		if (type == int.class) {
+			return Integer.valueOf(0);
+		}
+		if (type == long.class) {
+			return Long.valueOf(0L);
+		}
+		if (type == float.class) {
+			return Float.valueOf(0.0F);
+		}
+		return Double.valueOf(0.0D);
+	}
+}


### PR DESCRIPTION
## Problem

After #1337 makes the application own only `ServerPersistenceContext` and native Hibernate contracts, `JGitServerApplication` still constructs an anonymous copied `HibernateSessionFactoryProvider` solely because the legacy `SearchResource` constructor accepts that type. The copied repository adapter also contains its own private implementation of the same non-owning provider view.

## Change

- add one server-internal factory for copied-provider views whose `close()` is deliberately a no-op;
- reuse that ownership boundary from both `CopiedHibernateRepositoryService` and Search;
- add `NativeSearchResource(SessionFactory)` as the native application entry point;
- remove the copied provider import and anonymous compatibility object from `JGitServerApplication`;
- construct Search directly from the application-owned native factory;
- extend boundary tests to require the native constructor and prove the application-facing adapter declares no copied-backend field;
- keep the existing H2 repository lifecycle test on the shared view;
- add a Search lifecycle regression that extracts the actual compatibility provider, verifies it exposes the same native factory, calls `close()`, and proves the application-owned factory remains open.

## Scope

This PR is stacked on #1337. It does not yet rewrite the large legacy `SearchResource` implementation or replace copied Search entities and query services. It moves the temporary provider signature completely out of application bootstrap and centralizes its ownership semantics so the later Search cut-over is isolated and reviewable. The utility is deliberately placed under `org.eclipse.jgit.server.internal`; this Maven JAR does not enforce package exports, so the internal status is a source/API convention rather than an OSGi visibility guarantee.

The PR remains Draft until the release sequence completes, #1327 and #1337 are merged, this branch is rebased onto the resulting `main`, all review threads are resolved, and Java CI with Maven, Distribution Smoke Test, CodeQL and Codacy are green on the rebased head. Its temporary `main` base is solely to obtain the complete repository CI and will return to #1337 while stacked.

Refs #1303 and #1337.