### PR TITLE
Serialize all gh-pages publishers

### DIFF
--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -10,7 +10,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: sandbox-gh-pages-publication
+  group: release-workflow
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/mining-core.yml
+++ b/.github/workflows/mining-core.yml
@@ -13,7 +13,7 @@ on:
         default: ''
 
 concurrency:
-  group: mining-state
+  group: release-workflow
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/refactoring-mining.yml
+++ b/.github/workflows/refactoring-mining.yml
@@ -10,7 +10,7 @@ on:
         required: false
 
 concurrency:
-  group: refactoring-pattern-report
+  group: release-workflow
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/release-workflow-validation.yml
+++ b/.github/workflows/release-workflow-validation.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
     paths:
       - '.github/workflows/deploy-release.yml'
+      - '.github/workflows/deploy-snapshot.yml'
+      - '.github/workflows/mining-core.yml'
+      - '.github/workflows/refactoring-mining.yml'
       - '.github/workflows/release-workflow-validation.yml'
       - '.github/scripts/verify_release_identity.py'
       - '.github/scripts/test_verify_release_identity.py'
@@ -36,3 +39,19 @@ jobs:
           python3 .github/scripts/test_verify_release_identity.py
           python3 .github/scripts/test_wait_for_pages_build.py
           python3 .github/scripts/test_verify_published_repository.py
+      - name: Validate shared gh-pages publication lock
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+
+          workflows = [
+              Path('.github/workflows/deploy-release.yml'),
+              Path('.github/workflows/deploy-snapshot.yml'),
+              Path('.github/workflows/mining-core.yml'),
+              Path('.github/workflows/refactoring-mining.yml'),
+          ]
+          contract = "concurrency:\n  group: release-workflow\n  cancel-in-progress: false"
+          failures = [str(path) for path in workflows if contract not in path.read_text(encoding='utf-8')]
+          if failures:
+              raise SystemExit(f"gh-pages publishers must share the release-workflow lock: {failures}")
+          PY


### PR DESCRIPTION
## Problem

The bounded 1.3.3 release reached the versioned p2 publication but exposed an inconsistent public composite: `compositeContent.xml` contained child `1.3.3`, while `compositeArtifacts.xml` still ended at `1.3.2`.

The repository has four independent workflows that write to the same `gh-pages` branch:

- fail-closed release publication;
- verified snapshot publication;
- nightly commit-mining report;
- nightly refactoring-pattern report.

Only release used `release-workflow`; snapshot and both mining publishers used unrelated groups. A stale `peaceiris/actions-gh-pages` checkout can therefore publish while the release workflow is updating or rolling back the same branch.

## Change

- change the other three writers to the existing release lock:

```yaml
concurrency:
  group: release-workflow
  cancel-in-progress: false
```

- extend `Release Workflow Validation` so changes to any Pages writer trigger it;
- add a contract test requiring all four workflow files to contain the exact shared, non-cancelling lock.

The three publisher files each have exactly one line replaced. The validation workflow adds only the three trigger paths and one self-contained contract step. No trigger, permission, build, report, p2, destination or rollback behavior is changed.

## Result

All `gh-pages` writers are serialized across their complete workflow runs. A snapshot or mining deployment waits until release publication or rollback has finished, and future lock drift fails in PR validation.

This PR must be merged before another 1.3.3 request. The current request must first fail closed and restore the pre-publication composite state.

Refs #1285.