### PR TITLE
Model staged JDT Core JUnit harness migration

### DIFF
--- a/docs/jdt-core-junit-harness-migration.md
+++ b/docs/jdt-core-junit-harness-migration.md
@@ -1,0 +1,86 @@
+# JDT Core JUnit harness migration
+
+## Goal
+
+Migrate Eclipse JDT Core test families from their custom JUnit 3 harness to Jupiter without flattening or silently losing the harness semantics that determine test identity, ordering, filtering, shared suite state, compiler compliance, indexer control, memory logging and performance measurements.
+
+This migration builds on the ordinary closed-hierarchy path from #1336, but it is a distinct framework migration. The JDT Core harness must be made explicit before its inheritance can be removed.
+
+## Source contract being migrated
+
+The implementation is based on the current upstream sources:
+
+- `org.eclipse.jdt.core.tests.junit.extension.TestCase` extends `org.eclipse.test.performance.PerformanceTestCase`, requires a `String` test-name constructor, filters `test*` methods through `TESTS_PREFIX`, `TESTS_NAMES`, `TESTS_NUMBERS`, `TESTS_RANGE` and `RUN_ONLY_ID`, supports configurable ordering, controls the JDT indexer, clears interrupt state and exposes performance/memory hooks.
+- `SuiteOfTestCases` uses a custom `TestSuite` to call `setUpSuite()` once, copy mutable instance fields from one freshly constructed test object to the next, and call `tearDownSuite()` once.
+- `AbstractJavaModelTests.buildModelTestSuite(...)` uses that suite-state contract with zero inherited test depth.
+- `AbstractCompilerTest` multiplies tests across compiler compliance levels, reads an optional `INHERITED_DEPTH` field and wraps classes in compliance-specific setup suites.
+- Eclipse Platform already provides `PerformanceTestCaseJunit5`, backed by the same `AbstractPerformanceTestCase` measurement API. The migration must use that existing class rather than create another performance framework.
+
+Upstream references:
+
+- https://github.com/eclipse-jdt/eclipse.jdt.core/blob/master/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/junit/extension/TestCase.java
+- https://github.com/eclipse-jdt/eclipse.jdt.core/blob/master/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/SuiteOfTestCases.java
+- https://github.com/eclipse-jdt/eclipse.jdt.core/blob/master/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaModelTests.java
+- https://github.com/eclipse-jdt/eclipse.jdt.core/blob/master/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/util/AbstractCompilerTest.java
+- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/blob/master/eclipse.platform.releng/bundles/org.eclipse.test.performance/src/org/eclipse/test/performance/PerformanceTestCaseJunit5.java
+
+## Staged target architecture
+
+### Slice A: direct custom-TestCase families
+
+A source-compatible nested Jupiter bridge is inserted into the existing JDT Core `TestCase` source. The original JUnit 3 class remains unchanged for families not migrated yet.
+
+Eligible direct families are changed from:
+
+```java
+class ExampleTests extends TestCase {
+    ExampleTests(String name) {
+        super(name);
+    }
+}
+```
+
+to the nested Jupiter bridge:
+
+```java
+class ExampleTests extends TestCase.Jupiter {
+}
+```
+
+The bridge uses the existing `PerformanceTestCaseJunit5`, preserves the current test name through `TestInfo`, applies the JDT filter and ordering contract, controls the indexer, clears interrupt state and retains the supported memory/performance hooks. Test methods and assertions are materialized through the existing plan-aware hint backend. Only simple name constructors and exact per-class suite factories are removed.
+
+The slice rejects lifecycle overrides, suite-state classes, compliance multiplication, decorators, custom `runTest` logic, unsupported TestCase helper calls, out-of-scope suite owners and any stale or unresolved binding.
+
+### Slice B: SuiteOfTestCases state transfer
+
+A Jupiter extension nested in the existing `SuiteOfTestCases` source must reproduce the current semantics rather than approximate them with `@TestInstance(PER_CLASS)`:
+
+- a fresh instance per test;
+- `setUpSuite()` before the first test;
+- mutable non-static, non-final fields copied from the previously executed instance;
+- `tearDownSuite()` after the final test;
+- same-thread execution and deterministic order;
+- standalone rerun support.
+
+### Slice C: compiler compliance templates
+
+Compliance multiplication becomes an explicit Jupiter test-template or suite descriptor. It must retain:
+
+- the exact set and order of supported compliance levels;
+- the `INHERITED_DEPTH` contract;
+- setup-suite construction and cleanup;
+- preview-test exclusion on future JREs;
+- test class and method multiplicity in the JDT runtime tree.
+
+### Slice D: aggregate suites and remaining callbacks
+
+Global `Run*`/`TestAll` owners, decorators, filters, performance callbacks and rerun setup hooks are migrated only after their complete JDT launch tree is captured. Mixed Jupiter/Vintage aggregate suites may be used during the transition.
+
+## Safety rules
+
+- The semantic planner identifies the exact upstream harness shape by bindings and source structure; matching only class names is insufficient.
+- The old JUnit 3 harness remains available until every dependent family in the selected slice has migrated.
+- No migration is applied when a constructor, suite owner, helper call, filter assignment, binary subtype or setup wrapper is outside the closed source scope.
+- Every supported slice runs the same JDT launch before and after and compares a non-empty successful tree including nesting, display name, class/method identity, order and multiplicity.
+- Test execution is part of acceptance; a matching discovery tree alone is insufficient.
+- Compliance and suite-state semantics are never replaced by `@Test` annotations alone.

--- a/docs/jdt-core-junit-harness-migration.md
+++ b/docs/jdt-core-junit-harness-migration.md
@@ -26,7 +26,7 @@ Upstream references:
 
 ## Staged target architecture
 
-### Slice A: direct custom-TestCase families
+### Slice A: unfiltered direct custom-TestCase families
 
 A source-compatible nested Jupiter bridge is inserted into the existing JDT Core `TestCase` source. The original JUnit 3 class remains unchanged for families not migrated yet.
 
@@ -47,11 +47,22 @@ class ExampleTests extends TestCase.Jupiter {
 }
 ```
 
-The bridge uses the existing `PerformanceTestCaseJunit5`, preserves the current test name through `TestInfo`, applies the JDT filter and ordering contract, controls the indexer, clears interrupt state and retains the supported memory/performance hooks. Test methods and assertions are materialized through the existing plan-aware hint backend. Only simple name constructors and exact per-class suite factories are removed.
+The bridge uses the existing `PerformanceTestCaseJunit5`, preserves the current test name through `TestInfo`, applies the JDT ordering contract, controls the indexer, clears interrupt state and retains the supported memory/performance hooks. Test methods and assertions are materialized through the existing plan-aware hint backend. Only simple name constructors and exact per-class suite factories are removed.
 
-The slice rejects lifecycle overrides, suite-state classes, compliance multiplication, decorators, custom `runTest` logic, unsupported TestCase helper calls, out-of-scope suite owners and any stale or unresolved binding.
+This first slice deliberately rejects `TESTS_PREFIX`, `TESTS_NAMES`, `TESTS_NUMBERS`, `TESTS_RANGE`, `RUN_ONLY_ID` use and `testONLY_*` methods. A Jupiter `ExecutionCondition` can disable execution, but Eclipse's JUnit listener still retains those skipped test nodes; that would change runtime-tree identity and multiplicity. Configured selection therefore remains on the unchanged JUnit 3 harness until a discovery-time mapping is implemented and proven.
 
-### Slice B: SuiteOfTestCases state transfer
+The slice also rejects lifecycle overrides, suite-state classes, compliance multiplication, decorators, custom `runTest` logic, unsupported TestCase helper calls, out-of-scope suite owners and any stale or unresolved binding.
+
+### Slice B: configured direct-family selection
+
+Configured selection must be represented before excluded Jupiter methods enter the discovered test tree. The slice must preserve:
+
+- exact `TESTS_PREFIX`, `TESTS_NAMES`, `TESTS_NUMBERS` and `TESTS_RANGE` behavior;
+- `RUN_ONLY_ID` and `testONLY_*` precedence;
+- source or external filter ownership and reset behavior;
+- the same non-empty JDT runtime tree before and after migration, without ignored or skipped replacement nodes.
+
+### Slice C: SuiteOfTestCases state transfer
 
 A Jupiter extension nested in the existing `SuiteOfTestCases` source must reproduce the current semantics rather than approximate them with `@TestInstance(PER_CLASS)`:
 
@@ -62,7 +73,7 @@ A Jupiter extension nested in the existing `SuiteOfTestCases` source must reprod
 - same-thread execution and deterministic order;
 - standalone rerun support.
 
-### Slice C: compiler compliance templates
+### Slice D: compiler compliance templates
 
 Compliance multiplication becomes an explicit Jupiter test-template or suite descriptor. It must retain:
 
@@ -72,9 +83,9 @@ Compliance multiplication becomes an explicit Jupiter test-template or suite des
 - preview-test exclusion on future JREs;
 - test class and method multiplicity in the JDT runtime tree.
 
-### Slice D: aggregate suites and remaining callbacks
+### Slice E: aggregate suites and remaining callbacks
 
-Global `Run*`/`TestAll` owners, decorators, filters, performance callbacks and rerun setup hooks are migrated only after their complete JDT launch tree is captured. Mixed Jupiter/Vintage aggregate suites may be used during the transition.
+Global `Run*`/`TestAll` owners, decorators, performance callbacks and rerun setup hooks are migrated only after their complete JDT launch tree is captured. Mixed Jupiter/Vintage aggregate suites may be used during the transition.
 
 ## Safety rules
 
@@ -83,4 +94,4 @@ Global `Run*`/`TestAll` owners, decorators, filters, performance callbacks and r
 - No migration is applied when a constructor, suite owner, helper call, filter assignment, binary subtype or setup wrapper is outside the closed source scope.
 - Every supported slice runs the same JDT launch before and after and compares a non-empty successful tree including nesting, display name, class/method identity, order and multiplicity.
 - Test execution is part of acceptance; a matching discovery tree alone is insufficient.
-- Compliance and suite-state semantics are never replaced by `@Test` annotations alone.
+- Compliance, filtering and suite-state semantics are never replaced by `@Test` annotations or skipped Jupiter nodes alone.

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnit3AssertionInventory.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnit3AssertionInventory.java
@@ -64,6 +64,8 @@ final class JUnit3AssertionInventory {
 	 */
 	static Result analyze(TypeDeclaration declaration, Set<String> ignoredMethodBindingKeys) {
 		Set<String> ignored= ignoredMethodBindingKeys == null ? Set.of() : Set.copyOf(ignoredMethodBindingKeys);
+		boolean jdtCoreHarness= declaration != null
+				&& JdtCoreHarnessScopeDetector.inheritsJdtCoreHarness(declaration.resolveBinding());
 		String[] rejection= new String[1];
 		List<InvocationMigration> invocations= new ArrayList<>();
 		declaration.accept(new ASTVisitor() {
@@ -88,13 +90,19 @@ final class JUnit3AssertionInventory {
 				IMethodBinding binding= node.resolveMethodBinding();
 				String name= node.getName().getIdentifier();
 				if (binding == null) {
-					if (CUSTOM_EXECUTION_METHODS.contains(name) || ASSERTION_METHODS.contains(name)) {
+					if (CUSTOM_EXECUTION_METHODS.contains(name) || ASSERTION_METHODS.contains(name)
+							|| jdtCoreHarness && "buildTestSuite".equals(name)) { //$NON-NLS-1$
 						rejection[0]= "A potentially JUnit-related invocation has no resolved method binding."; //$NON-NLS-1$
 					}
 					return rejection[0] == null;
 				}
 				ITypeBinding declaringClass= binding.getDeclaringClass();
 				String owner= declaringClass == null ? "" : declaringClass.getErasure().getQualifiedName(); //$NON-NLS-1$
+				if (jdtCoreHarness && "buildTestSuite".equals(name) //$NON-NLS-1$
+						&& !JdtCoreHarnessPlanner.JDT_CORE_TEST_CASE.equals(owner)) {
+					rejection[0]= "The removable local JDT Core suite delegates to an external harness owner."; //$NON-NLS-1$
+					return false;
+				}
 				if (!JUNIT3_TEST_CASE.equals(owner) && !JUNIT3_ASSERT.equals(owner)) {
 					return true;
 				}

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnit3AssertionInventory.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnit3AssertionInventory.java
@@ -15,6 +15,7 @@ import static org.sandbox.jdt.internal.corext.fix.helper.lib.JUnit3SemanticSuppo
 import static org.sandbox.jdt.internal.corext.fix.helper.lib.JUnit3SemanticSupport.JUNIT3_TEST_CASE;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -23,8 +24,11 @@ import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.Modifier;
+import org.eclipse.jdt.core.dom.ReturnStatement;
 import org.eclipse.jdt.core.dom.SuperMethodInvocation;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.core.dom.TypeLiteral;
 
 import org.sandbox.jdt.internal.corext.fix.helper.lib.JUnit3SemanticSupport;
 import org.sandbox.jdt.internal.corext.fix.multifile.JUnit3HierarchyMigration.InvocationKind;
@@ -51,7 +55,7 @@ final class JUnit3AssertionInventory {
 	}
 
 	static Result analyze(TypeDeclaration declaration) {
-		return analyze(declaration, Set.of());
+		return analyze(declaration, removableJdtCoreSuiteKeys(declaration));
 	}
 
 	/**
@@ -111,5 +115,52 @@ final class JUnit3AssertionInventory {
 			}
 		});
 		return new Result(rejection[0], invocations);
+	}
+
+	private static Set<String> removableJdtCoreSuiteKeys(TypeDeclaration declaration) {
+		ITypeBinding owner= declaration == null ? null : declaration.resolveBinding();
+		if (!JdtCoreHarnessScopeDetector.inheritsJdtCoreHarness(owner)) {
+			return Set.of();
+		}
+		Set<String> result= new LinkedHashSet<>();
+		for (MethodDeclaration method : declaration.getMethods()) {
+			String key= exactRemovableJdtCoreSuiteKey(method, owner);
+			if (key != null) {
+				result.add(key);
+			}
+		}
+		return Set.copyOf(result);
+	}
+
+	private static String exactRemovableJdtCoreSuiteKey(MethodDeclaration method, ITypeBinding owner) {
+		if (!"suite".equals(method.getName().getIdentifier()) //$NON-NLS-1$
+				|| !Modifier.isPublic(method.getModifiers()) || !Modifier.isStatic(method.getModifiers())
+				|| !method.parameters().isEmpty() || method.getBody() == null
+				|| method.getBody().statements().size() != 1) {
+			return null;
+		}
+		IMethodBinding binding= method.resolveBinding();
+		ITypeBinding returnType= binding == null ? null : binding.getReturnType();
+		if (returnType == null || !"junit.framework.Test".equals(returnType.getErasure().getQualifiedName())) { //$NON-NLS-1$
+			return null;
+		}
+		Object statement= method.getBody().statements().get(0);
+		if (!(statement instanceof ReturnStatement returnStatement)
+				|| !(returnStatement.getExpression() instanceof MethodInvocation invocation)
+				|| !"buildTestSuite".equals(invocation.getName().getIdentifier()) //$NON-NLS-1$
+				|| invocation.arguments().size() != 1
+				|| !(invocation.arguments().get(0) instanceof TypeLiteral literal)) {
+			return null;
+		}
+		IMethodBinding invoked= invocation.resolveMethodBinding();
+		ITypeBinding invokedOwner= invoked == null ? null : invoked.getDeclaringClass();
+		ITypeBinding selected= literal.getType().resolveBinding();
+		if (invokedOwner == null || selected == null
+				|| !JdtCoreHarnessPlanner.JDT_CORE_TEST_CASE.equals(
+						invokedOwner.getErasure().getQualifiedName())
+				|| !JUnitMigrationPlan.typeKey(owner).equals(JUnitMigrationPlan.typeKey(selected))) {
+			return null;
+		}
+		return binding.getMethodDeclaration().getKey();
 	}
 }

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnit3AssertionInventory.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnit3AssertionInventory.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.core.dom.SuperMethodInvocation;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
@@ -50,9 +51,25 @@ final class JUnit3AssertionInventory {
 	}
 
 	static Result analyze(TypeDeclaration declaration) {
+		return analyze(declaration, Set.of());
+	}
+
+	/**
+	 * Analyzes assertions while skipping method bodies whose complete semantics were
+	 * separately validated and whose declarations are removed by the same atomic plan.
+	 */
+	static Result analyze(TypeDeclaration declaration, Set<String> ignoredMethodBindingKeys) {
+		Set<String> ignored= ignoredMethodBindingKeys == null ? Set.of() : Set.copyOf(ignoredMethodBindingKeys);
 		String[] rejection= new String[1];
 		List<InvocationMigration> invocations= new ArrayList<>();
 		declaration.accept(new ASTVisitor() {
+			@Override
+			public boolean visit(MethodDeclaration node) {
+				IMethodBinding binding= node.resolveBinding();
+				String key= binding == null ? null : binding.getMethodDeclaration().getKey();
+				return key == null || !ignored.contains(key);
+			}
+
 			@Override
 			public boolean visit(SuperMethodInvocation node) {
 				rejection[0]= "Explicit superclass method calls can change lifecycle semantics under Jupiter."; //$NON-NLS-1$

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnit3AssertionInventory.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnit3AssertionInventory.java
@@ -22,10 +22,12 @@ import java.util.Set;
 import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.IVariableBinding;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.core.dom.Modifier;
 import org.eclipse.jdt.core.dom.ReturnStatement;
+import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.SuperMethodInvocation;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.TypeLiteral;
@@ -79,6 +81,26 @@ final class JUnit3AssertionInventory {
 			@Override
 			public boolean visit(SuperMethodInvocation node) {
 				rejection[0]= "Explicit superclass method calls can change lifecycle semantics under Jupiter."; //$NON-NLS-1$
+				return false;
+			}
+
+			@Override
+			public boolean visit(SimpleName node) {
+				if (rejection[0] != null || !jdtCoreHarness
+						|| !(node.resolveBinding() instanceof IVariableBinding variable) || !variable.isField()) {
+					return rejection[0] == null;
+				}
+				IVariableBinding declarationBinding= variable.getVariableDeclaration();
+				ITypeBinding owner= declarationBinding.getDeclaringClass();
+				if (owner == null || !JdtCoreHarnessPlanner.JDT_CORE_TEST_CASE.equals(
+						owner.getErasure().getQualifiedName())
+						|| Modifier.isStatic(declarationBinding.getModifiers())
+						|| "indexDisabledForTest".equals(declarationBinding.getName())) { //$NON-NLS-1$
+					return true;
+				}
+				rejection[0]= "The direct family accesses inherited JDT Core TestCase field " //$NON-NLS-1$
+						+ declarationBinding.getName()
+						+ ", which is not represented by the Jupiter bridge."; //$NON-NLS-1$
 				return false;
 			}
 

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnit3HierarchyScopeDetector.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnit3HierarchyScopeDetector.java
@@ -36,7 +36,7 @@ import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
 import org.eclipse.jdt.internal.corext.refactoring.util.RefactoringASTParser;
 
-/** Finds the source closure needed before any ordinary JUnit 3 hierarchy rewrite. */
+/** Finds the source closure needed before any JUnit 3 hierarchy rewrite. */
 public final class JUnit3HierarchyScopeDetector {
 
 	private JUnit3HierarchyScopeDetector() {
@@ -45,9 +45,11 @@ public final class JUnit3HierarchyScopeDetector {
 	public static JUnitScopeCandidateDetector.SearchSeeds findSearchSeeds(IJavaProject project,
 			Collection<ICompilationUnit> currentScope, IProgressMonitor monitor) {
 		if (project == null || currentScope == null || currentScope.isEmpty()) {
-			return new JUnitScopeCandidateDetector.SearchSeeds(false, true, List.of(), List.of());
+			return empty();
 		}
 		checkCanceled(monitor);
+		JUnitScopeCandidateDetector.SearchSeeds jdtCoreSeeds=
+				JdtCoreHarnessScopeDetector.findSearchSeeds(project, currentScope, monitor);
 		Set<ICompilationUnit> units= new LinkedHashSet<>();
 		for (ICompilationUnit unit : currentScope) {
 			if (unit != null && unit.exists() && project.equals(unit.getJavaProject())) {
@@ -55,7 +57,7 @@ public final class JUnit3HierarchyScopeDetector {
 			}
 		}
 		if (units.isEmpty()) {
-			return new JUnitScopeCandidateDetector.SearchSeeds(false, true, List.of(), List.of());
+			return jdtCoreSeeds;
 		}
 
 		boolean[] candidateFound= { false };
@@ -118,8 +120,23 @@ public final class JUnit3HierarchyScopeDetector {
 			}
 		}, monitor);
 		checkCanceled(monitor);
-		return new JUnitScopeCandidateDetector.SearchSeeds(candidateFound[0], complete[0],
-				new ArrayList<>(elements), new ArrayList<>(directUnits));
+		JUnitScopeCandidateDetector.SearchSeeds ordinarySeeds=
+				new JUnitScopeCandidateDetector.SearchSeeds(candidateFound[0], complete[0],
+						new ArrayList<>(elements), new ArrayList<>(directUnits));
+		return merge(ordinarySeeds, jdtCoreSeeds);
+	}
+
+	private static JUnitScopeCandidateDetector.SearchSeeds merge(
+			JUnitScopeCandidateDetector.SearchSeeds ordinary,
+			JUnitScopeCandidateDetector.SearchSeeds jdtCore) {
+		Set<IJavaElement> elements= new LinkedHashSet<>(ordinary.elements());
+		elements.addAll(jdtCore.elements());
+		Set<ICompilationUnit> units= new LinkedHashSet<>(ordinary.directCompilationUnits());
+		units.addAll(jdtCore.directCompilationUnits());
+		return new JUnitScopeCandidateDetector.SearchSeeds(
+				ordinary.candidateFound() || jdtCore.candidateFound(),
+				ordinary.complete() && jdtCore.complete(),
+				new ArrayList<>(elements), new ArrayList<>(units));
 	}
 
 	private static boolean isJUnit3Type(ITypeBinding binding) {
@@ -157,6 +174,10 @@ public final class JUnit3HierarchyScopeDetector {
 		elements.add(type);
 		units.add(unit.getPrimary());
 		return true;
+	}
+
+	private static JUnitScopeCandidateDetector.SearchSeeds empty() {
+		return new JUnitScopeCandidateDetector.SearchSeeds(false, true, List.of(), List.of());
 	}
 
 	private static void checkCanceled(IProgressMonitor monitor) {

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnit3HierarchyScopeDetector.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnit3HierarchyScopeDetector.java
@@ -36,7 +36,7 @@ import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
 import org.eclipse.jdt.internal.corext.refactoring.util.RefactoringASTParser;
 
-/** Finds the source closure needed before any JUnit 3 hierarchy rewrite. */
+/** Finds the source closure needed before any ordinary JUnit 3 hierarchy rewrite. */
 public final class JUnit3HierarchyScopeDetector {
 
 	private JUnit3HierarchyScopeDetector() {
@@ -75,6 +75,9 @@ public final class JUnit3HierarchyScopeDetector {
 					@Override
 					public boolean visit(TypeDeclaration node) {
 						ITypeBinding binding= node.resolveBinding();
+						if (JdtCoreHarnessScopeDetector.inheritsJdtCoreHarness(binding)) {
+							return true;
+						}
 						if (!isJUnit3Type(binding)) {
 							return true;
 						}

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnitMigrationPlan.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnitMigrationPlan.java
@@ -67,6 +67,7 @@ import org.sandbox.jdt.triggerpattern.cleanup.PlannedStructuralRewriteOperation.
 public record JUnitMigrationPlan(SelectedCompilationUnitPlan selectedScope,
 		List<ExternalResourceRuleMigration> externalResourceRules,
 		List<JUnit3HierarchyMigration> junit3Hierarchies,
+		List<JdtCoreDirectFamilyMigration> jdtCoreDirectFamilies,
 		JUnitTestTypeInventory testTypeInventory) {
 
 	private static final String JUNIT3_HINT_RESOURCE=
@@ -76,12 +77,20 @@ public record JUnitMigrationPlan(SelectedCompilationUnitPlan selectedScope,
 		Objects.requireNonNull(selectedScope);
 		externalResourceRules= List.copyOf(externalResourceRules);
 		junit3Hierarchies= List.copyOf(junit3Hierarchies);
+		jdtCoreDirectFamilies= List.copyOf(jdtCoreDirectFamilies);
 		testTypeInventory= Objects.requireNonNull(testTypeInventory);
 	}
 
 	public JUnitMigrationPlan(SelectedCompilationUnitPlan selectedScope,
+			List<ExternalResourceRuleMigration> externalResourceRules,
+			List<JUnit3HierarchyMigration> junit3Hierarchies,
+			JUnitTestTypeInventory testTypeInventory) {
+		this(selectedScope, externalResourceRules, junit3Hierarchies, List.of(), testTypeInventory);
+	}
+
+	public JUnitMigrationPlan(SelectedCompilationUnitPlan selectedScope,
 			List<ExternalResourceRuleMigration> externalResourceRules) {
-		this(selectedScope, externalResourceRules, List.of(), new JUnitTestTypeInventory(List.of()));
+		this(selectedScope, externalResourceRules, List.of(), List.of(), new JUnitTestTypeInventory(List.of()));
 	}
 
 	public boolean contains(ICompilationUnit unit) {
@@ -89,7 +98,8 @@ public record JUnitMigrationPlan(SelectedCompilationUnitPlan selectedScope,
 	}
 
 	public boolean hasCoordinatedChanges() {
-		return !externalResourceRules.isEmpty() || !junit3Hierarchies.isEmpty();
+		return !externalResourceRules.isEmpty() || !junit3Hierarchies.isEmpty()
+				|| !jdtCoreDirectFamilies.isEmpty();
 	}
 
 	public void addOperationsFor(ICompilationUnit unit, CompilationUnit root,
@@ -98,6 +108,7 @@ public record JUnitMigrationPlan(SelectedCompilationUnitPlan selectedScope,
 		String unitHandle= unit.getPrimary().getHandleIdentifier();
 		addExternalResourceOperations(unit, unitHandle, root, operations, nodesProcessed);
 		addJUnit3HierarchyOperations(unit, unitHandle, root, operations, nodesProcessed);
+		addJdtCoreHarnessOperations(unit, unitHandle, root, operations, nodesProcessed);
 	}
 
 	private void addExternalResourceOperations(ICompilationUnit unit, String unitHandle, CompilationUnit root,
@@ -152,35 +163,8 @@ public record JUnitMigrationPlan(SelectedCompilationUnitPlan selectedScope,
 		Map<String, TypeDeclaration> resolvedTypes= new LinkedHashMap<>();
 		Map<String, MethodDeclaration> resolvedMethods= new LinkedHashMap<>();
 		Map<NodeKey, MethodInvocation> resolvedInvocations= new LinkedHashMap<>();
-		root.accept(new ASTVisitor() {
-			@Override
-			public boolean visit(TypeDeclaration node) {
-				String key= typeKey(node.resolveBinding());
-				if (key != null && expectedTypes.containsKey(key)) {
-					resolvedTypes.put(key, node);
-				}
-				return true;
-			}
-
-			@Override
-			public boolean visit(MethodDeclaration node) {
-				IMethodBinding binding= node.resolveBinding();
-				String key= binding == null ? null : binding.getMethodDeclaration().getKey();
-				if (key != null && expectedMethodKeys.contains(key)) {
-					resolvedMethods.put(key, node);
-				}
-				return true;
-			}
-
-			@Override
-			public boolean visit(MethodInvocation node) {
-				NodeKey key= NodeKey.from(node);
-				if (key != null && expectedInvocations.containsKey(key)) {
-					resolvedInvocations.put(key, node);
-				}
-				return true;
-			}
-		});
+		resolveTargets(root, expectedTypes.keySet(), expectedMethodKeys, expectedInvocations.keySet(),
+				resolvedTypes, resolvedMethods, resolvedInvocations);
 		if (!resolvedTypes.keySet().equals(expectedTypes.keySet())
 				|| !resolvedMethods.keySet().equals(expectedMethodKeys)
 				|| !resolvedInvocations.keySet().equals(expectedInvocations.keySet())) {
@@ -220,8 +204,7 @@ public record JUnitMigrationPlan(SelectedCompilationUnitPlan selectedScope,
 				}
 			}
 			for (InvocationMigration invocation : planned.invocations()) {
-				NodeKey key= NodeKey.invocation(invocation.methodBindingKey(), invocation.sourceStart(),
-						invocation.sourceLength());
+				NodeKey key= invocationKey(invocation);
 				plan.add(key, invocation.kind() == InvocationKind.MESSAGE_FIRST
 						? ROLE_ASSERTION_MESSAGE_FIRST : ROLE_ASSERTION_QUALIFY);
 				expectedHintTargets.add(key);
@@ -229,9 +212,7 @@ public record JUnitMigrationPlan(SelectedCompilationUnitPlan selectedScope,
 			nodesProcessed.add(type);
 			planned.methods().stream().map(MethodMigration::methodBindingKey)
 					.map(resolvedMethods::get).forEach(nodesProcessed::add);
-			planned.invocations().stream()
-					.map(invocation -> NodeKey.invocation(invocation.methodBindingKey(), invocation.sourceStart(),
-							invocation.sourceLength()))
+			planned.invocations().stream().map(JUnitMigrationPlan::invocationKey)
 					.map(resolvedInvocations::get).forEach(nodesProcessed::add);
 			if (planned.removeTestCaseSuperclass() || !annotationRemovals.isEmpty()
 					|| !integerAnnotationAdditions.isEmpty() || !typeLiteralAnnotationAdditions.isEmpty()) {
@@ -242,6 +223,99 @@ public record JUnitMigrationPlan(SelectedCompilationUnitPlan selectedScope,
 			}
 		}
 
+		applyHintProgram(unit, root, operations, nodesProcessed, plan, expectedHintTargets);
+	}
+
+	private void addJdtCoreHarnessOperations(ICompilationUnit unit, String unitHandle, CompilationUnit root,
+			Set<CompilationUnitRewriteOperationWithSourceRange> operations, Set<ASTNode> nodesProcessed)
+			throws CoreException {
+		List<JdtCoreDirectFamilyMigration> harnessMigrations= jdtCoreDirectFamilies.stream()
+				.filter(migration -> unitHandle.equals(migration.harnessCompilationUnitHandle())).toList();
+		List<JdtCoreDirectFamilyMigration> familyMigrations= jdtCoreDirectFamilies.stream()
+				.filter(migration -> unitHandle.equals(migration.familyCompilationUnitHandle())).toList();
+		if (harnessMigrations.isEmpty() && familyMigrations.isEmpty()) {
+			return;
+		}
+
+		Set<String> expectedTypeKeys= new LinkedHashSet<>();
+		Set<String> expectedMethodKeys= new LinkedHashSet<>();
+		Map<NodeKey, InvocationMigration> expectedInvocations= new LinkedHashMap<>();
+		for (JdtCoreDirectFamilyMigration migration : harnessMigrations) {
+			expectedTypeKeys.add(migration.harnessTypeBindingKey());
+		}
+		for (JdtCoreDirectFamilyMigration migration : familyMigrations) {
+			expectedTypeKeys.add(migration.familyTypeBindingKey());
+			expectedMethodKeys.add(migration.constructorBindingKey());
+			if (migration.localSuiteMethodBindingKey() != null) {
+				expectedMethodKeys.add(migration.localSuiteMethodBindingKey());
+			}
+			migration.testMethods().stream().map(MethodMigration::methodBindingKey)
+					.forEach(expectedMethodKeys::add);
+			for (InvocationMigration invocation : migration.assertionInvocations()) {
+				expectedInvocations.put(invocationKey(invocation), invocation);
+			}
+		}
+
+		Map<String, TypeDeclaration> resolvedTypes= new LinkedHashMap<>();
+		Map<String, MethodDeclaration> resolvedMethods= new LinkedHashMap<>();
+		Map<NodeKey, MethodInvocation> resolvedInvocations= new LinkedHashMap<>();
+		resolveTargets(root, expectedTypeKeys, expectedMethodKeys, expectedInvocations.keySet(),
+				resolvedTypes, resolvedMethods, resolvedInvocations);
+		if (!resolvedTypes.keySet().equals(expectedTypeKeys)
+				|| !resolvedMethods.keySet().equals(expectedMethodKeys)
+				|| !resolvedInvocations.keySet().equals(expectedInvocations.keySet())) {
+			throw staleJdtCorePlan(unit, expectedTypeKeys, expectedMethodKeys, expectedInvocations.keySet(),
+					resolvedTypes.keySet(), resolvedMethods.keySet(), resolvedInvocations.keySet());
+		}
+
+		if (!harnessMigrations.isEmpty()) {
+			Set<String> harnessKeys= harnessMigrations.stream()
+					.map(JdtCoreDirectFamilyMigration::harnessTypeBindingKey).collect(Collectors.toSet());
+			if (harnessKeys.size() != 1) {
+				throw new CoreException(new Status(IStatus.ERROR, "sandbox_junit_cleanup", //$NON-NLS-1$
+						"One JDT Core harness source unit resolved multiple bridge target types: " + harnessKeys)); //$NON-NLS-1$
+			}
+			TypeDeclaration harness= resolvedTypes.get(harnessKeys.iterator().next());
+			nodesProcessed.add(harness);
+			operations.add(JdtCoreHarnessRewriteOperation.addBridge(harness));
+		}
+
+		SemanticRewritePlan.Builder plan= SemanticRewritePlan.builder("junit3-hierarchy"); //$NON-NLS-1$
+		Set<NodeKey> expectedHintTargets= new LinkedHashSet<>();
+		for (JdtCoreDirectFamilyMigration migration : familyMigrations) {
+			TypeDeclaration family= resolvedTypes.get(migration.familyTypeBindingKey());
+			MethodDeclaration constructor= resolvedMethods.get(migration.constructorBindingKey());
+			MethodDeclaration suite= migration.localSuiteMethodBindingKey() == null ? null
+					: resolvedMethods.get(migration.localSuiteMethodBindingKey());
+			operations.add(JdtCoreHarnessRewriteOperation.migrateFamily(family, constructor, suite));
+			nodesProcessed.add(family);
+			nodesProcessed.add(constructor);
+			if (suite != null) {
+				nodesProcessed.add(suite);
+			}
+			plan.add(NodeKey.type(migration.familyTypeBindingKey()), ROLE_HIERARCHY_TYPE);
+			for (MethodMigration method : migration.testMethods()) {
+				NodeKey key= NodeKey.method(method.methodBindingKey());
+				plan.add(key, ROLE_TEST_METHOD);
+				expectedHintTargets.add(key);
+				nodesProcessed.add(resolvedMethods.get(method.methodBindingKey()));
+			}
+			for (InvocationMigration invocation : migration.assertionInvocations()) {
+				NodeKey key= invocationKey(invocation);
+				plan.add(key, invocation.kind() == InvocationKind.MESSAGE_FIRST
+						? ROLE_ASSERTION_MESSAGE_FIRST : ROLE_ASSERTION_QUALIFY);
+				expectedHintTargets.add(key);
+				nodesProcessed.add(resolvedInvocations.get(key));
+			}
+		}
+		if (!familyMigrations.isEmpty()) {
+			applyHintProgram(unit, root, operations, nodesProcessed, plan, expectedHintTargets);
+		}
+	}
+
+	private static void applyHintProgram(ICompilationUnit unit, CompilationUnit root,
+			Set<CompilationUnitRewriteOperationWithSourceRange> operations, Set<ASTNode> nodesProcessed,
+			SemanticRewritePlan.Builder plan, Set<NodeKey> expectedHintTargets) throws CoreException {
 		Set<NodeKey> covered= PlanAwareHintFileFixCore.findOperationsFromContent(root, loadJUnit3HintProgram(),
 				plan.build(), unit.getJavaProject().getOptions(true), operations, nodesProcessed);
 		if (!covered.equals(expectedHintTargets)) {
@@ -249,6 +323,45 @@ public record JUnitMigrationPlan(SelectedCompilationUnitPlan selectedScope,
 					"The plan-aware JUnit hint program covered " + covered + " but expected " //$NON-NLS-1$ //$NON-NLS-2$
 							+ expectedHintTargets));
 		}
+	}
+
+	private static void resolveTargets(CompilationUnit root, Set<String> expectedTypeKeys,
+			Set<String> expectedMethodKeys, Set<NodeKey> expectedInvocationKeys,
+			Map<String, TypeDeclaration> resolvedTypes, Map<String, MethodDeclaration> resolvedMethods,
+			Map<NodeKey, MethodInvocation> resolvedInvocations) {
+		root.accept(new ASTVisitor() {
+			@Override
+			public boolean visit(TypeDeclaration node) {
+				String key= typeKey(node.resolveBinding());
+				if (key != null && expectedTypeKeys.contains(key)) {
+					resolvedTypes.put(key, node);
+				}
+				return true;
+			}
+
+			@Override
+			public boolean visit(MethodDeclaration node) {
+				IMethodBinding binding= node.resolveBinding();
+				String key= binding == null ? null : binding.getMethodDeclaration().getKey();
+				if (key != null && expectedMethodKeys.contains(key)) {
+					resolvedMethods.put(key, node);
+				}
+				return true;
+			}
+
+			@Override
+			public boolean visit(MethodInvocation node) {
+				NodeKey key= NodeKey.from(node);
+				if (key != null && expectedInvocationKeys.contains(key)) {
+					resolvedInvocations.put(key, node);
+				}
+				return true;
+			}
+		});
+	}
+
+	private static NodeKey invocationKey(InvocationMigration invocation) {
+		return NodeKey.invocation(invocation.methodBindingKey(), invocation.sourceStart(), invocation.sourceLength());
 	}
 
 	private static String methodRole(MethodKind kind) {
@@ -354,6 +467,16 @@ public record JUnitMigrationPlan(SelectedCompilationUnitPlan selectedScope,
 			Set<String> expectedMethodKeys, Set<NodeKey> expectedInvocationKeys, Set<String> resolvedTypeKeys,
 			Set<String> resolvedMethodKeys, Set<NodeKey> resolvedInvocationKeys) {
 		String message= "The coordinated JUnit 3 hierarchy plan is stale for " + unit.getElementName() //$NON-NLS-1$
+				+ ". Expected types " + expectedTypeKeys + ", methods " + expectedMethodKeys //$NON-NLS-1$ //$NON-NLS-2$
+				+ " and invocations " + expectedInvocationKeys + ", but resolved types " + resolvedTypeKeys //$NON-NLS-1$ //$NON-NLS-2$
+				+ ", methods " + resolvedMethodKeys + " and invocations " + resolvedInvocationKeys; //$NON-NLS-1$ //$NON-NLS-2$
+		return new CoreException(new Status(IStatus.ERROR, "sandbox_junit_cleanup", message)); //$NON-NLS-1$
+	}
+
+	private static CoreException staleJdtCorePlan(ICompilationUnit unit, Set<String> expectedTypeKeys,
+			Set<String> expectedMethodKeys, Set<NodeKey> expectedInvocationKeys, Set<String> resolvedTypeKeys,
+			Set<String> resolvedMethodKeys, Set<NodeKey> resolvedInvocationKeys) {
+		String message= "The JDT Core harness migration plan is stale for " + unit.getElementName() //$NON-NLS-1$
 				+ ". Expected types " + expectedTypeKeys + ", methods " + expectedMethodKeys //$NON-NLS-1$ //$NON-NLS-2$
 				+ " and invocations " + expectedInvocationKeys + ", but resolved types " + resolvedTypeKeys //$NON-NLS-1$ //$NON-NLS-2$
 				+ ", methods " + resolvedMethodKeys + " and invocations " + resolvedInvocationKeys; //$NON-NLS-1$ //$NON-NLS-2$

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnitMultiFilePlanner.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnitMultiFilePlanner.java
@@ -144,7 +144,7 @@ public final class JUnitMultiFilePlanner {
 					? JUnitTestTypeInventory.capture(project, monitor)
 					: new JUnitTestTypeInventory(List.of());
 			MultiFileCleanUpDiagnostics diagnostics= diagnostics(selectedUnits, false, List.of());
-			JUnitMigrationPlan plan= new JUnitMigrationPlan(selectedScope, List.of(), List.of(), inventory);
+			JUnitMigrationPlan plan= new JUnitMigrationPlan(selectedScope, List.of(), List.of(), List.of(), inventory);
 			return MultiFileCleanUpPlanResult.success(plan, new RefactoringStatus(),
 					MultiFilePlanningMetrics.empty(), diagnostics);
 		}
@@ -169,11 +169,17 @@ public final class JUnitMultiFilePlanner {
 		JUnit3HierarchyPlanner.Result junit3Result= migrateJUnit3Hierarchies
 				? JUnit3HierarchyPlanner.create(project, selectedUnits, rootsByHandle, true, monitor)
 				: new JUnit3HierarchyPlanner.Result(List.of(), List.of(), new JUnitTestTypeInventory(List.of()));
+		MultiFilePlanningBudget.checkCanceled(monitor);
+		JdtCoreHarnessPlanner.Result jdtCoreResult= migrateJUnit3Hierarchies
+				? JdtCoreHarnessPlanner.create(project, selectedUnits, rootsByHandle, true, monitor)
+				: new JdtCoreHarnessPlanner.Result(JdtCoreHarnessInventory.empty(), List.of(), List.of());
 
 		List<MultiFileCandidateDiagnostic> candidateDiagnostics= new ArrayList<>();
 		candidateDiagnostics.addAll(externalResult.diagnostics());
 		candidateDiagnostics.addAll(junit3Result.diagnostics());
-		int retainedEntries= externalResult.migrations().size() + junit3Result.migrations().size();
+		candidateDiagnostics.addAll(jdtCoreResult.diagnostics());
+		int retainedEntries= externalResult.migrations().size() + junit3Result.migrations().size()
+				+ jdtCoreResult.directMigrations().size();
 		MultiFilePlanningMetrics metrics= budget.metrics()
 				.withDurations(parseNanos, System.nanoTime() - planningStarted)
 				.withRetainedPlanEntries(retainedEntries);
@@ -182,12 +188,13 @@ public final class JUnitMultiFilePlanner {
 			return new MultiFileCleanUpPlanResult<>(null, status, metrics, diagnostics);
 		}
 		JUnitMigrationPlan plan= new JUnitMigrationPlan(selectedScope, externalResult.migrations(),
-				junit3Result.migrations(), junit3Result.inventory());
+				junit3Result.migrations(), jdtCoreResult.directMigrations(), junit3Result.inventory());
 		return MultiFileCleanUpPlanResult.success(plan, status, metrics, diagnostics);
 	}
 
 	private static JUnitMigrationPlan emptyPlan(SelectedCompilationUnitPlan selectedScope) {
-		return new JUnitMigrationPlan(selectedScope, List.of(), List.of(), new JUnitTestTypeInventory(List.of()));
+		return new JUnitMigrationPlan(selectedScope, List.of(), List.of(), List.of(),
+				new JUnitTestTypeInventory(List.of()));
 	}
 
 	private static MigrationResult planExternalResources(Map<String, CompilationUnit> rootsByHandle,

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreDirectFamilyMigration.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreDirectFamilyMigration.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.corext.fix.multifile;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.sandbox.jdt.internal.corext.fix.multifile.JUnit3HierarchyMigration.InvocationMigration;
+import org.sandbox.jdt.internal.corext.fix.multifile.JUnit3HierarchyMigration.MethodMigration;
+
+/** Exact immutable rewrite targets for one direct custom JDT Core TestCase family. */
+public record JdtCoreDirectFamilyMigration(String harnessCompilationUnitHandle,
+		String harnessTypeBindingKey, String familyCompilationUnitHandle,
+		String familyTypeBindingKey, String constructorBindingKey,
+		String localSuiteMethodBindingKey, List<MethodMigration> testMethods,
+		List<InvocationMigration> assertionInvocations) {
+
+	public JdtCoreDirectFamilyMigration {
+		harnessCompilationUnitHandle= Objects.requireNonNull(harnessCompilationUnitHandle);
+		harnessTypeBindingKey= Objects.requireNonNull(harnessTypeBindingKey);
+		familyCompilationUnitHandle= Objects.requireNonNull(familyCompilationUnitHandle);
+		familyTypeBindingKey= Objects.requireNonNull(familyTypeBindingKey);
+		constructorBindingKey= Objects.requireNonNull(constructorBindingKey);
+		testMethods= List.copyOf(testMethods);
+		assertionInvocations= List.copyOf(assertionInvocations);
+	}
+}

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessInventory.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessInventory.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.corext.fix.multifile;
+
+import java.util.List;
+import java.util.Objects;
+
+/** Immutable inventory of source families using the custom Eclipse JDT Core JUnit 3 harness. */
+public record JdtCoreHarnessInventory(List<Family> families) {
+
+	/** The framework layer whose semantics control a test family. */
+	public enum FamilyKind {
+		/** Direct family using the custom named-test {@code TestCase} base only. */
+		DIRECT_TEST_CASE,
+		/** Family using {@code SuiteOfTestCases} once-per-suite state transfer. */
+		SUITE_STATE,
+		/** Family multiplied through {@code AbstractCompilerTest} compliance suites. */
+		COMPILER_COMPLIANCE
+	}
+
+	/** One binding-stable family classification and its migration boundary. */
+	public record Family(String compilationUnitHandle, String typeBindingKey, String typeName,
+			FamilyKind kind, boolean directSliceApplicable, String reasonCode, String message,
+			List<String> relatedCompilationUnitHandles) {
+		public Family {
+			compilationUnitHandle= Objects.requireNonNull(compilationUnitHandle);
+			typeBindingKey= Objects.requireNonNull(typeBindingKey);
+			typeName= Objects.requireNonNull(typeName);
+			kind= Objects.requireNonNull(kind);
+			reasonCode= Objects.requireNonNull(reasonCode);
+			message= Objects.requireNonNull(message);
+			relatedCompilationUnitHandles= relatedCompilationUnitHandles == null
+					? List.of()
+					: relatedCompilationUnitHandles.stream().filter(Objects::nonNull).distinct().sorted().toList();
+		}
+	}
+
+	public JdtCoreHarnessInventory {
+		families= families == null ? List.of() : List.copyOf(families);
+	}
+
+	/** Empty inventory for projects that do not contain the JDT Core harness. */
+	public static JdtCoreHarnessInventory empty() {
+		return new JdtCoreHarnessInventory(List.of());
+	}
+
+	/** Number of direct families admitted by the first explicit harness slice. */
+	public long applicableDirectFamilyCount() {
+		return families.stream().filter(Family::directSliceApplicable).count();
+	}
+}

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessPlanner.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessPlanner.java
@@ -1,0 +1,411 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.corext.fix.multifile;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.IVariableBinding;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.Modifier;
+import org.eclipse.jdt.core.dom.ReturnStatement;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
+import org.eclipse.jdt.core.dom.SuperConstructorInvocation;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.core.dom.TypeLiteral;
+
+import org.sandbox.jdt.cleanup.multifile.MultiFileCandidateDiagnostic;
+import org.sandbox.jdt.cleanup.multifile.MultiFileCandidateOutcome;
+import org.sandbox.jdt.cleanup.multifile.RelatedCompilationUnitSearch;
+import org.sandbox.jdt.internal.corext.fix.helper.lib.JUnit3SemanticSupport;
+import org.sandbox.jdt.internal.corext.fix.multifile.JUnit3HierarchyMigration.MethodKind;
+import org.sandbox.jdt.internal.corext.fix.multifile.JUnit3HierarchyMigration.MethodMigration;
+import org.sandbox.jdt.internal.corext.fix.multifile.JdtCoreHarnessInventory.Family;
+import org.sandbox.jdt.internal.corext.fix.multifile.JdtCoreHarnessInventory.FamilyKind;
+
+/**
+ * Inventories the source-level concepts of the custom Eclipse JDT Core JUnit 3
+ * harness before any framework rewrite is attempted.
+ */
+final class JdtCoreHarnessPlanner {
+
+	static final String JDT_CORE_TEST_CASE= "org.eclipse.jdt.core.tests.junit.extension.TestCase"; //$NON-NLS-1$
+	static final String JDT_CORE_SUITE_OF_TEST_CASES= "org.eclipse.jdt.core.tests.model.SuiteOfTestCases"; //$NON-NLS-1$
+	static final String JDT_CORE_ABSTRACT_COMPILER_TEST= "org.eclipse.jdt.core.tests.util.AbstractCompilerTest"; //$NON-NLS-1$
+
+	private static final Set<String> HARNESS_BASE_TYPES= Set.of(JDT_CORE_TEST_CASE,
+			JDT_CORE_SUITE_OF_TEST_CASES, "org.eclipse.jdt.core.tests.model.AbstractJavaModelTests", //$NON-NLS-1$
+			JDT_CORE_ABSTRACT_COMPILER_TEST);
+	private static final Set<String> DIRECT_SLICE_REJECTED_METHODS= Set.of(
+			"setUp", "tearDown", "setUpSuite", "tearDownSuite", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+			"runTest", "runBare", "run", "setUpTest"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+	private static final Set<String> SUPPORTED_PERFORMANCE_METHODS= Set.of(
+			"startMeasuring", "stopMeasuring", "commitMeasurements", "assertPerformance", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+			"assertPerformanceInRelativeBand", "tagAsSummary", "tagAsGlobalSummary", "setComment"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+
+	record Result(JdtCoreHarnessInventory inventory,
+			List<JdtCoreDirectFamilyMigration> directMigrations,
+			List<MultiFileCandidateDiagnostic> diagnostics) {
+		Result {
+			inventory= inventory == null ? JdtCoreHarnessInventory.empty() : inventory;
+			directMigrations= directMigrations == null ? List.of() : List.copyOf(directMigrations);
+			diagnostics= diagnostics == null ? List.of() : List.copyOf(diagnostics);
+		}
+	}
+
+	private record SourceType(String unitHandle, TypeDeclaration declaration,
+			ITypeBinding binding, IType javaType) {
+		String key() {
+			return JUnitMigrationPlan.typeKey(binding);
+		}
+
+		String name() {
+			return binding.getQualifiedName();
+		}
+	}
+
+	private record DirectAssessment(boolean applicable, String reasonCode, String message,
+			List<String> relatedHandles, JdtCoreDirectFamilyMigration migration) {
+		static DirectAssessment applicable(List<String> relatedHandles,
+				JdtCoreDirectFamilyMigration migration) {
+			return new DirectAssessment(true, "JDT_CORE_DIRECT_SLICE_APPLICABLE", //$NON-NLS-1$
+					"The direct JDT Core TestCase family has a closed, explicit Slice A shape.", //$NON-NLS-1$
+					relatedHandles, migration);
+		}
+
+		static DirectAssessment rejected(String reasonCode, String message, List<String> relatedHandles) {
+			return new DirectAssessment(false, reasonCode, message, relatedHandles, null);
+		}
+	}
+
+	private JdtCoreHarnessPlanner() {
+	}
+
+	static Result create(IJavaProject project, ICompilationUnit[] selectedUnits,
+			Map<String, CompilationUnit> rootsByHandle, boolean closedScope, IProgressMonitor monitor)
+			throws CoreException {
+		Map<String, SourceType> sourceTypes= collectSourceTypes(rootsByHandle);
+		SourceType harness= sourceTypes.values().stream()
+				.filter(type -> JDT_CORE_TEST_CASE.equals(type.name())).findFirst().orElse(null);
+		if (harness == null) {
+			return new Result(JdtCoreHarnessInventory.empty(), List.of(), List.of());
+		}
+
+		List<ICompilationUnit> selectedList= Arrays.asList(selectedUnits);
+		List<Family> families= new ArrayList<>();
+		List<JdtCoreDirectFamilyMigration> migrations= new ArrayList<>();
+		List<MultiFileCandidateDiagnostic> diagnostics= new ArrayList<>();
+		for (SourceType type : sourceTypes.values().stream()
+				.filter(candidate -> !HARNESS_BASE_TYPES.contains(candidate.name()))
+				.filter(candidate -> inherits(candidate.binding(), JDT_CORE_TEST_CASE))
+				.sorted(Comparator.comparing(SourceType::name)).toList()) {
+			FamilyKind kind= familyKind(type.binding());
+			List<String> baseRelated= List.of(harness.unitHandle(), type.unitHandle());
+			if (kind == FamilyKind.COMPILER_COMPLIANCE) {
+				addRejected(type, kind, "JDT_CORE_COMPLIANCE_MATRIX_REQUIRED", //$NON-NLS-1$
+						"The family is multiplied through AbstractCompilerTest compliance suites and requires an explicit Jupiter test-template migration.", //$NON-NLS-1$
+						baseRelated, families, diagnostics);
+				continue;
+			}
+			if (kind == FamilyKind.SUITE_STATE) {
+				addRejected(type, kind, "JDT_CORE_SUITE_STATE_REQUIRED", //$NON-NLS-1$
+						"The family relies on SuiteOfTestCases once-per-suite setup and mutable field transfer between fresh test instances.", //$NON-NLS-1$
+						baseRelated, families, diagnostics);
+				continue;
+			}
+
+			DirectAssessment assessment= assessDirectFamily(project, type, harness, selectedList,
+					closedScope, monitor);
+			families.add(new Family(type.unitHandle(), type.key(), type.name(), kind,
+					assessment.applicable(), assessment.reasonCode(), assessment.message(),
+					assessment.relatedHandles()));
+			if (assessment.migration() != null) {
+				migrations.add(assessment.migration());
+			}
+			String candidateId= "jdt-core-harness:" + type.name(); //$NON-NLS-1$
+			if (assessment.applicable()) {
+				diagnostics.add(new MultiFileCandidateDiagnostic(candidateId, type.unitHandle(),
+						MultiFileCandidateOutcome.APPLICABLE, assessment.reasonCode(), assessment.message(),
+						assessment.relatedHandles()));
+			} else {
+				diagnostics.add(MultiFileCandidateDiagnostic.rejected(candidateId, type.unitHandle(),
+						assessment.reasonCode(), assessment.message(), assessment.relatedHandles()));
+			}
+		}
+		return new Result(new JdtCoreHarnessInventory(families), migrations, diagnostics);
+	}
+
+	private static void addRejected(SourceType type, FamilyKind kind, String reasonCode, String message,
+			List<String> relatedHandles, List<Family> families,
+			List<MultiFileCandidateDiagnostic> diagnostics) {
+		families.add(new Family(type.unitHandle(), type.key(), type.name(), kind, false,
+				reasonCode, message, relatedHandles));
+		diagnostics.add(MultiFileCandidateDiagnostic.rejected("jdt-core-harness:" + type.name(), //$NON-NLS-1$
+				type.unitHandle(), reasonCode, message, relatedHandles));
+	}
+
+	private static DirectAssessment assessDirectFamily(IJavaProject project, SourceType type,
+			SourceType harness, List<ICompilationUnit> selectedUnits, boolean closedScope,
+			IProgressMonitor monitor) throws CoreException {
+		List<String> baseRelated= List.of(harness.unitHandle(), type.unitHandle());
+		ITypeBinding superclass= type.binding().getSuperclass();
+		if (superclass == null || !JDT_CORE_TEST_CASE.equals(superclass.getErasure().getQualifiedName())) {
+			return DirectAssessment.rejected("JDT_CORE_CUSTOM_BASE_REQUIRED", //$NON-NLS-1$
+					"The first harness slice supports only concrete families directly extending the custom JDT Core TestCase.", //$NON-NLS-1$
+					baseRelated);
+		}
+		if (Modifier.isAbstract(type.binding().getModifiers())) {
+			return DirectAssessment.rejected("JDT_CORE_ABSTRACT_FAMILY_BASE", //$NON-NLS-1$
+					"Abstract custom TestCase bases require their complete descendant family to be migrated together.", //$NON-NLS-1$
+					baseRelated);
+		}
+		if (!closedScope) {
+			return DirectAssessment.rejected("INCOMPLETE_JDT_CORE_HARNESS_SCOPE", //$NON-NLS-1$
+					"The selected source scope is not closed for the JDT Core harness family.", baseRelated); //$NON-NLS-1$
+		}
+
+		List<MethodDeclaration> constructors= Arrays.stream(type.declaration().getMethods())
+				.filter(MethodDeclaration::isConstructor).toList();
+		if (constructors.size() != 1 || !isSimpleNamedConstructor(constructors.get(0))) {
+			return DirectAssessment.rejected("JDT_CORE_NAMED_CONSTRUCTOR_REQUIRED", //$NON-NLS-1$
+					"Slice A requires exactly the conventional String constructor whose only statement is super(name).", //$NON-NLS-1$
+					baseRelated);
+		}
+		String constructorKey= methodKey(constructors.get(0));
+		if (constructorKey == null) {
+			return DirectAssessment.rejected("UNRESOLVED_JDT_CORE_CONSTRUCTOR", //$NON-NLS-1$
+					"The conventional JDT Core String constructor has no stable binding key.", baseRelated); //$NON-NLS-1$
+		}
+
+		List<MethodMigration> testMethods= new ArrayList<>();
+		String suiteMethodKey= null;
+		for (MethodDeclaration method : type.declaration().getMethods()) {
+			if (method.isConstructor()) {
+				continue;
+			}
+			String name= method.getName().getIdentifier();
+			if ("suite".equals(name)) { //$NON-NLS-1$
+				if (!isExactLocalSuite(method, type.binding())) {
+					return DirectAssessment.rejected("JDT_CORE_CUSTOM_SUITE_REQUIRED", //$NON-NLS-1$
+							"The local suite() method is not the removable buildTestSuite(Self.class) form.", //$NON-NLS-1$
+							baseRelated);
+				}
+				suiteMethodKey= methodKey(method);
+				if (suiteMethodKey == null) {
+					return DirectAssessment.rejected("UNRESOLVED_JDT_CORE_LOCAL_SUITE", //$NON-NLS-1$
+							"The removable local suite() method has no stable binding key.", baseRelated); //$NON-NLS-1$
+				}
+				continue;
+			}
+			if (DIRECT_SLICE_REJECTED_METHODS.contains(name)) {
+				return DirectAssessment.rejected("JDT_CORE_LIFECYCLE_OR_RUN_HOOK_REQUIRED", //$NON-NLS-1$
+						"The family overrides " + name + "() and requires an explicit Jupiter lifecycle/harness mapping.", //$NON-NLS-1$ //$NON-NLS-2$
+						baseRelated);
+			}
+			if (name.startsWith("test")) { //$NON-NLS-1$
+				String key= methodKey(method);
+				if (!JUnit3SemanticSupport.isExactTestMethod(method) || key == null) {
+					return DirectAssessment.rejected("UNSUPPORTED_JDT_CORE_TEST_SIGNATURE", //$NON-NLS-1$
+							"A test-prefixed method does not satisfy the exact public non-static void zero-argument contract.", //$NON-NLS-1$
+							baseRelated);
+				}
+				testMethods.add(new MethodMigration(key, MethodKind.TEST));
+			}
+		}
+		if (testMethods.isEmpty()) {
+			return DirectAssessment.rejected("NO_JDT_CORE_TEST_METHODS", //$NON-NLS-1$
+					"The concrete harness family declares no exact JUnit 3 test methods.", baseRelated); //$NON-NLS-1$
+		}
+
+		String unsupportedInvocation= unsupportedHarnessInvocation(type.declaration(), suiteMethodKey);
+		if (unsupportedInvocation != null) {
+			return DirectAssessment.rejected("JDT_CORE_CUSTOM_HELPER_REQUIRED", //$NON-NLS-1$
+					unsupportedInvocation, baseRelated);
+		}
+		JUnit3AssertionInventory.Result assertions= JUnit3AssertionInventory.analyze(type.declaration());
+		if (!assertions.supported()) {
+			return DirectAssessment.rejected("UNSUPPORTED_JDT_CORE_ASSERTION_OR_EXECUTION", //$NON-NLS-1$
+					assertions.rejectionReason(), baseRelated);
+		}
+
+		RelatedCompilationUnitSearch.Result references= RelatedCompilationUnitSearch.findReferences(project,
+				List.of(type.javaType()), List.of(type.javaType().getCompilationUnit()), selectedUnits, monitor);
+		if (!references.complete()) {
+			List<String> related= new ArrayList<>(baseRelated);
+			related.addAll(references.compilationUnits().stream().map(IJavaElement::getHandleIdentifier).toList());
+			return DirectAssessment.rejected("INCOMPLETE_JDT_CORE_HARNESS_REFERENCES", //$NON-NLS-1$
+					"The direct family has unresolved, binary, or out-of-scope references: " //$NON-NLS-1$
+							+ String.join("; ", references.rejectionReasons()), related); //$NON-NLS-1$
+		}
+		List<String> externalHandles= references.compilationUnits().stream()
+				.map(IJavaElement::getHandleIdentifier)
+				.filter(handle -> !type.unitHandle().equals(handle))
+				.sorted().toList();
+		if (!externalHandles.isEmpty()) {
+			List<String> related= new ArrayList<>(baseRelated);
+			related.addAll(externalHandles);
+			return DirectAssessment.rejected("JDT_CORE_AGGREGATE_SUITE_REQUIRED", //$NON-NLS-1$
+					"The family is referenced by aggregate suite or harness source that must be migrated in the same slice.", //$NON-NLS-1$
+					related);
+		}
+		JdtCoreDirectFamilyMigration migration= new JdtCoreDirectFamilyMigration(harness.unitHandle(),
+				harness.key(), type.unitHandle(), type.key(), constructorKey, suiteMethodKey,
+				testMethods, assertions.invocations());
+		return DirectAssessment.applicable(baseRelated, migration);
+	}
+
+	private static String unsupportedHarnessInvocation(TypeDeclaration declaration, String suiteMethodKey) {
+		String[] rejection= new String[1];
+		declaration.accept(new ASTVisitor() {
+			@Override
+			public boolean visit(MethodDeclaration method) {
+				return suiteMethodKey == null || !suiteMethodKey.equals(methodKey(method));
+			}
+
+			@Override
+			public boolean visit(MethodInvocation invocation) {
+				IMethodBinding binding= invocation.resolveMethodBinding();
+				if (binding == null) {
+					return true;
+				}
+				ITypeBinding declaring= binding.getDeclaringClass();
+				String owner= declaring == null ? "" : declaring.getErasure().getQualifiedName(); //$NON-NLS-1$
+				String name= binding.getName();
+				if (JDT_CORE_TEST_CASE.equals(owner)) {
+					rejection[0]= "The direct family calls custom JDT Core harness method " + name //$NON-NLS-1$
+							+ "(), which is not yet represented by the Jupiter bridge."; //$NON-NLS-1$
+					return false;
+				}
+				if (owner.startsWith("org.eclipse.test.performance.") //$NON-NLS-1$
+						&& !SUPPORTED_PERFORMANCE_METHODS.contains(name)) {
+					rejection[0]= "The direct family calls unsupported performance harness method " //$NON-NLS-1$
+							+ owner + "." + name + "()."; //$NON-NLS-1$ //$NON-NLS-2$
+					return false;
+				}
+				return true;
+			}
+		});
+		return rejection[0];
+	}
+
+	private static boolean isSimpleNamedConstructor(MethodDeclaration constructor) {
+		if (constructor.parameters().size() != 1 || constructor.getBody() == null
+				|| constructor.getBody().statements().size() != 1) {
+			return false;
+		}
+		SingleVariableDeclaration parameter= (SingleVariableDeclaration) constructor.parameters().get(0);
+		ITypeBinding parameterType= parameter.getType().resolveBinding();
+		if (parameterType == null || !"java.lang.String".equals(parameterType.getErasure().getQualifiedName())) { //$NON-NLS-1$
+			return false;
+		}
+		Object statement= constructor.getBody().statements().get(0);
+		if (!(statement instanceof SuperConstructorInvocation invocation) || invocation.arguments().size() != 1) {
+			return false;
+		}
+		Expression argument= (Expression) invocation.arguments().get(0);
+		if (!(argument instanceof SimpleName simpleName)) {
+			return false;
+		}
+		IVariableBinding parameterBinding= parameter.resolveBinding();
+		return parameterBinding != null && parameterBinding.equals(simpleName.resolveBinding());
+	}
+
+	private static boolean isExactLocalSuite(MethodDeclaration method, ITypeBinding owner) {
+		if (!Modifier.isPublic(method.getModifiers()) || !Modifier.isStatic(method.getModifiers())
+				|| !method.parameters().isEmpty() || method.getBody() == null
+				|| method.getBody().statements().size() != 1) {
+			return false;
+		}
+		IMethodBinding methodBinding= method.resolveBinding();
+		ITypeBinding returnType= methodBinding == null ? null : methodBinding.getReturnType();
+		if (returnType == null || !"junit.framework.Test".equals(returnType.getErasure().getQualifiedName())) { //$NON-NLS-1$
+			return false;
+		}
+		Object statement= method.getBody().statements().get(0);
+		if (!(statement instanceof ReturnStatement returnStatement)
+				|| !(returnStatement.getExpression() instanceof MethodInvocation invocation)
+				|| !"buildTestSuite".equals(invocation.getName().getIdentifier()) //$NON-NLS-1$
+				|| invocation.arguments().size() != 1) {
+			return false;
+		}
+		Object argument= invocation.arguments().get(0);
+		if (!(argument instanceof TypeLiteral literal)) {
+			return false;
+		}
+		ITypeBinding selectedType= literal.getType().resolveBinding();
+		return selectedType != null && JUnitMigrationPlan.typeKey(owner)
+				.equals(JUnitMigrationPlan.typeKey(selectedType));
+	}
+
+	private static String methodKey(MethodDeclaration method) {
+		IMethodBinding binding= method.resolveBinding();
+		return binding == null ? null : binding.getMethodDeclaration().getKey();
+	}
+
+	private static FamilyKind familyKind(ITypeBinding binding) {
+		if (inherits(binding, JDT_CORE_ABSTRACT_COMPILER_TEST)) {
+			return FamilyKind.COMPILER_COMPLIANCE;
+		}
+		if (inherits(binding, JDT_CORE_SUITE_OF_TEST_CASES)) {
+			return FamilyKind.SUITE_STATE;
+		}
+		return FamilyKind.DIRECT_TEST_CASE;
+	}
+
+	private static boolean inherits(ITypeBinding binding, String qualifiedName) {
+		ITypeBinding current= binding;
+		while (current != null) {
+			if (qualifiedName.equals(current.getErasure().getQualifiedName())) {
+				return true;
+			}
+			current= current.getSuperclass();
+		}
+		return false;
+	}
+
+	private static Map<String, SourceType> collectSourceTypes(Map<String, CompilationUnit> rootsByHandle) {
+		Map<String, SourceType> result= new LinkedHashMap<>();
+		for (Map.Entry<String, CompilationUnit> entry : rootsByHandle.entrySet()) {
+			entry.getValue().accept(new ASTVisitor() {
+				@Override
+				public boolean visit(TypeDeclaration node) {
+					ITypeBinding binding= node.resolveBinding();
+					String key= JUnitMigrationPlan.typeKey(binding);
+					IJavaElement element= binding == null ? null : binding.getErasure().getJavaElement();
+					if (key != null && element instanceof IType type && type.getCompilationUnit() != null) {
+						result.put(key, new SourceType(entry.getKey(), node, binding, type));
+					}
+					return true;
+				}
+			});
+		}
+		return result;
+	}
+}

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessPlanner.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessPlanner.java
@@ -25,9 +25,12 @@ import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.Assignment;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.FieldAccess;
 import org.eclipse.jdt.core.dom.IBinding;
 import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
@@ -35,9 +38,12 @@ import org.eclipse.jdt.core.dom.IVariableBinding;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.core.dom.Modifier;
+import org.eclipse.jdt.core.dom.NullLiteral;
+import org.eclipse.jdt.core.dom.QualifiedName;
 import org.eclipse.jdt.core.dom.ReturnStatement;
 import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
+import org.eclipse.jdt.core.dom.StringLiteral;
 import org.eclipse.jdt.core.dom.SuperConstructorInvocation;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.TypeLiteral;
@@ -310,17 +316,43 @@ final class JdtCoreHarnessPlanner {
 				}
 				IVariableBinding declarationBinding= variable.getVariableDeclaration();
 				ITypeBinding owner= declarationBinding.getDeclaringClass();
-				if (owner != null && JDT_CORE_TEST_CASE.equals(owner.getErasure().getQualifiedName())
-						&& FILTER_FIELDS.contains(declarationBinding.getName())) {
-					rejection[0]= "The family reads or writes JDT Core filter field " //$NON-NLS-1$
-							+ declarationBinding.getName()
-							+ "; execution conditions would retain excluded Jupiter nodes and change runtime-tree multiplicity."; //$NON-NLS-1$
-					return false;
+				if (owner == null || !JDT_CORE_TEST_CASE.equals(owner.getErasure().getQualifiedName())
+						|| !FILTER_FIELDS.contains(declarationBinding.getName())) {
+					return true;
 				}
-				return true;
+				Assignment assignment= enclosingAssignmentTo(node);
+				if (assignment != null && isDefaultFilterReset(declarationBinding.getName(),
+						assignment.getRightHandSide())) {
+					return true;
+				}
+				rejection[0]= "The family reads or configures JDT Core filter field " //$NON-NLS-1$
+						+ declarationBinding.getName()
+						+ "; execution conditions would retain excluded Jupiter nodes and change runtime-tree multiplicity."; //$NON-NLS-1$
+				return false;
 			}
 		});
 		return rejection[0];
+	}
+
+	private static Assignment enclosingAssignmentTo(SimpleName name) {
+		ASTNode current= name;
+		while (current.getParent() instanceof QualifiedName qualified && qualified.getName() == current
+				|| current.getParent() instanceof FieldAccess access && access.getName() == current) {
+			current= current.getParent();
+		}
+		if (current.getParent() instanceof Assignment assignment
+				&& assignment.getOperator() == Assignment.Operator.ASSIGN
+				&& assignment.getLeftHandSide() == current) {
+			return assignment;
+		}
+		return null;
+	}
+
+	private static boolean isDefaultFilterReset(String fieldName, Expression value) {
+		if ("RUN_ONLY_ID".equals(fieldName)) { //$NON-NLS-1$
+			return value instanceof StringLiteral literal && "ONLY_".equals(literal.getLiteralValue()); //$NON-NLS-1$
+		}
+		return value instanceof NullLiteral;
 	}
 
 	private static String unsupportedHarnessInvocation(TypeDeclaration declaration, String suiteMethodKey) {

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessPlanner.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessPlanner.java
@@ -373,6 +373,9 @@ final class JdtCoreHarnessPlanner {
 				String owner= declaring == null ? "" : declaring.getErasure().getQualifiedName(); //$NON-NLS-1$
 				String name= binding.getName();
 				if (JDT_CORE_TEST_CASE.equals(owner)) {
+					if (SUPPORTED_PERFORMANCE_METHODS.contains(name)) {
+						return true;
+					}
 					rejection[0]= "The direct family calls custom JDT Core harness method " + name //$NON-NLS-1$
 							+ "(), which is not yet represented by the Jupiter bridge."; //$NON-NLS-1$
 					return false;

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessPlanner.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessPlanner.java
@@ -72,7 +72,8 @@ final class JdtCoreHarnessPlanner {
 			JDT_CORE_ABSTRACT_COMPILER_TEST);
 	private static final Set<String> DIRECT_SLICE_REJECTED_METHODS= Set.of(
 			"setUp", "tearDown", "setUpSuite", "tearDownSuite", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-			"runTest", "runBare", "run", "setUpTest"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+			"runTest", "runBare", "run", "setUpTest", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+			"createResult", "countTestCases", "getName", "setName"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 	private static final Set<String> FILTER_FIELDS= Set.of(
 			"RUN_ONLY_ID", "TESTS_PREFIX", "TESTS_NAMES", "TESTS_NUMBERS", "TESTS_RANGE"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
 	private static final Set<String> SUPPORTED_PERFORMANCE_METHODS= Set.of(

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessPlanner.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessPlanner.java
@@ -186,6 +186,11 @@ final class JdtCoreHarnessPlanner {
 					"Abstract custom TestCase bases require their complete descendant family to be migrated together.", //$NON-NLS-1$
 					baseRelated);
 		}
+		if (!Modifier.isPublic(type.binding().getModifiers())) {
+			return DirectAssessment.rejected("JDT_CORE_PUBLIC_FAMILY_REQUIRED", //$NON-NLS-1$
+					"The JUnit 3 harness constructs direct families reflectively and therefore requires a public test class; Jupiter would otherwise change test multiplicity.", //$NON-NLS-1$
+					baseRelated);
+		}
 		if (!closedScope) {
 			return DirectAssessment.rejected("INCOMPLETE_JDT_CORE_HARNESS_SCOPE", //$NON-NLS-1$
 					"The selected source scope is not closed for the JDT Core harness family.", baseRelated); //$NON-NLS-1$
@@ -195,7 +200,7 @@ final class JdtCoreHarnessPlanner {
 				.filter(MethodDeclaration::isConstructor).toList();
 		if (constructors.size() != 1 || !isSimpleNamedConstructor(constructors.get(0))) {
 			return DirectAssessment.rejected("JDT_CORE_NAMED_CONSTRUCTOR_REQUIRED", //$NON-NLS-1$
-					"Slice A requires exactly the conventional String constructor whose only statement is super(name).", //$NON-NLS-1$
+					"Slice A requires exactly the public conventional String constructor whose only statement is super(name).", //$NON-NLS-1$
 					baseRelated);
 		}
 		String constructorKey= methodKey(constructors.get(0));
@@ -316,8 +321,8 @@ final class JdtCoreHarnessPlanner {
 	}
 
 	private static boolean isSimpleNamedConstructor(MethodDeclaration constructor) {
-		if (constructor.parameters().size() != 1 || constructor.getBody() == null
-				|| constructor.getBody().statements().size() != 1) {
+		if (!Modifier.isPublic(constructor.getModifiers()) || constructor.parameters().size() != 1
+				|| constructor.getBody() == null || constructor.getBody().statements().size() != 1) {
 			return false;
 		}
 		SingleVariableDeclaration parameter= (SingleVariableDeclaration) constructor.parameters().get(0);

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessPlanner.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessPlanner.java
@@ -28,6 +28,7 @@ import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.IBinding;
 import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.IVariableBinding;
@@ -66,6 +67,8 @@ final class JdtCoreHarnessPlanner {
 	private static final Set<String> DIRECT_SLICE_REJECTED_METHODS= Set.of(
 			"setUp", "tearDown", "setUpSuite", "tearDownSuite", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 			"runTest", "runBare", "run", "setUpTest"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+	private static final Set<String> FILTER_FIELDS= Set.of(
+			"RUN_ONLY_ID", "TESTS_PREFIX", "TESTS_NAMES", "TESTS_NUMBERS", "TESTS_RANGE"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
 	private static final Set<String> SUPPORTED_PERFORMANCE_METHODS= Set.of(
 			"startMeasuring", "stopMeasuring", "commitMeasurements", "assertPerformance", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 			"assertPerformanceInRelativeBand", "tagAsSummary", "tagAsGlobalSummary", "setComment"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
@@ -248,6 +251,11 @@ final class JdtCoreHarnessPlanner {
 			return DirectAssessment.rejected("NO_JDT_CORE_TEST_METHODS", //$NON-NLS-1$
 					"The concrete harness family declares no exact JUnit 3 test methods.", baseRelated); //$NON-NLS-1$
 		}
+		String unsupportedFilter= unsupportedFilterConfiguration(type.declaration());
+		if (unsupportedFilter != null) {
+			return DirectAssessment.rejected("JDT_CORE_FILTER_MAPPING_REQUIRED", //$NON-NLS-1$
+					unsupportedFilter, baseRelated);
+		}
 
 		String unsupportedInvocation= unsupportedHarnessInvocation(type.declaration(), suiteMethodKey);
 		if (unsupportedInvocation != null) {
@@ -284,6 +292,35 @@ final class JdtCoreHarnessPlanner {
 				harness.key(), type.unitHandle(), type.key(), constructorKey, suiteMethodKey,
 				testMethods, assertions.invocations());
 		return DirectAssessment.applicable(baseRelated, migration);
+	}
+
+	private static String unsupportedFilterConfiguration(TypeDeclaration declaration) {
+		for (MethodDeclaration method : declaration.getMethods()) {
+			if (method.getName().getIdentifier().startsWith("testONLY_")) { //$NON-NLS-1$
+				return "The family uses JDT Core testONLY_ discovery, which must be mapped before Jupiter annotations are added."; //$NON-NLS-1$
+			}
+		}
+		String[] rejection= new String[1];
+		declaration.accept(new ASTVisitor() {
+			@Override
+			public boolean visit(SimpleName node) {
+				IBinding binding= node.resolveBinding();
+				if (!(binding instanceof IVariableBinding variable)) {
+					return true;
+				}
+				IVariableBinding declarationBinding= variable.getVariableDeclaration();
+				ITypeBinding owner= declarationBinding.getDeclaringClass();
+				if (owner != null && JDT_CORE_TEST_CASE.equals(owner.getErasure().getQualifiedName())
+						&& FILTER_FIELDS.contains(declarationBinding.getName())) {
+					rejection[0]= "The family reads or writes JDT Core filter field " //$NON-NLS-1$
+							+ declarationBinding.getName()
+							+ "; execution conditions would retain excluded Jupiter nodes and change runtime-tree multiplicity."; //$NON-NLS-1$
+					return false;
+				}
+				return true;
+			}
+		});
+		return rejection[0];
 	}
 
 	private static String unsupportedHarnessInvocation(TypeDeclaration declaration, String suiteMethodKey) {

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessRewriteOperation.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessRewriteOperation.java
@@ -10,6 +10,10 @@
  *******************************************************************************/
 package org.sandbox.jdt.internal.corext.fix.multifile;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -32,358 +36,13 @@ import org.eclipse.text.edits.TextEditGroup;
 /** Applies exact source edits for the first direct JDT Core harness slice. */
 final class JdtCoreHarnessRewriteOperation extends CompilationUnitRewriteOperationWithSourceRange {
 
+	private static final String BRIDGE_RESOURCE=
+			"org/sandbox/jdt/internal/corext/fix/multifile/jdt-core-jupiter-bridge.java.template"; //$NON-NLS-1$
+
 	private enum Kind {
 		ADD_BRIDGE,
 		MIGRATE_FAMILY
 	}
-
-	private static final String JUPITER_BRIDGE_SOURCE= """
-			@org.junit.jupiter.api.TestMethodOrder(Jupiter.JdtCoreMethodOrderer.class)
-			@org.junit.jupiter.api.extension.ExtendWith(Jupiter.JdtCoreFilterCondition.class)
-			public abstract static class Jupiter extends org.eclipse.test.performance.PerformanceTestCaseJunit5 {
-				private String jdtCoreTestName;
-				private boolean jdtCoreIndexerDisabled;
-				private boolean jdtCoreFirstTest;
-
-				@Override
-				@org.junit.jupiter.api.BeforeEach
-				public void setUp(org.junit.jupiter.api.TestInfo testInfo) throws Exception {
-					super.setUp(testInfo);
-					this.jdtCoreTestName= testInfo.getTestMethod().map(java.lang.reflect.Method::getName)
-							.orElse(testInfo.getDisplayName());
-					this.jdtCoreIndexerDisabled= org.eclipse.jdt.core.JavaCore.getPlugin() != null
-							&& isIndexDisabledForTest();
-					if (this.jdtCoreIndexerDisabled) {
-						disableJdtCoreIndexer();
-					}
-
-					boolean firstRun= CURRENT_CLASS == null;
-					this.jdtCoreFirstTest= firstRun || CURRENT_CLASS != getClass();
-					if (this.jdtCoreFirstTest) {
-						if (CURRENT_CLASS != null && RUN_GC) {
-							runJdtCoreGarbageCollection();
-						}
-						CURRENT_CLASS= getClass();
-						CURRENT_CLASS_NAME= getClass().getName();
-						int marker= CURRENT_CLASS_NAME.indexOf(".tests.");
-						if (marker >= 0) {
-							CURRENT_CLASS_NAME= CURRENT_CLASS_NAME.substring(marker + 7);
-						}
-					}
-					if (STORE_MEMORY != null && MEM_LOG_FILE != null) {
-						if (firstRun) {
-							runJdtCoreGarbageCollection();
-						}
-						if (ALL_TESTS_LOG && MEM_LOG_FILE.exists()) {
-							writeMemoryStart();
-						} else if (firstRun) {
-							long total= Runtime.getRuntime().totalMemory();
-							long used= total - Runtime.getRuntime().freeMemory();
-							System.out.println("\talready used while starting: " + formatMemory(used));
-						}
-					}
-				}
-
-				@Override
-				@org.junit.jupiter.api.AfterEach
-				public void tearDown() throws Exception {
-					try {
-						super.tearDown();
-						if (this.jdtCoreIndexerDisabled) {
-							enableJdtCoreIndexer();
-						}
-						if (STORE_MEMORY != null && MEM_LOG_FILE != null
-								&& (this.jdtCoreFirstTest || ALL_TESTS_LOG) && MEM_LOG_FILE.exists()) {
-							writeMemoryEnd();
-						}
-					} finally {
-						Thread.interrupted();
-					}
-				}
-
-				public String getName() {
-					return this.jdtCoreTestName;
-				}
-
-				public boolean isIndexDisabledForTest() {
-					return true;
-				}
-
-				@Override
-				public void startMeasuring() {
-					super.startMeasuring();
-				}
-
-				@Override
-				public void stopMeasuring() {
-					super.stopMeasuring();
-				}
-
-				@Override
-				public void commitMeasurements() {
-					super.commitMeasurements();
-				}
-
-				@Override
-				public void assertPerformance() {
-					super.assertPerformance();
-				}
-
-				protected boolean isFirst() {
-					return this.jdtCoreFirstTest;
-				}
-
-				private void disableJdtCoreIndexer() {
-					while (org.eclipse.jdt.internal.core.JavaModelManager.getIndexManager().isEnabled()) {
-						org.eclipse.jdt.internal.core.JavaModelManager.getIndexManager().disable();
-					}
-				}
-
-				private void enableJdtCoreIndexer() {
-					while (!org.eclipse.jdt.internal.core.JavaModelManager.getIndexManager().isEnabled()) {
-						org.eclipse.jdt.internal.core.JavaModelManager.getIndexManager().enable();
-					}
-				}
-
-				private void runJdtCoreGarbageCollection() {
-					for (int iteration= 0; iteration < MAX_GC; iteration++) {
-						long before= Runtime.getRuntime().freeMemory();
-						System.gc();
-						long delta= Runtime.getRuntime().freeMemory() - before;
-						try {
-							Thread.sleep(TIME_GC);
-						} catch (InterruptedException exception) {
-							Thread.currentThread().interrupt();
-							return;
-						}
-						if (delta <= DELTA_GC) {
-							return;
-						}
-					}
-				}
-
-				private void writeMemoryStart() throws java.io.FileNotFoundException {
-					try (java.io.PrintStream stream= new java.io.PrintStream(
-							new java.io.FileOutputStream(MEM_LOG_FILE, true))) {
-						stream.print(CURRENT_CLASS_NAME);
-						stream.print('\t');
-						stream.print(this.jdtCoreTestName);
-						stream.print('\t');
-						writeMemoryValues(stream);
-					}
-				}
-
-				private void writeMemoryEnd() throws java.io.FileNotFoundException {
-					try (java.io.PrintStream stream= new java.io.PrintStream(
-							new java.io.FileOutputStream(MEM_LOG_FILE, true))) {
-						stream.print(CURRENT_CLASS_NAME);
-						stream.print('\t');
-						if (ALL_TESTS_LOG) {
-							stream.print(".".repeat(Math.max(0, this.jdtCoreTestName.length() - 4)));
-							stream.print("end:\t");
-						}
-						writeMemoryValues(stream);
-					}
-				}
-
-				private static void writeMemoryValues(java.io.PrintStream stream) {
-					long total= Runtime.getRuntime().totalMemory();
-					long used= total - Runtime.getRuntime().freeMemory();
-					stream.print(formatMemory(used));
-					stream.print('\t');
-					stream.print(formatMemory(total));
-					stream.print('\t');
-					stream.println(formatMemory(Runtime.getRuntime().maxMemory()));
-				}
-
-				private static String formatMemory(long number) {
-					long quotient= number;
-					int[] values= new int[10];
-					int position= -1;
-					do {
-						long current= quotient;
-						quotient= current / 1000L;
-						values[++position]= (int) (current - quotient * 1000L);
-					} while (quotient > 0 && position + 1 < values.length);
-					StringBuilder result= new StringBuilder(Integer.toString(values[position]));
-					for (int index= position - 1; index >= 0; index--) {
-						result.append(',').append(String.format(java.util.Locale.ROOT, "%03d", values[index]));
-					}
-					return result.toString();
-				}
-
-				public static final class JdtCoreFilterCondition
-						implements org.junit.jupiter.api.extension.ExecutionCondition {
-					@Override
-					public org.junit.jupiter.api.extension.ConditionEvaluationResult evaluateExecutionCondition(
-							org.junit.jupiter.api.extension.ExtensionContext context) {
-						java.util.Optional<java.lang.reflect.Method> selected= context.getTestMethod();
-						if (selected.isEmpty()) {
-							return org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled("container");
-						}
-						String name= selected.orElseThrow().getName();
-						java.util.List<String> testNames= java.util.Arrays.stream(context.getRequiredTestClass().getMethods())
-								.filter(method -> java.lang.reflect.Modifier.isPublic(method.getModifiers()))
-								.filter(method -> !java.lang.reflect.Modifier.isStatic(method.getModifiers()))
-								.map(java.lang.reflect.Method::getName)
-								.filter(candidate -> candidate.startsWith(METHOD_PREFIX)).distinct().toList();
-						java.util.List<String> onlyNames= RUN_ONLY_ID == null ? java.util.List.of()
-								: testNames.stream().filter(candidate -> candidate.substring(METHOD_PREFIX.length())
-										.startsWith(RUN_ONLY_ID)).toList();
-						boolean enabled= onlyNames.isEmpty() ? selectedByConfiguredFilter(name) : onlyNames.contains(name);
-						return enabled
-								? org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled("selected by JDT Core filter")
-								: org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled("excluded by JDT Core filter");
-					}
-
-					private static boolean selectedByConfiguredFilter(String name) {
-						if (TESTS_PREFIX == null && TESTS_NAMES == null && TESTS_NUMBERS == null && TESTS_RANGE == null) {
-							return true;
-						}
-						if (TESTS_PREFIX != null && !name.startsWith(TESTS_PREFIX)) {
-							return false;
-						}
-						if (TESTS_NAMES != null && java.util.Arrays.stream(TESTS_NAMES).anyMatch(name::contains)) {
-							return true;
-						}
-						int number= testNumber(name);
-						if (TESTS_NUMBERS != null && java.util.Arrays.stream(TESTS_NUMBERS)
-								.anyMatch(candidate -> candidate == number)) {
-							return true;
-						}
-						if (TESTS_RANGE != null && TESTS_RANGE.length == 2 && number >= 0
-								&& (TESTS_RANGE[0] == -1 || number >= TESTS_RANGE[0])
-								&& (TESTS_RANGE[1] == -1 || number <= TESTS_RANGE[1])) {
-							return true;
-						}
-						return TESTS_NAMES == null && TESTS_NUMBERS == null && TESTS_RANGE == null;
-					}
-
-					private static int testNumber(String name) {
-						int index= TESTS_PREFIX == null ? METHOD_PREFIX.length() : TESTS_PREFIX.length();
-						while (index < name.length() && !Character.isDigit(name.charAt(index))) {
-							index++;
-						}
-						while (index < name.length() && name.charAt(index) == '0') {
-							index++;
-						}
-						int end= index;
-						while (end < name.length() && Character.isDigit(name.charAt(end))) {
-							end++;
-						}
-						if (end == index) {
-							return -1;
-						}
-						try {
-							return Integer.parseInt(name.substring(index, end));
-						} catch (NumberFormatException exception) {
-							return -1;
-						}
-					}
-				}
-
-				public static final class JdtCoreMethodOrderer implements org.junit.jupiter.api.MethodOrderer {
-					@Override
-					public void orderMethods(org.junit.jupiter.api.MethodOrdererContext context) {
-						if (ORDERING == ALPHA_REVERSE_SORT) {
-							context.getMethodDescriptors().sort((left, right) -> right.getMethod().getName()
-									.compareTo(left.getMethod().getName()));
-						} else if (ORDERING == ALPHABETICAL_SORT || ORDERING == NO_ORDER) {
-							context.getMethodDescriptors().sort((left, right) -> left.getMethod().getName()
-									.compareTo(right.getMethod().getName()));
-						} else if (ORDERING == BYTECODE_DECLARATION_ORDER) {
-							try {
-								java.util.List<String> ordered= bytecodeDeclaredTestNames(context.getTestClass());
-								context.getMethodDescriptors().sort(java.util.Comparator.comparingInt(descriptor -> {
-									int index= ordered.indexOf(descriptor.getMethod().getName());
-									return index < 0 ? Integer.MAX_VALUE : index;
-								}));
-							} catch (java.io.IOException exception) {
-								context.getMethodDescriptors().sort((left, right) -> left.getMethod().getName()
-										.compareTo(right.getMethod().getName()));
-							}
-						} else {
-							java.util.Collections.shuffle(context.getMethodDescriptors(), new java.util.Random(ORDERING));
-						}
-					}
-				}
-
-				private static java.util.List<String> bytecodeDeclaredTestNames(Class<?> testClass)
-						throws java.io.IOException {
-					String simpleName= testClass.getName().substring(testClass.getName().lastIndexOf('.') + 1);
-					try (java.io.DataInputStream input= new java.io.DataInputStream(new java.io.BufferedInputStream(
-							testClass.getResourceAsStream(simpleName + ".class")))) {
-						if (input.readInt() != 0xcafebabe) {
-							throw new java.io.IOException("Invalid classfile magic");
-						}
-						input.readUnsignedShort();
-						input.readUnsignedShort();
-						int constantPoolCount= input.readUnsignedShort();
-						String[] utf8= new String[constantPoolCount];
-						for (int index= 1; index < constantPoolCount; index++) {
-							int tag= input.readUnsignedByte();
-							switch (tag) {
-							case 1 -> utf8[index]= input.readUTF();
-							case 3, 4 -> skipFully(input, 4);
-							case 5, 6 -> { skipFully(input, 8); index++; }
-							case 7, 8, 16, 19, 20 -> skipFully(input, 2);
-							case 9, 10, 11, 12, 17, 18 -> skipFully(input, 4);
-							case 15 -> skipFully(input, 3);
-							default -> throw new java.io.IOException("Unknown constant-pool tag " + tag);
-							}
-						}
-						skipFully(input, 6);
-						int interfaces= input.readUnsignedShort();
-						skipFully(input, interfaces * 2L);
-						int fields= input.readUnsignedShort();
-						for (int index= 0; index < fields; index++) {
-							skipMember(input);
-						}
-						int methods= input.readUnsignedShort();
-						java.util.List<String> result= new java.util.ArrayList<>();
-						for (int index= 0; index < methods; index++) {
-							int access= input.readUnsignedShort();
-							String name= utf8[input.readUnsignedShort()];
-							String descriptor= utf8[input.readUnsignedShort()];
-							int attributes= input.readUnsignedShort();
-							for (int attribute= 0; attribute < attributes; attribute++) {
-								input.readUnsignedShort();
-								skipFully(input, Integer.toUnsignedLong(input.readInt()));
-							}
-							if ((access & java.lang.reflect.Modifier.PUBLIC) != 0
-									&& (access & java.lang.reflect.Modifier.STATIC) == 0
-									&& "()V".equals(descriptor) && name.startsWith(METHOD_PREFIX)) {
-								result.add(name);
-							}
-						}
-						return result;
-					}
-				}
-
-				private static void skipMember(java.io.DataInputStream input) throws java.io.IOException {
-					skipFully(input, 6);
-					int attributes= input.readUnsignedShort();
-					for (int attribute= 0; attribute < attributes; attribute++) {
-						input.readUnsignedShort();
-						skipFully(input, Integer.toUnsignedLong(input.readInt()));
-					}
-				}
-
-				private static void skipFully(java.io.DataInputStream input, long count) throws java.io.IOException {
-					long remaining= count;
-					while (remaining > 0) {
-						long skipped= input.skip(remaining);
-						if (skipped <= 0) {
-							if (input.read() < 0) {
-								throw new java.io.IOException("Unexpected end of classfile");
-							}
-							skipped= 1;
-						}
-						remaining-= skipped;
-					}
-				}
-			}
-			""";
 
 	private final Kind kind;
 	private final TypeDeclaration type;
@@ -411,7 +70,7 @@ final class JdtCoreHarnessRewriteOperation extends CompilationUnitRewriteOperati
 	public void rewriteASTInternal(CompilationUnitRewrite cuRewrite, LinkedProposalModelCore linkedModel)
 			throws CoreException {
 		if (type == null) {
-			throw failure("The planned JDT Core harness type is missing"); //$NON-NLS-1$
+			throw failure("The planned JDT Core harness type is missing", null); //$NON-NLS-1$
 		}
 		TextEditGroup group= createTextEditGroup(kind == Kind.ADD_BRIDGE
 				? "Add the JDT Core Jupiter compatibility bridge" //$NON-NLS-1$
@@ -427,15 +86,15 @@ final class JdtCoreHarnessRewriteOperation extends CompilationUnitRewriteOperati
 		ITypeBinding binding= type.resolveBinding();
 		if (binding == null || !JdtCoreHarnessPlanner.JDT_CORE_TEST_CASE.equals(
 				binding.getErasure().getQualifiedName())) {
-			throw failure("The planned bridge target is not the JDT Core custom TestCase"); //$NON-NLS-1$
+			throw failure("The planned bridge target is not the JDT Core custom TestCase", null); //$NON-NLS-1$
 		}
 		for (TypeDeclaration nested : type.getTypes()) {
 			if ("Jupiter".equals(nested.getName().getIdentifier())) { //$NON-NLS-1$
-				throw failure("The JDT Core TestCase already contains a Jupiter bridge"); //$NON-NLS-1$
+				throw failure("The JDT Core TestCase already contains a Jupiter bridge", null); //$NON-NLS-1$
 			}
 		}
 		ASTRewrite rewrite= cuRewrite.getASTRewrite();
-		ASTNode placeholder= rewrite.createStringPlaceholder(JUPITER_BRIDGE_SOURCE, ASTNode.TYPE_DECLARATION);
+		ASTNode placeholder= rewrite.createStringPlaceholder(loadBridgeSource(), ASTNode.TYPE_DECLARATION);
 		ListRewrite members= rewrite.getListRewrite(type, TypeDeclaration.BODY_DECLARATIONS_PROPERTY);
 		members.insertLast(placeholder, group);
 	}
@@ -445,14 +104,15 @@ final class JdtCoreHarnessRewriteOperation extends CompilationUnitRewriteOperati
 		ITypeBinding binding= superclass == null ? null : superclass.resolveBinding();
 		if (binding == null || !JdtCoreHarnessPlanner.JDT_CORE_TEST_CASE.equals(
 				binding.getErasure().getQualifiedName())) {
-			throw failure("The direct family no longer extends the expected JDT Core TestCase"); //$NON-NLS-1$
+			throw failure("The direct family no longer extends the expected JDT Core TestCase", null); //$NON-NLS-1$
 		}
 		if (constructor == null) {
-			throw failure("The planned JDT Core String constructor is missing"); //$NON-NLS-1$
+			throw failure("The planned JDT Core String constructor is missing", null); //$NON-NLS-1$
 		}
 		ASTRewrite rewrite= cuRewrite.getASTRewrite();
 		AST ast= cuRewrite.getRoot().getAST();
-		SimpleType replacement= ast.newSimpleType(ast.newName("TestCase.Jupiter")); //$NON-NLS-1$
+		String harnessName= cuRewrite.getImportRewrite().addImport(JdtCoreHarnessPlanner.JDT_CORE_TEST_CASE);
+		SimpleType replacement= ast.newSimpleType(ast.newName(harnessName + ".Jupiter")); //$NON-NLS-1$
 		rewrite.replace(superclass, replacement, group);
 		rewrite.remove(constructor, group);
 		cuRewrite.getImportRemover().registerRemovedNode(constructor);
@@ -470,7 +130,19 @@ final class JdtCoreHarnessRewriteOperation extends CompilationUnitRewriteOperati
 				: "Moves one closed direct JDT Core TestCase family to the nested Jupiter bridge."; //$NON-NLS-1$
 	}
 
-	private static CoreException failure(String message) {
-		return new CoreException(new Status(IStatus.ERROR, "sandbox_junit_cleanup", message)); //$NON-NLS-1$
+	private static String loadBridgeSource() throws CoreException {
+		try (InputStream stream= JdtCoreHarnessRewriteOperation.class.getClassLoader()
+				.getResourceAsStream(BRIDGE_RESOURCE)) {
+			if (stream == null) {
+				throw new IOException("Missing resource " + BRIDGE_RESOURCE); //$NON-NLS-1$
+			}
+			return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+		} catch (IOException exception) {
+			throw failure("Cannot load the JDT Core Jupiter bridge source template", exception); //$NON-NLS-1$
+		}
+	}
+
+	private static CoreException failure(String message, Throwable cause) {
+		return new CoreException(new Status(IStatus.ERROR, "sandbox_junit_cleanup", message, cause)); //$NON-NLS-1$
 	}
 }

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessRewriteOperation.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessRewriteOperation.java
@@ -23,6 +23,7 @@ import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.SimpleType;
+import org.eclipse.jdt.core.dom.SingleMemberAnnotation;
 import org.eclipse.jdt.core.dom.Type;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
@@ -114,6 +115,15 @@ final class JdtCoreHarnessRewriteOperation extends CompilationUnitRewriteOperati
 		String harnessName= cuRewrite.getImportRewrite().addImport(JdtCoreHarnessPlanner.JDT_CORE_TEST_CASE);
 		SimpleType replacement= ast.newSimpleType(ast.newName(harnessName + ".Jupiter")); //$NON-NLS-1$
 		rewrite.replace(superclass, replacement, group);
+
+		String executionName= cuRewrite.getImportRewrite().addImport("org.junit.jupiter.api.parallel.Execution"); //$NON-NLS-1$
+		String modeName= cuRewrite.getImportRewrite().addImport("org.junit.jupiter.api.parallel.ExecutionMode"); //$NON-NLS-1$
+		SingleMemberAnnotation execution= ast.newSingleMemberAnnotation();
+		execution.setTypeName(ast.newName(executionName));
+		execution.setValue(ast.newName(modeName + ".SAME_THREAD")); //$NON-NLS-1$
+		ListRewrite modifiers= rewrite.getListRewrite(type, TypeDeclaration.MODIFIERS2_PROPERTY);
+		modifiers.insertFirst(execution, group);
+
 		rewrite.remove(constructor, group);
 		cuRewrite.getImportRemover().registerRemovedNode(constructor);
 		if (localSuite != null) {
@@ -127,7 +137,7 @@ final class JdtCoreHarnessRewriteOperation extends CompilationUnitRewriteOperati
 	public String getAdditionalInfo() {
 		return kind == Kind.ADD_BRIDGE
 				? "Adds a nested Jupiter bridge while retaining the original JUnit 3 harness for unmigrated families." //$NON-NLS-1$
-				: "Moves one closed direct JDT Core TestCase family to the nested Jupiter bridge."; //$NON-NLS-1$
+				: "Moves one closed direct JDT Core TestCase family to the nested Jupiter bridge on one thread."; //$NON-NLS-1$
 	}
 
 	private static String loadBridgeSource() throws CoreException {

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessRewriteOperation.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessRewriteOperation.java
@@ -1,0 +1,476 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.corext.fix.multifile;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.SimpleType;
+import org.eclipse.jdt.core.dom.Type;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
+import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
+import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
+
+import org.eclipse.text.edits.TextEditGroup;
+
+/** Applies exact source edits for the first direct JDT Core harness slice. */
+final class JdtCoreHarnessRewriteOperation extends CompilationUnitRewriteOperationWithSourceRange {
+
+	private enum Kind {
+		ADD_BRIDGE,
+		MIGRATE_FAMILY
+	}
+
+	private static final String JUPITER_BRIDGE_SOURCE= """
+			@org.junit.jupiter.api.TestMethodOrder(Jupiter.JdtCoreMethodOrderer.class)
+			@org.junit.jupiter.api.extension.ExtendWith(Jupiter.JdtCoreFilterCondition.class)
+			public abstract static class Jupiter extends org.eclipse.test.performance.PerformanceTestCaseJunit5 {
+				private String jdtCoreTestName;
+				private boolean jdtCoreIndexerDisabled;
+				private boolean jdtCoreFirstTest;
+
+				@Override
+				@org.junit.jupiter.api.BeforeEach
+				public void setUp(org.junit.jupiter.api.TestInfo testInfo) throws Exception {
+					super.setUp(testInfo);
+					this.jdtCoreTestName= testInfo.getTestMethod().map(java.lang.reflect.Method::getName)
+							.orElse(testInfo.getDisplayName());
+					this.jdtCoreIndexerDisabled= org.eclipse.jdt.core.JavaCore.getPlugin() != null
+							&& isIndexDisabledForTest();
+					if (this.jdtCoreIndexerDisabled) {
+						disableJdtCoreIndexer();
+					}
+
+					boolean firstRun= CURRENT_CLASS == null;
+					this.jdtCoreFirstTest= firstRun || CURRENT_CLASS != getClass();
+					if (this.jdtCoreFirstTest) {
+						if (CURRENT_CLASS != null && RUN_GC) {
+							runJdtCoreGarbageCollection();
+						}
+						CURRENT_CLASS= getClass();
+						CURRENT_CLASS_NAME= getClass().getName();
+						int marker= CURRENT_CLASS_NAME.indexOf(".tests.");
+						if (marker >= 0) {
+							CURRENT_CLASS_NAME= CURRENT_CLASS_NAME.substring(marker + 7);
+						}
+					}
+					if (STORE_MEMORY != null && MEM_LOG_FILE != null) {
+						if (firstRun) {
+							runJdtCoreGarbageCollection();
+						}
+						if (ALL_TESTS_LOG && MEM_LOG_FILE.exists()) {
+							writeMemoryStart();
+						} else if (firstRun) {
+							long total= Runtime.getRuntime().totalMemory();
+							long used= total - Runtime.getRuntime().freeMemory();
+							System.out.println("\talready used while starting: " + formatMemory(used));
+						}
+					}
+				}
+
+				@Override
+				@org.junit.jupiter.api.AfterEach
+				public void tearDown() throws Exception {
+					try {
+						super.tearDown();
+						if (this.jdtCoreIndexerDisabled) {
+							enableJdtCoreIndexer();
+						}
+						if (STORE_MEMORY != null && MEM_LOG_FILE != null
+								&& (this.jdtCoreFirstTest || ALL_TESTS_LOG) && MEM_LOG_FILE.exists()) {
+							writeMemoryEnd();
+						}
+					} finally {
+						Thread.interrupted();
+					}
+				}
+
+				public String getName() {
+					return this.jdtCoreTestName;
+				}
+
+				public boolean isIndexDisabledForTest() {
+					return true;
+				}
+
+				@Override
+				public void startMeasuring() {
+					super.startMeasuring();
+				}
+
+				@Override
+				public void stopMeasuring() {
+					super.stopMeasuring();
+				}
+
+				@Override
+				public void commitMeasurements() {
+					super.commitMeasurements();
+				}
+
+				@Override
+				public void assertPerformance() {
+					super.assertPerformance();
+				}
+
+				protected boolean isFirst() {
+					return this.jdtCoreFirstTest;
+				}
+
+				private void disableJdtCoreIndexer() {
+					while (org.eclipse.jdt.internal.core.JavaModelManager.getIndexManager().isEnabled()) {
+						org.eclipse.jdt.internal.core.JavaModelManager.getIndexManager().disable();
+					}
+				}
+
+				private void enableJdtCoreIndexer() {
+					while (!org.eclipse.jdt.internal.core.JavaModelManager.getIndexManager().isEnabled()) {
+						org.eclipse.jdt.internal.core.JavaModelManager.getIndexManager().enable();
+					}
+				}
+
+				private void runJdtCoreGarbageCollection() {
+					for (int iteration= 0; iteration < MAX_GC; iteration++) {
+						long before= Runtime.getRuntime().freeMemory();
+						System.gc();
+						long delta= Runtime.getRuntime().freeMemory() - before;
+						try {
+							Thread.sleep(TIME_GC);
+						} catch (InterruptedException exception) {
+							Thread.currentThread().interrupt();
+							return;
+						}
+						if (delta <= DELTA_GC) {
+							return;
+						}
+					}
+				}
+
+				private void writeMemoryStart() throws java.io.FileNotFoundException {
+					try (java.io.PrintStream stream= new java.io.PrintStream(
+							new java.io.FileOutputStream(MEM_LOG_FILE, true))) {
+						stream.print(CURRENT_CLASS_NAME);
+						stream.print('\t');
+						stream.print(this.jdtCoreTestName);
+						stream.print('\t');
+						writeMemoryValues(stream);
+					}
+				}
+
+				private void writeMemoryEnd() throws java.io.FileNotFoundException {
+					try (java.io.PrintStream stream= new java.io.PrintStream(
+							new java.io.FileOutputStream(MEM_LOG_FILE, true))) {
+						stream.print(CURRENT_CLASS_NAME);
+						stream.print('\t');
+						if (ALL_TESTS_LOG) {
+							stream.print(".".repeat(Math.max(0, this.jdtCoreTestName.length() - 4)));
+							stream.print("end:\t");
+						}
+						writeMemoryValues(stream);
+					}
+				}
+
+				private static void writeMemoryValues(java.io.PrintStream stream) {
+					long total= Runtime.getRuntime().totalMemory();
+					long used= total - Runtime.getRuntime().freeMemory();
+					stream.print(formatMemory(used));
+					stream.print('\t');
+					stream.print(formatMemory(total));
+					stream.print('\t');
+					stream.println(formatMemory(Runtime.getRuntime().maxMemory()));
+				}
+
+				private static String formatMemory(long number) {
+					long quotient= number;
+					int[] values= new int[10];
+					int position= -1;
+					do {
+						long current= quotient;
+						quotient= current / 1000L;
+						values[++position]= (int) (current - quotient * 1000L);
+					} while (quotient > 0 && position + 1 < values.length);
+					StringBuilder result= new StringBuilder(Integer.toString(values[position]));
+					for (int index= position - 1; index >= 0; index--) {
+						result.append(',').append(String.format(java.util.Locale.ROOT, "%03d", values[index]));
+					}
+					return result.toString();
+				}
+
+				public static final class JdtCoreFilterCondition
+						implements org.junit.jupiter.api.extension.ExecutionCondition {
+					@Override
+					public org.junit.jupiter.api.extension.ConditionEvaluationResult evaluateExecutionCondition(
+							org.junit.jupiter.api.extension.ExtensionContext context) {
+						java.util.Optional<java.lang.reflect.Method> selected= context.getTestMethod();
+						if (selected.isEmpty()) {
+							return org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled("container");
+						}
+						String name= selected.orElseThrow().getName();
+						java.util.List<String> testNames= java.util.Arrays.stream(context.getRequiredTestClass().getMethods())
+								.filter(method -> java.lang.reflect.Modifier.isPublic(method.getModifiers()))
+								.filter(method -> !java.lang.reflect.Modifier.isStatic(method.getModifiers()))
+								.map(java.lang.reflect.Method::getName)
+								.filter(candidate -> candidate.startsWith(METHOD_PREFIX)).distinct().toList();
+						java.util.List<String> onlyNames= RUN_ONLY_ID == null ? java.util.List.of()
+								: testNames.stream().filter(candidate -> candidate.substring(METHOD_PREFIX.length())
+										.startsWith(RUN_ONLY_ID)).toList();
+						boolean enabled= onlyNames.isEmpty() ? selectedByConfiguredFilter(name) : onlyNames.contains(name);
+						return enabled
+								? org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled("selected by JDT Core filter")
+								: org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled("excluded by JDT Core filter");
+					}
+
+					private static boolean selectedByConfiguredFilter(String name) {
+						if (TESTS_PREFIX == null && TESTS_NAMES == null && TESTS_NUMBERS == null && TESTS_RANGE == null) {
+							return true;
+						}
+						if (TESTS_PREFIX != null && !name.startsWith(TESTS_PREFIX)) {
+							return false;
+						}
+						if (TESTS_NAMES != null && java.util.Arrays.stream(TESTS_NAMES).anyMatch(name::contains)) {
+							return true;
+						}
+						int number= testNumber(name);
+						if (TESTS_NUMBERS != null && java.util.Arrays.stream(TESTS_NUMBERS)
+								.anyMatch(candidate -> candidate == number)) {
+							return true;
+						}
+						if (TESTS_RANGE != null && TESTS_RANGE.length == 2 && number >= 0
+								&& (TESTS_RANGE[0] == -1 || number >= TESTS_RANGE[0])
+								&& (TESTS_RANGE[1] == -1 || number <= TESTS_RANGE[1])) {
+							return true;
+						}
+						return TESTS_NAMES == null && TESTS_NUMBERS == null && TESTS_RANGE == null;
+					}
+
+					private static int testNumber(String name) {
+						int index= TESTS_PREFIX == null ? METHOD_PREFIX.length() : TESTS_PREFIX.length();
+						while (index < name.length() && !Character.isDigit(name.charAt(index))) {
+							index++;
+						}
+						while (index < name.length() && name.charAt(index) == '0') {
+							index++;
+						}
+						int end= index;
+						while (end < name.length() && Character.isDigit(name.charAt(end))) {
+							end++;
+						}
+						if (end == index) {
+							return -1;
+						}
+						try {
+							return Integer.parseInt(name.substring(index, end));
+						} catch (NumberFormatException exception) {
+							return -1;
+						}
+					}
+				}
+
+				public static final class JdtCoreMethodOrderer implements org.junit.jupiter.api.MethodOrderer {
+					@Override
+					public void orderMethods(org.junit.jupiter.api.MethodOrdererContext context) {
+						if (ORDERING == ALPHA_REVERSE_SORT) {
+							context.getMethodDescriptors().sort((left, right) -> right.getMethod().getName()
+									.compareTo(left.getMethod().getName()));
+						} else if (ORDERING == ALPHABETICAL_SORT || ORDERING == NO_ORDER) {
+							context.getMethodDescriptors().sort((left, right) -> left.getMethod().getName()
+									.compareTo(right.getMethod().getName()));
+						} else if (ORDERING == BYTECODE_DECLARATION_ORDER) {
+							try {
+								java.util.List<String> ordered= bytecodeDeclaredTestNames(context.getTestClass());
+								context.getMethodDescriptors().sort(java.util.Comparator.comparingInt(descriptor -> {
+									int index= ordered.indexOf(descriptor.getMethod().getName());
+									return index < 0 ? Integer.MAX_VALUE : index;
+								}));
+							} catch (java.io.IOException exception) {
+								context.getMethodDescriptors().sort((left, right) -> left.getMethod().getName()
+										.compareTo(right.getMethod().getName()));
+							}
+						} else {
+							java.util.Collections.shuffle(context.getMethodDescriptors(), new java.util.Random(ORDERING));
+						}
+					}
+				}
+
+				private static java.util.List<String> bytecodeDeclaredTestNames(Class<?> testClass)
+						throws java.io.IOException {
+					String simpleName= testClass.getName().substring(testClass.getName().lastIndexOf('.') + 1);
+					try (java.io.DataInputStream input= new java.io.DataInputStream(new java.io.BufferedInputStream(
+							testClass.getResourceAsStream(simpleName + ".class")))) {
+						if (input.readInt() != 0xcafebabe) {
+							throw new java.io.IOException("Invalid classfile magic");
+						}
+						input.readUnsignedShort();
+						input.readUnsignedShort();
+						int constantPoolCount= input.readUnsignedShort();
+						String[] utf8= new String[constantPoolCount];
+						for (int index= 1; index < constantPoolCount; index++) {
+							int tag= input.readUnsignedByte();
+							switch (tag) {
+							case 1 -> utf8[index]= input.readUTF();
+							case 3, 4 -> skipFully(input, 4);
+							case 5, 6 -> { skipFully(input, 8); index++; }
+							case 7, 8, 16, 19, 20 -> skipFully(input, 2);
+							case 9, 10, 11, 12, 17, 18 -> skipFully(input, 4);
+							case 15 -> skipFully(input, 3);
+							default -> throw new java.io.IOException("Unknown constant-pool tag " + tag);
+							}
+						}
+						skipFully(input, 6);
+						int interfaces= input.readUnsignedShort();
+						skipFully(input, interfaces * 2L);
+						int fields= input.readUnsignedShort();
+						for (int index= 0; index < fields; index++) {
+							skipMember(input);
+						}
+						int methods= input.readUnsignedShort();
+						java.util.List<String> result= new java.util.ArrayList<>();
+						for (int index= 0; index < methods; index++) {
+							int access= input.readUnsignedShort();
+							String name= utf8[input.readUnsignedShort()];
+							String descriptor= utf8[input.readUnsignedShort()];
+							int attributes= input.readUnsignedShort();
+							for (int attribute= 0; attribute < attributes; attribute++) {
+								input.readUnsignedShort();
+								skipFully(input, Integer.toUnsignedLong(input.readInt()));
+							}
+							if ((access & java.lang.reflect.Modifier.PUBLIC) != 0
+									&& (access & java.lang.reflect.Modifier.STATIC) == 0
+									&& "()V".equals(descriptor) && name.startsWith(METHOD_PREFIX)) {
+								result.add(name);
+							}
+						}
+						return result;
+					}
+				}
+
+				private static void skipMember(java.io.DataInputStream input) throws java.io.IOException {
+					skipFully(input, 6);
+					int attributes= input.readUnsignedShort();
+					for (int attribute= 0; attribute < attributes; attribute++) {
+						input.readUnsignedShort();
+						skipFully(input, Integer.toUnsignedLong(input.readInt()));
+					}
+				}
+
+				private static void skipFully(java.io.DataInputStream input, long count) throws java.io.IOException {
+					long remaining= count;
+					while (remaining > 0) {
+						long skipped= input.skip(remaining);
+						if (skipped <= 0) {
+							if (input.read() < 0) {
+								throw new java.io.IOException("Unexpected end of classfile");
+							}
+							skipped= 1;
+						}
+						remaining-= skipped;
+					}
+				}
+			}
+			""";
+
+	private final Kind kind;
+	private final TypeDeclaration type;
+	private final MethodDeclaration constructor;
+	private final MethodDeclaration localSuite;
+
+	private JdtCoreHarnessRewriteOperation(Kind kind, TypeDeclaration type,
+			MethodDeclaration constructor, MethodDeclaration localSuite) {
+		this.kind= kind;
+		this.type= type;
+		this.constructor= constructor;
+		this.localSuite= localSuite;
+	}
+
+	static JdtCoreHarnessRewriteOperation addBridge(TypeDeclaration harnessType) {
+		return new JdtCoreHarnessRewriteOperation(Kind.ADD_BRIDGE, harnessType, null, null);
+	}
+
+	static JdtCoreHarnessRewriteOperation migrateFamily(TypeDeclaration familyType,
+			MethodDeclaration constructor, MethodDeclaration localSuite) {
+		return new JdtCoreHarnessRewriteOperation(Kind.MIGRATE_FAMILY, familyType, constructor, localSuite);
+	}
+
+	@Override
+	public void rewriteASTInternal(CompilationUnitRewrite cuRewrite, LinkedProposalModelCore linkedModel)
+			throws CoreException {
+		if (type == null) {
+			throw failure("The planned JDT Core harness type is missing"); //$NON-NLS-1$
+		}
+		TextEditGroup group= createTextEditGroup(kind == Kind.ADD_BRIDGE
+				? "Add the JDT Core Jupiter compatibility bridge" //$NON-NLS-1$
+				: "Migrate a direct JDT Core TestCase family to Jupiter", cuRewrite); //$NON-NLS-1$
+		if (kind == Kind.ADD_BRIDGE) {
+			addBridge(cuRewrite, group);
+		} else {
+			migrateFamily(cuRewrite, group);
+		}
+	}
+
+	private void addBridge(CompilationUnitRewrite cuRewrite, TextEditGroup group) throws CoreException {
+		ITypeBinding binding= type.resolveBinding();
+		if (binding == null || !JdtCoreHarnessPlanner.JDT_CORE_TEST_CASE.equals(
+				binding.getErasure().getQualifiedName())) {
+			throw failure("The planned bridge target is not the JDT Core custom TestCase"); //$NON-NLS-1$
+		}
+		for (TypeDeclaration nested : type.getTypes()) {
+			if ("Jupiter".equals(nested.getName().getIdentifier())) { //$NON-NLS-1$
+				throw failure("The JDT Core TestCase already contains a Jupiter bridge"); //$NON-NLS-1$
+			}
+		}
+		ASTRewrite rewrite= cuRewrite.getASTRewrite();
+		ASTNode placeholder= rewrite.createStringPlaceholder(JUPITER_BRIDGE_SOURCE, ASTNode.TYPE_DECLARATION);
+		ListRewrite members= rewrite.getListRewrite(type, TypeDeclaration.BODY_DECLARATIONS_PROPERTY);
+		members.insertLast(placeholder, group);
+	}
+
+	private void migrateFamily(CompilationUnitRewrite cuRewrite, TextEditGroup group) throws CoreException {
+		Type superclass= type.getSuperclassType();
+		ITypeBinding binding= superclass == null ? null : superclass.resolveBinding();
+		if (binding == null || !JdtCoreHarnessPlanner.JDT_CORE_TEST_CASE.equals(
+				binding.getErasure().getQualifiedName())) {
+			throw failure("The direct family no longer extends the expected JDT Core TestCase"); //$NON-NLS-1$
+		}
+		if (constructor == null) {
+			throw failure("The planned JDT Core String constructor is missing"); //$NON-NLS-1$
+		}
+		ASTRewrite rewrite= cuRewrite.getASTRewrite();
+		AST ast= cuRewrite.getRoot().getAST();
+		SimpleType replacement= ast.newSimpleType(ast.newName("TestCase.Jupiter")); //$NON-NLS-1$
+		rewrite.replace(superclass, replacement, group);
+		rewrite.remove(constructor, group);
+		cuRewrite.getImportRemover().registerRemovedNode(constructor);
+		if (localSuite != null) {
+			rewrite.remove(localSuite, group);
+			cuRewrite.getImportRemover().registerRemovedNode(localSuite);
+		}
+		cuRewrite.getImportRemover().applyRemoves(cuRewrite.getImportRewrite());
+	}
+
+	@Override
+	public String getAdditionalInfo() {
+		return kind == Kind.ADD_BRIDGE
+				? "Adds a nested Jupiter bridge while retaining the original JUnit 3 harness for unmigrated families." //$NON-NLS-1$
+				: "Moves one closed direct JDT Core TestCase family to the nested Jupiter bridge."; //$NON-NLS-1$
+	}
+
+	private static CoreException failure(String message) {
+		return new CoreException(new Status(IStatus.ERROR, "sandbox_junit_cleanup", message)); //$NON-NLS-1$
+	}
+}

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessRewriteOperation.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessRewriteOperation.java
@@ -21,9 +21,12 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.MemberValuePair;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.NormalAnnotation;
 import org.eclipse.jdt.core.dom.SimpleType;
 import org.eclipse.jdt.core.dom.SingleMemberAnnotation;
+import org.eclipse.jdt.core.dom.StringLiteral;
 import org.eclipse.jdt.core.dom.Type;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
@@ -39,6 +42,7 @@ final class JdtCoreHarnessRewriteOperation extends CompilationUnitRewriteOperati
 
 	private static final String BRIDGE_RESOURCE=
 			"org/sandbox/jdt/internal/corext/fix/multifile/jdt-core-jupiter-bridge.java.template"; //$NON-NLS-1$
+	private static final String GLOBAL_HARNESS_LOCK= JdtCoreHarnessPlanner.JDT_CORE_TEST_CASE;
 
 	private enum Kind {
 		ADD_BRIDGE,
@@ -100,6 +104,7 @@ final class JdtCoreHarnessRewriteOperation extends CompilationUnitRewriteOperati
 		members.insertLast(placeholder, group);
 	}
 
+	@SuppressWarnings("unchecked")
 	private void migrateFamily(CompilationUnitRewrite cuRewrite, TextEditGroup group) throws CoreException {
 		Type superclass= type.getSuperclassType();
 		ITypeBinding binding= superclass == null ? null : superclass.resolveBinding();
@@ -121,7 +126,25 @@ final class JdtCoreHarnessRewriteOperation extends CompilationUnitRewriteOperati
 		SingleMemberAnnotation execution= ast.newSingleMemberAnnotation();
 		execution.setTypeName(ast.newName(executionName));
 		execution.setValue(ast.newName(modeName + ".SAME_THREAD")); //$NON-NLS-1$
+
+		String lockName= cuRewrite.getImportRewrite().addImport("org.junit.jupiter.api.parallel.ResourceLock"); //$NON-NLS-1$
+		String accessModeName= cuRewrite.getImportRewrite()
+				.addImport("org.junit.jupiter.api.parallel.ResourceAccessMode"); //$NON-NLS-1$
+		NormalAnnotation resourceLock= ast.newNormalAnnotation();
+		resourceLock.setTypeName(ast.newName(lockName));
+		MemberValuePair valuePair= ast.newMemberValuePair();
+		valuePair.setName(ast.newSimpleName("value")); //$NON-NLS-1$
+		StringLiteral lockValue= ast.newStringLiteral();
+		lockValue.setLiteralValue(GLOBAL_HARNESS_LOCK);
+		valuePair.setValue(lockValue);
+		resourceLock.values().add(valuePair);
+		MemberValuePair modePair= ast.newMemberValuePair();
+		modePair.setName(ast.newSimpleName("mode")); //$NON-NLS-1$
+		modePair.setValue(ast.newName(accessModeName + ".READ_WRITE")); //$NON-NLS-1$
+		resourceLock.values().add(modePair);
+
 		ListRewrite modifiers= rewrite.getListRewrite(type, TypeDeclaration.MODIFIERS2_PROPERTY);
+		modifiers.insertFirst(resourceLock, group);
 		modifiers.insertFirst(execution, group);
 
 		rewrite.remove(constructor, group);
@@ -137,7 +160,7 @@ final class JdtCoreHarnessRewriteOperation extends CompilationUnitRewriteOperati
 	public String getAdditionalInfo() {
 		return kind == Kind.ADD_BRIDGE
 				? "Adds a nested Jupiter bridge while retaining the original JUnit 3 harness for unmigrated families." //$NON-NLS-1$
-				: "Moves one closed direct JDT Core TestCase family to the nested Jupiter bridge on one thread."; //$NON-NLS-1$
+				: "Moves one closed direct JDT Core TestCase family to the nested Jupiter bridge under a global lock."; //$NON-NLS-1$
 	}
 
 	private static String loadBridgeSource() throws CoreException {

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessScopeDetector.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessScopeDetector.java
@@ -35,6 +35,12 @@ import org.eclipse.jdt.internal.corext.refactoring.util.RefactoringASTParser;
 /** Finds the exact source chain needed to classify a selected JDT Core harness family. */
 public final class JdtCoreHarnessScopeDetector {
 
+	private static final Set<String> FRAMEWORK_TYPES= Set.of(
+			JdtCoreHarnessPlanner.JDT_CORE_TEST_CASE,
+			JdtCoreHarnessPlanner.JDT_CORE_SUITE_OF_TEST_CASES,
+			"org.eclipse.jdt.core.tests.model.AbstractJavaModelTests", //$NON-NLS-1$
+			JdtCoreHarnessPlanner.JDT_CORE_ABSTRACT_COMPILER_TEST);
+
 	private JdtCoreHarnessScopeDetector() {
 	}
 
@@ -71,11 +77,11 @@ public final class JdtCoreHarnessScopeDetector {
 					@Override
 					public boolean visit(TypeDeclaration node) {
 						ITypeBinding binding= node.resolveBinding();
-						if (!inheritsJdtCoreHarness(binding)) {
+						if (!inheritsJdtCoreHarness(binding) || isFrameworkType(binding)) {
 							return true;
 						}
 						candidateFound[0]= true;
-						IJavaElement selectedElement= binding == null ? null : binding.getErasure().getJavaElement();
+						IJavaElement selectedElement= binding.getErasure().getJavaElement();
 						if (selectedElement instanceof IType selectedType && selectedType.getCompilationUnit() != null) {
 							referenceTargets.add(selectedType);
 							directUnits.add(selectedType.getCompilationUnit().getPrimary());
@@ -102,6 +108,10 @@ public final class JdtCoreHarnessScopeDetector {
 			current= current.getSuperclass();
 		}
 		return false;
+	}
+
+	static boolean isFrameworkType(ITypeBinding binding) {
+		return binding != null && FRAMEWORK_TYPES.contains(binding.getErasure().getQualifiedName());
 	}
 
 	private static boolean addSourceSupertypeChain(ITypeBinding binding, Set<ICompilationUnit> units) {

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessScopeDetector.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessScopeDetector.java
@@ -1,0 +1,143 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.corext.fix.multifile;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.ASTRequestor;
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
+import org.eclipse.jdt.internal.corext.refactoring.util.RefactoringASTParser;
+
+/** Finds the exact source chain needed to classify a selected JDT Core harness family. */
+public final class JdtCoreHarnessScopeDetector {
+
+	private JdtCoreHarnessScopeDetector() {
+	}
+
+	public static JUnitScopeCandidateDetector.SearchSeeds findSearchSeeds(IJavaProject project,
+			Collection<ICompilationUnit> currentScope, IProgressMonitor monitor) {
+		if (project == null || currentScope == null || currentScope.isEmpty()) {
+			return empty();
+		}
+		checkCanceled(monitor);
+		Set<ICompilationUnit> units= new LinkedHashSet<>();
+		for (ICompilationUnit unit : currentScope) {
+			if (unit != null && unit.exists() && project.equals(unit.getJavaProject())) {
+				units.add(unit.getPrimary());
+			}
+		}
+		if (units.isEmpty()) {
+			return empty();
+		}
+
+		boolean[] candidateFound= { false };
+		boolean[] complete= { true };
+		Set<IJavaElement> referenceTargets= new LinkedHashSet<>();
+		Set<ICompilationUnit> directUnits= new LinkedHashSet<>();
+		ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
+		parser.setProject(project);
+		parser.setResolveBindings(true);
+		parser.setBindingsRecovery(IASTSharedValues.SHARED_BINDING_RECOVERY);
+		parser.setStatementsRecovery(IASTSharedValues.SHARED_AST_STATEMENT_RECOVERY);
+		parser.setCompilerOptions(RefactoringASTParser.getCompilerOptions(project));
+		parser.createASTs(units.toArray(ICompilationUnit[]::new), new String[0], new ASTRequestor() {
+			@Override
+			public void acceptAST(ICompilationUnit source, CompilationUnit ast) {
+				ast.accept(new ASTVisitor() {
+					@Override
+					public boolean visit(TypeDeclaration node) {
+						ITypeBinding binding= node.resolveBinding();
+						if (!inheritsJdtCoreHarness(binding)) {
+							return true;
+						}
+						candidateFound[0]= true;
+						IJavaElement selectedElement= binding == null ? null : binding.getErasure().getJavaElement();
+						if (selectedElement instanceof IType selectedType && selectedType.getCompilationUnit() != null) {
+							referenceTargets.add(selectedType);
+							directUnits.add(selectedType.getCompilationUnit().getPrimary());
+						} else {
+							complete[0]= false;
+						}
+						complete[0]&= addSourceSupertypeChain(binding, directUnits);
+						return false;
+					}
+				});
+			}
+		}, monitor);
+		checkCanceled(monitor);
+		return new JUnitScopeCandidateDetector.SearchSeeds(candidateFound[0], complete[0],
+				new ArrayList<>(referenceTargets), new ArrayList<>(directUnits));
+	}
+
+	static boolean inheritsJdtCoreHarness(ITypeBinding binding) {
+		ITypeBinding current= binding;
+		while (current != null) {
+			if (JdtCoreHarnessPlanner.JDT_CORE_TEST_CASE.equals(current.getErasure().getQualifiedName())) {
+				return true;
+			}
+			current= current.getSuperclass();
+		}
+		return false;
+	}
+
+	private static boolean addSourceSupertypeChain(ITypeBinding binding, Set<ICompilationUnit> units) {
+		boolean complete= true;
+		ITypeBinding current= binding;
+		boolean harnessReached= false;
+		while (current != null) {
+			IJavaElement element= current.getErasure().getJavaElement();
+			if (element instanceof IType type) {
+				ICompilationUnit unit= type.getCompilationUnit();
+				if (unit != null && unit.exists()) {
+					units.add(unit.getPrimary());
+				} else if (JdtCoreHarnessPlanner.JDT_CORE_TEST_CASE.equals(
+						current.getErasure().getQualifiedName())) {
+					complete= false;
+				}
+			} else if (JdtCoreHarnessPlanner.JDT_CORE_TEST_CASE.equals(
+					current.getErasure().getQualifiedName())) {
+				complete= false;
+			}
+			if (JdtCoreHarnessPlanner.JDT_CORE_TEST_CASE.equals(current.getErasure().getQualifiedName())) {
+				harnessReached= true;
+				break;
+			}
+			current= current.getSuperclass();
+		}
+		return complete && harnessReached;
+	}
+
+	private static JUnitScopeCandidateDetector.SearchSeeds empty() {
+		return new JUnitScopeCandidateDetector.SearchSeeds(false, true, List.of(), List.of());
+	}
+
+	private static void checkCanceled(IProgressMonitor monitor) {
+		if (monitor != null && monitor.isCanceled()) {
+			throw new OperationCanceledException();
+		}
+	}
+}

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/jdt-core-jupiter-bridge.java.template
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/jdt-core-jupiter-bridge.java.template
@@ -160,6 +160,15 @@ public abstract static class Jupiter extends org.eclipse.test.performance.Perfor
 		return result.toString();
 	}
 
+	private static void initializeTestClass(Class<?> testClass) {
+		try {
+			Class.forName(testClass.getName(), true, testClass.getClassLoader());
+		} catch (ClassNotFoundException exception) {
+			throw new IllegalStateException("Cannot initialize JDT Core test class " + testClass.getName(),
+					exception);
+		}
+	}
+
 	public static final class JdtCoreFilterCondition
 			implements org.junit.jupiter.api.extension.ExecutionCondition,
 			org.junit.jupiter.api.extension.InvocationInterceptor {
@@ -192,6 +201,7 @@ public abstract static class Jupiter extends org.eclipse.test.performance.Perfor
 		}
 
 		private static boolean isSelected(Class<?> testClass, String name) {
+			initializeTestClass(testClass);
 			java.util.List<String> testNames= java.util.Arrays.stream(testClass.getDeclaredMethods())
 					.filter(method -> java.lang.reflect.Modifier.isPublic(method.getModifiers()))
 					.filter(method -> !java.lang.reflect.Modifier.isStatic(method.getModifiers()))
@@ -252,6 +262,7 @@ public abstract static class Jupiter extends org.eclipse.test.performance.Perfor
 	public static final class JdtCoreMethodOrderer implements org.junit.jupiter.api.MethodOrderer {
 		@Override
 		public void orderMethods(org.junit.jupiter.api.MethodOrdererContext context) {
+			initializeTestClass(context.getTestClass());
 			java.util.Comparator<org.junit.jupiter.api.MethodDescriptor> defaultOrder=
 					java.util.Comparator.comparingInt((org.junit.jupiter.api.MethodDescriptor descriptor) ->
 							descriptor.getMethod().getName().hashCode())

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/jdt-core-jupiter-bridge.java.template
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/jdt-core-jupiter-bridge.java.template
@@ -1,0 +1,366 @@
+@org.junit.jupiter.api.TestMethodOrder(Jupiter.JdtCoreMethodOrderer.class)
+@org.junit.jupiter.api.extension.ExtendWith(Jupiter.JdtCoreFilterCondition.class)
+public abstract static class Jupiter extends org.eclipse.test.performance.PerformanceTestCaseJunit5 {
+	private static final java.text.DecimalFormat JUPITER_DIGIT_FORMAT= new java.text.DecimalFormat("000");
+
+	private String jdtCoreTestName;
+	private boolean first;
+	protected boolean indexDisabledForTest= true;
+
+	@Override
+	@org.junit.jupiter.api.BeforeEach
+	public void setUp(org.junit.jupiter.api.TestInfo testInfo) throws Exception {
+		if (org.eclipse.jdt.core.JavaCore.getPlugin() != null && isIndexDisabledForTest()) {
+			disableIndexer();
+		}
+		super.setUp(testInfo);
+		this.jdtCoreTestName= testInfo.getTestMethod().map(java.lang.reflect.Method::getName)
+				.orElse(testInfo.getDisplayName());
+
+		this.first= false;
+		boolean firstTestRun= CURRENT_CLASS == null;
+		if (firstTestRun || CURRENT_CLASS != getClass()) {
+			if (CURRENT_CLASS != null && RUN_GC) {
+				runGarbageCollection();
+			}
+			CURRENT_CLASS= getClass();
+			this.first= true;
+			CURRENT_CLASS_NAME= getClass().getName();
+			CURRENT_CLASS_NAME= CURRENT_CLASS_NAME.substring(
+					CURRENT_CLASS_NAME.indexOf(".tests.") + 7, CURRENT_CLASS_NAME.length());
+		}
+
+		if (STORE_MEMORY != null && MEM_LOG_FILE != null) {
+			if (firstTestRun) {
+				runGarbageCollection();
+			}
+			if (ALL_TESTS_LOG && MEM_LOG_FILE.exists()) {
+				try (java.io.PrintStream stream= new java.io.PrintStream(
+						new java.io.FileOutputStream(MEM_LOG_FILE, true))) {
+					stream.print(CURRENT_CLASS_NAME);
+					stream.print('\t');
+					stream.print(getName());
+					stream.print('\t');
+					writeMemoryValues(stream);
+				}
+				if (firstTestRun) {
+					long total= Runtime.getRuntime().totalMemory();
+					long used= total - Runtime.getRuntime().freeMemory();
+					System.out.println("\t" + formatMemory(used));
+				}
+			} else if (firstTestRun) {
+				long total= Runtime.getRuntime().totalMemory();
+				long used= total - Runtime.getRuntime().freeMemory();
+				System.out.println("\talready used while starting: " + formatMemory(used));
+			}
+		}
+	}
+
+	@Override
+	@org.junit.jupiter.api.AfterEach
+	public void tearDown() throws Exception {
+		super.tearDown();
+		if (org.eclipse.jdt.core.JavaCore.getPlugin() != null && isIndexDisabledForTest()) {
+			enableIndexer();
+		}
+		if (STORE_MEMORY != null && MEM_LOG_FILE != null
+				&& (this.first || ALL_TESTS_LOG) && MEM_LOG_FILE.exists()) {
+			try (java.io.PrintStream stream= new java.io.PrintStream(
+					new java.io.FileOutputStream(MEM_LOG_FILE, true))) {
+				stream.print(CURRENT_CLASS_NAME);
+				stream.print('\t');
+				if (ALL_TESTS_LOG) {
+					String testName= getName();
+					stream.print(".".repeat(Math.max(0, testName.length() - 4)));
+					stream.print("end:\t");
+				}
+				writeMemoryValues(stream);
+			}
+		}
+	}
+
+	public String getName() {
+		return this.jdtCoreTestName;
+	}
+
+	protected boolean isFirst() {
+		return this.first;
+	}
+
+	public boolean isIndexDisabledForTest() {
+		return this.indexDisabledForTest;
+	}
+
+	public void assertPerformance() {
+		super.assertPerformance();
+	}
+
+	public void commitMeasurements() {
+		super.commitMeasurements();
+	}
+
+	public void startMeasuring() {
+		super.startMeasuring();
+	}
+
+	public void stopMeasuring() {
+		super.stopMeasuring();
+	}
+
+	protected void runGarbageCollection() {
+		long delta= 0;
+		for (int iteration= 0; iteration < MAX_GC; iteration++) {
+			long free= Runtime.getRuntime().freeMemory();
+			System.gc();
+			delta= Runtime.getRuntime().freeMemory() - free;
+			try {
+				Thread.sleep(TIME_GC);
+			} catch (InterruptedException exception) {
+				// Preserve the historical harness behavior; runTest clears the flag.
+			}
+		}
+		if (false && delta > DELTA_GC) {
+			// Retains the unreachable historical fallback branch without changing timing.
+			try {
+				Thread.sleep(1000);
+			} catch (InterruptedException exception) {
+				// Historical behavior ignores this interruption.
+			}
+		}
+	}
+
+	protected void disableIndexer() {
+		while (org.eclipse.jdt.internal.core.JavaModelManager.getJavaModelManager()
+				.getIndexManager().isEnabled()) {
+			org.eclipse.jdt.internal.core.JavaModelManager.getJavaModelManager()
+					.getIndexManager().disable();
+		}
+	}
+
+	protected void enableIndexer() {
+		while (!org.eclipse.jdt.internal.core.JavaModelManager.getJavaModelManager()
+				.getIndexManager().isEnabled()) {
+			org.eclipse.jdt.internal.core.JavaModelManager.getJavaModelManager()
+					.getIndexManager().enable();
+		}
+	}
+
+	private static void writeMemoryValues(java.io.PrintStream stream) {
+		long total= Runtime.getRuntime().totalMemory();
+		long used= total - Runtime.getRuntime().freeMemory();
+		stream.print(formatMemory(used));
+		stream.print('\t');
+		stream.print(formatMemory(total));
+		stream.print('\t');
+		stream.println(formatMemory(Runtime.getRuntime().maxMemory()));
+	}
+
+	private static String formatMemory(long number) {
+		long quotient= number;
+		int[] values= new int[10];
+		int position= -1;
+		do {
+			long current= quotient;
+			quotient= current / 1000L;
+			values[++position]= (int) (current - quotient * 1000L);
+		} while (quotient > 0 && position + 1 < values.length);
+		StringBuilder result= new StringBuilder(Integer.toString(values[position]));
+		for (int index= position - 1; index >= 0; index--) {
+			result.append(',').append(JUPITER_DIGIT_FORMAT.format(values[index]));
+		}
+		return result.toString();
+	}
+
+	public static final class JdtCoreFilterCondition
+			implements org.junit.jupiter.api.extension.ExecutionCondition,
+			org.junit.jupiter.api.extension.InvocationInterceptor {
+
+		@Override
+		public org.junit.jupiter.api.extension.ConditionEvaluationResult evaluateExecutionCondition(
+				org.junit.jupiter.api.extension.ExtensionContext context) {
+			java.util.Optional<java.lang.reflect.Method> selected= context.getTestMethod();
+			if (selected.isEmpty()) {
+				return org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled("container");
+			}
+			String name= selected.orElseThrow().getName();
+			java.util.List<String> testNames= java.util.Arrays.stream(
+					context.getRequiredTestClass().getDeclaredMethods())
+					.filter(method -> java.lang.reflect.Modifier.isPublic(method.getModifiers()))
+					.filter(method -> !java.lang.reflect.Modifier.isStatic(method.getModifiers()))
+					.map(java.lang.reflect.Method::getName)
+					.filter(candidate -> candidate.startsWith(METHOD_PREFIX)).distinct().toList();
+			java.util.List<String> onlyNames= RUN_ONLY_ID == null ? java.util.List.of()
+					: testNames.stream().filter(candidate -> candidate.substring(METHOD_PREFIX.length())
+							.startsWith(RUN_ONLY_ID)).toList();
+			boolean enabled= onlyNames.isEmpty() ? selectedByConfiguredFilter(name) : onlyNames.contains(name);
+			return enabled
+					? org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled(
+							"selected by JDT Core filter")
+					: org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled(
+							"excluded by JDT Core filter");
+		}
+
+		@Override
+		public void interceptTestMethod(Invocation<Void> invocation,
+				ReflectiveInvocationContext<java.lang.reflect.Method> invocationContext,
+				org.junit.jupiter.api.extension.ExtensionContext extensionContext) throws Throwable {
+			try {
+				invocation.proceed();
+			} finally {
+				Thread.interrupted();
+			}
+		}
+
+		private static boolean selectedByConfiguredFilter(String name) {
+			if (TESTS_PREFIX == null && TESTS_NAMES == null && TESTS_NUMBERS == null && TESTS_RANGE == null) {
+				return true;
+			}
+			if (TESTS_PREFIX != null && !name.startsWith(TESTS_PREFIX)) {
+				return false;
+			}
+			if (TESTS_NAMES != null && java.util.Arrays.stream(TESTS_NAMES).anyMatch(name::contains)) {
+				return true;
+			}
+			int number= testNumber(name);
+			if (TESTS_NUMBERS != null && java.util.Arrays.stream(TESTS_NUMBERS)
+					.anyMatch(candidate -> candidate == number)) {
+				return true;
+			}
+			if (TESTS_RANGE != null && TESTS_RANGE.length == 2 && number >= 0
+					&& (TESTS_RANGE[0] == -1 || number >= TESTS_RANGE[0])
+					&& (TESTS_RANGE[1] == -1 || number <= TESTS_RANGE[1])) {
+				return true;
+			}
+			return TESTS_NAMES == null && TESTS_NUMBERS == null && TESTS_RANGE == null;
+		}
+
+		private static int testNumber(String name) {
+			int index= TESTS_PREFIX == null ? METHOD_PREFIX.length() : TESTS_PREFIX.length();
+			while (index < name.length() && !Character.isDigit(name.charAt(index))) {
+				index++;
+			}
+			while (index < name.length() && name.charAt(index) == '0') {
+				index++;
+			}
+			int end= index;
+			while (end < name.length() && Character.isDigit(name.charAt(end))) {
+				end++;
+			}
+			if (end == index) {
+				return -1;
+			}
+			try {
+				return Integer.parseInt(name.substring(index, end));
+			} catch (NumberFormatException exception) {
+				return -1;
+			}
+		}
+	}
+
+	public static final class JdtCoreMethodOrderer implements org.junit.jupiter.api.MethodOrderer {
+		@Override
+		public void orderMethods(org.junit.jupiter.api.MethodOrdererContext context) {
+			if (ORDERING == ALPHA_REVERSE_SORT) {
+				context.getMethodDescriptors().sort((left, right) -> right.getMethod().getName()
+						.compareTo(left.getMethod().getName()));
+			} else if (ORDERING == ALPHABETICAL_SORT) {
+				context.getMethodDescriptors().sort((left, right) -> left.getMethod().getName()
+						.compareTo(right.getMethod().getName()));
+			} else if (ORDERING == BYTECODE_DECLARATION_ORDER) {
+				try {
+					java.util.List<String> ordered= bytecodeDeclaredTestNames(context.getTestClass());
+					context.getMethodDescriptors().sort(java.util.Comparator.comparingInt(descriptor -> {
+						int index= ordered.indexOf(descriptor.getMethod().getName());
+						return index < 0 ? Integer.MAX_VALUE : index;
+					}));
+				} catch (java.io.IOException exception) {
+					System.err.println("suite failed to detect test order: " + context.getTestClass().getName());
+				}
+			} else if (ORDERING != NO_ORDER) {
+				java.util.Collections.shuffle(context.getMethodDescriptors(), new java.util.Random(ORDERING));
+			}
+		}
+	}
+
+	private static java.util.List<String> bytecodeDeclaredTestNames(Class<?> testClass)
+			throws java.io.IOException {
+		String simpleName= testClass.getName().substring(testClass.getName().lastIndexOf('.') + 1);
+		java.io.InputStream resource= testClass.getResourceAsStream(simpleName + ".class");
+		if (resource == null) {
+			throw new java.io.IOException("Cannot load classfile for " + testClass.getName());
+		}
+		try (java.io.DataInputStream input= new java.io.DataInputStream(
+				new java.io.BufferedInputStream(resource))) {
+			if (input.readInt() != 0xcafebabe) {
+				throw new java.io.IOException("Invalid classfile magic");
+			}
+			input.readUnsignedShort();
+			input.readUnsignedShort();
+			int constantPoolCount= input.readUnsignedShort();
+			String[] utf8= new String[constantPoolCount];
+			for (int index= 1; index < constantPoolCount; index++) {
+				int tag= input.readUnsignedByte();
+				switch (tag) {
+				case 1 -> utf8[index]= input.readUTF();
+				case 3, 4 -> skipFully(input, 4);
+				case 5, 6 -> {
+					skipFully(input, 8);
+					index++;
+				}
+				case 7, 8, 16, 19, 20 -> skipFully(input, 2);
+				case 9, 10, 11, 12, 17, 18 -> skipFully(input, 4);
+				case 15 -> skipFully(input, 3);
+				default -> throw new java.io.IOException("Unknown constant-pool tag " + tag);
+				}
+			}
+			skipFully(input, 6);
+			int interfaces= input.readUnsignedShort();
+			skipFully(input, interfaces * 2L);
+			int fields= input.readUnsignedShort();
+			for (int index= 0; index < fields; index++) {
+				skipMember(input);
+			}
+			int methods= input.readUnsignedShort();
+			java.util.List<String> result= new java.util.ArrayList<>();
+			for (int index= 0; index < methods; index++) {
+				int access= input.readUnsignedShort();
+				String name= utf8[input.readUnsignedShort()];
+				String descriptor= utf8[input.readUnsignedShort()];
+				int attributes= input.readUnsignedShort();
+				for (int attribute= 0; attribute < attributes; attribute++) {
+					input.readUnsignedShort();
+					skipFully(input, Integer.toUnsignedLong(input.readInt()));
+				}
+				if ((access & java.lang.reflect.Modifier.PUBLIC) != 0
+						&& (access & java.lang.reflect.Modifier.STATIC) == 0
+						&& "()V".equals(descriptor) && name.startsWith(METHOD_PREFIX)) {
+					result.add(name);
+				}
+			}
+			return result;
+		}
+	}
+
+	private static void skipMember(java.io.DataInputStream input) throws java.io.IOException {
+		skipFully(input, 6);
+		int attributes= input.readUnsignedShort();
+		for (int attribute= 0; attribute < attributes; attribute++) {
+			input.readUnsignedShort();
+			skipFully(input, Integer.toUnsignedLong(input.readInt()));
+		}
+	}
+
+	private static void skipFully(java.io.DataInputStream input, long count) throws java.io.IOException {
+		long remaining= count;
+		while (remaining > 0) {
+			long skipped= input.skip(remaining);
+			if (skipped <= 0) {
+				if (input.read() < 0) {
+					throw new java.io.IOException("Unexpected end of classfile");
+				}
+				skipped= 1;
+			}
+			remaining-= skipped;
+		}
+	}
+}

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/jdt-core-jupiter-bridge.java.template
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/jdt-core-jupiter-bridge.java.template
@@ -263,11 +263,18 @@ public abstract static class Jupiter extends org.eclipse.test.performance.Perfor
 		@Override
 		public void orderMethods(org.junit.jupiter.api.MethodOrdererContext context) {
 			initializeTestClass(context.getTestClass());
-			java.util.Comparator<org.junit.jupiter.api.MethodDescriptor> defaultOrder=
-					java.util.Comparator.comparingInt((org.junit.jupiter.api.MethodDescriptor descriptor) ->
-							descriptor.getMethod().getName().hashCode())
-							.thenComparing(descriptor -> descriptor.getMethod().getName());
-			context.getMethodDescriptors().sort(defaultOrder);
+			java.util.List<String> reflectedNames= java.util.Arrays.stream(
+					context.getTestClass().getDeclaredMethods())
+					.filter(method -> java.lang.reflect.Modifier.isPublic(method.getModifiers()))
+					.filter(method -> !java.lang.reflect.Modifier.isStatic(method.getModifiers()))
+					.map(java.lang.reflect.Method::getName)
+					.filter(name -> name.startsWith(METHOD_PREFIX)).distinct().toList();
+			java.util.Comparator<org.junit.jupiter.api.MethodDescriptor> reflectionOrder=
+					java.util.Comparator.comparingInt((org.junit.jupiter.api.MethodDescriptor descriptor) -> {
+						int index= reflectedNames.indexOf(descriptor.getMethod().getName());
+						return index < 0 ? Integer.MAX_VALUE : index;
+					}).thenComparing(descriptor -> descriptor.getMethod().getName());
+			context.getMethodDescriptors().sort(reflectionOrder);
 			if (ORDERING == ALPHA_REVERSE_SORT) {
 				context.getMethodDescriptors().sort((left, right) -> right.getMethod().getName()
 						.compareTo(left.getMethod().getName()));
@@ -306,7 +313,7 @@ public abstract static class Jupiter extends org.eclipse.test.performance.Perfor
 					if (rightRank != null) {
 						return 1;
 					}
-					return defaultOrder.compare(left, right);
+					return reflectionOrder.compare(left, right);
 				});
 			}
 		}

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/jdt-core-jupiter-bridge.java.template
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/jdt-core-jupiter-bridge.java.template
@@ -109,12 +109,7 @@ public abstract static class Jupiter extends org.eclipse.test.performance.Perfor
 
 	protected void runGarbageCollection() {
 		for (int iteration= 0; iteration < MAX_GC; iteration++) {
-			long free= Runtime.getRuntime().freeMemory();
 			System.gc();
-			long delta= Runtime.getRuntime().freeMemory() - free;
-			if (delta < Long.MIN_VALUE) {
-				throw new AssertionError(delta);
-			}
 			try {
 				Thread.sleep(TIME_GC);
 			} catch (InterruptedException exception) {
@@ -176,17 +171,7 @@ public abstract static class Jupiter extends org.eclipse.test.performance.Perfor
 			if (selected.isEmpty()) {
 				return org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled("container");
 			}
-			String name= selected.orElseThrow().getName();
-			java.util.List<String> testNames= java.util.Arrays.stream(
-					context.getRequiredTestClass().getDeclaredMethods())
-					.filter(method -> java.lang.reflect.Modifier.isPublic(method.getModifiers()))
-					.filter(method -> !java.lang.reflect.Modifier.isStatic(method.getModifiers()))
-					.map(java.lang.reflect.Method::getName)
-					.filter(candidate -> candidate.startsWith(METHOD_PREFIX)).distinct().toList();
-			java.util.List<String> onlyNames= RUN_ONLY_ID == null ? java.util.List.of()
-					: testNames.stream().filter(candidate -> candidate.substring(METHOD_PREFIX.length())
-							.startsWith(RUN_ONLY_ID)).toList();
-			boolean enabled= onlyNames.isEmpty() ? selectedByConfiguredFilter(name) : onlyNames.contains(name);
+			boolean enabled= isSelected(context.getRequiredTestClass(), selected.orElseThrow().getName());
 			return enabled
 					? org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled(
 							"selected by JDT Core filter")
@@ -204,6 +189,18 @@ public abstract static class Jupiter extends org.eclipse.test.performance.Perfor
 			} finally {
 				Thread.interrupted();
 			}
+		}
+
+		private static boolean isSelected(Class<?> testClass, String name) {
+			java.util.List<String> testNames= java.util.Arrays.stream(testClass.getDeclaredMethods())
+					.filter(method -> java.lang.reflect.Modifier.isPublic(method.getModifiers()))
+					.filter(method -> !java.lang.reflect.Modifier.isStatic(method.getModifiers()))
+					.map(java.lang.reflect.Method::getName)
+					.filter(candidate -> candidate.startsWith(METHOD_PREFIX)).distinct().toList();
+			java.util.List<String> onlyNames= RUN_ONLY_ID == null ? java.util.List.of()
+					: testNames.stream().filter(candidate -> candidate.substring(METHOD_PREFIX.length())
+							.startsWith(RUN_ONLY_ID)).toList();
+			return onlyNames.isEmpty() ? selectedByConfiguredFilter(name) : onlyNames.contains(name);
 		}
 
 		private static boolean selectedByConfiguredFilter(String name) {
@@ -255,6 +252,11 @@ public abstract static class Jupiter extends org.eclipse.test.performance.Perfor
 	public static final class JdtCoreMethodOrderer implements org.junit.jupiter.api.MethodOrderer {
 		@Override
 		public void orderMethods(org.junit.jupiter.api.MethodOrdererContext context) {
+			java.util.Comparator<org.junit.jupiter.api.MethodDescriptor> defaultOrder=
+					java.util.Comparator.comparingInt((org.junit.jupiter.api.MethodDescriptor descriptor) ->
+							descriptor.getMethod().getName().hashCode())
+							.thenComparing(descriptor -> descriptor.getMethod().getName());
+			context.getMethodDescriptors().sort(defaultOrder);
 			if (ORDERING == ALPHA_REVERSE_SORT) {
 				context.getMethodDescriptors().sort((left, right) -> right.getMethod().getName()
 						.compareTo(left.getMethod().getName()));
@@ -272,7 +274,29 @@ public abstract static class Jupiter extends org.eclipse.test.performance.Perfor
 					System.err.println("suite failed to detect test order: " + context.getTestClass().getName());
 				}
 			} else if (ORDERING != NO_ORDER) {
-				java.util.Collections.shuffle(context.getMethodDescriptors(), new java.util.Random(ORDERING));
+				java.util.List<String> selectedNames= context.getMethodDescriptors().stream()
+						.map(descriptor -> descriptor.getMethod().getName())
+						.filter(name -> JdtCoreFilterCondition.isSelected(context.getTestClass(), name))
+						.collect(java.util.stream.Collectors.toCollection(java.util.ArrayList::new));
+				java.util.Collections.shuffle(selectedNames, new java.util.Random(ORDERING));
+				java.util.Map<String, Integer> ranks= new java.util.HashMap<>();
+				for (int index= 0; index < selectedNames.size(); index++) {
+					ranks.put(selectedNames.get(index), Integer.valueOf(index));
+				}
+				context.getMethodDescriptors().sort((left, right) -> {
+					Integer leftRank= ranks.get(left.getMethod().getName());
+					Integer rightRank= ranks.get(right.getMethod().getName());
+					if (leftRank != null && rightRank != null) {
+						return leftRank.compareTo(rightRank);
+					}
+					if (leftRank != null) {
+						return -1;
+					}
+					if (rightRank != null) {
+						return 1;
+					}
+					return defaultOrder.compare(left, right);
+				});
 			}
 		}
 	}

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/jdt-core-jupiter-bridge.java.template
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/jdt-core-jupiter-bridge.java.template
@@ -108,23 +108,17 @@ public abstract static class Jupiter extends org.eclipse.test.performance.Perfor
 	}
 
 	protected void runGarbageCollection() {
-		long delta= 0;
 		for (int iteration= 0; iteration < MAX_GC; iteration++) {
 			long free= Runtime.getRuntime().freeMemory();
 			System.gc();
-			delta= Runtime.getRuntime().freeMemory() - free;
+			long delta= Runtime.getRuntime().freeMemory() - free;
+			if (delta < Long.MIN_VALUE) {
+				throw new AssertionError(delta);
+			}
 			try {
 				Thread.sleep(TIME_GC);
 			} catch (InterruptedException exception) {
 				// Preserve the historical harness behavior; runTest clears the flag.
-			}
-		}
-		if (false && delta > DELTA_GC) {
-			// Retains the unreachable historical fallback branch without changing timing.
-			try {
-				Thread.sleep(1000);
-			} catch (InterruptedException exception) {
-				// Historical behavior ignores this interruption.
 			}
 		}
 	}
@@ -201,8 +195,9 @@ public abstract static class Jupiter extends org.eclipse.test.performance.Perfor
 		}
 
 		@Override
-		public void interceptTestMethod(Invocation<Void> invocation,
-				ReflectiveInvocationContext<java.lang.reflect.Method> invocationContext,
+		public void interceptTestMethod(
+				org.junit.jupiter.api.extension.InvocationInterceptor.Invocation<Void> invocation,
+				org.junit.jupiter.api.extension.ReflectiveInvocationContext<java.lang.reflect.Method> invocationContext,
 				org.junit.jupiter.api.extension.ExtensionContext extensionContext) throws Throwable {
 			try {
 				invocation.proceed();

--- a/sandbox_junit_cleanup_test/META-INF/MANIFEST.MF
+++ b/sandbox_junit_cleanup_test/META-INF/MANIFEST.MF
@@ -8,7 +8,8 @@ Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.junit,
  org.eclipse.debug.core,
  org.eclipse.jdt.junit,
- sandbox_test_commons
+ sandbox_test_commons,
+ org.eclipse.test.performance
 Bundle-ActivationPolicy: lazy
 Eclipse-BundleShape: dir
 Eclipse-BuddyPolicy: global

--- a/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/JdtCoreDirectHarnessContractTest.java
+++ b/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/JdtCoreDirectHarnessContractTest.java
@@ -1,0 +1,469 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.quickfix.Java8;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaCore;
+
+import org.eclipse.jdt.junit.JUnitCore;
+
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+
+import org.sandbox.jdt.internal.corext.fix2.MYCleanUpConstants;
+import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
+
+import org.eclipse.jdt.ui.tests.quickfix.Java8.JUnitRuntimeTestTree.Snapshot;
+
+/** Active contracts for the direct Eclipse JDT Core custom-harness slice. */
+public class JdtCoreDirectHarnessContractTest {
+
+	private static final class HarnessEclipseJava extends AbstractEclipseJava {
+		HarnessEclipseJava() {
+			super("testresources/rtstubs_17.jar", JavaCore.VERSION_17); //$NON-NLS-1$
+		}
+
+		RefactoringStatus migrate(ICompilationUnit... units) throws CoreException {
+			return performRefactoring(units, null);
+		}
+
+		void assertCompiles(ICompilationUnit... units) {
+			for (ICompilationUnit unit : units) {
+				assertNoCompilationError(unit);
+			}
+		}
+	}
+
+	@RegisterExtension
+	HarnessEclipseJava context= new HarnessEclipseJava();
+
+	private IPackageFragmentRoot root;
+
+	@BeforeEach
+	public void setup() throws CoreException {
+		root= context.createClasspathForJUnit(JUnitCore.JUNIT5_CONTAINER_PATH);
+	}
+
+	@Test
+	public void generatedBridgeCompilesAgainstTargetPerformanceBundle() throws CoreException {
+		context.addBundleToClasspath("org.eclipse.test.performance"); //$NON-NLS-1$
+		ICompilationUnit javaCore= javaCoreStub();
+		ICompilationUnit modelManager= javaModelManagerStub();
+		ICompilationUnit harness= harnessUsingTargetPerformanceBundle();
+		ICompilationUnit direct= unit("target", "TargetPerformanceTests.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package target;
+				import org.eclipse.jdt.core.tests.junit.extension.TestCase;
+				public class TargetPerformanceTests extends TestCase {
+					public TargetPerformanceTests(String name) { super(name); }
+					public void testCompiles() {}
+				}
+				""");
+
+		ICompilationUnit[] units= { javaCore, modelManager, harness, direct };
+		context.assertCompiles(units);
+		enableMigration();
+		RefactoringStatus status= context.migrate(harness, direct);
+		assertFalse(status.hasError(), status::toString);
+		context.assertCompiles(units);
+		assertTrue(harness.getBuffer().getContents().contains(
+				"extends org.eclipse.test.performance.PerformanceTestCaseJunit5")); //$NON-NLS-1$
+	}
+
+	@Test
+	public void preservesFilterOrderMultiplicityIndexerInterruptAndPerformanceCalls() throws CoreException {
+		ICompilationUnit abstractPerformance= unit("org.eclipse.test.performance", //$NON-NLS-1$
+				"AbstractPerformanceTestCase.java", performanceBaseSource("AbstractPerformanceTestCase")); //$NON-NLS-1$ //$NON-NLS-2$
+		ICompilationUnit performance3= unit("org.eclipse.test.performance", "PerformanceTestCase.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package org.eclipse.test.performance;
+				public class PerformanceTestCase extends junit.framework.TestCase {
+					protected int starts;
+					protected int stops;
+					protected int commits;
+					protected int assertions;
+					public PerformanceTestCase() {}
+					public PerformanceTestCase(String name) { super(name); }
+					protected void startMeasuring() { this.starts++; }
+					protected void stopMeasuring() { this.stops++; }
+					protected void commitMeasurements() { this.commits++; }
+					protected void assertPerformance() {
+						this.assertions++;
+						if (this.starts != 1 || this.stops != 1 || this.commits != 1 || this.assertions != 1) {
+							throw new AssertionError("performance calls were not preserved");
+						}
+					}
+				}
+				""");
+		ICompilationUnit performance5= unit("org.eclipse.test.performance", //$NON-NLS-1$
+				"PerformanceTestCaseJunit5.java", //$NON-NLS-1$
+				"""
+				package org.eclipse.test.performance;
+				public class PerformanceTestCaseJunit5 extends AbstractPerformanceTestCase {
+					@org.junit.jupiter.api.BeforeEach
+					public void setUp(org.junit.jupiter.api.TestInfo testInfo) throws Exception {}
+					@org.junit.jupiter.api.AfterEach
+					public void tearDown() throws Exception {}
+				}
+				""");
+		ICompilationUnit javaCore= javaCoreStub();
+		ICompilationUnit modelManager= javaModelManagerStub();
+		ICompilationUnit harness= instrumentedHarness();
+		ICompilationUnit ordered= unit("direct", "OrderedHarnessTests.java", orderedFamilySource()); //$NON-NLS-1$ //$NON-NLS-2$
+		ICompilationUnit filtered= unit("direct", "FilteredHarnessTests.java", filteredFamilySource()); //$NON-NLS-1$ //$NON-NLS-2$
+
+		ICompilationUnit[] allUnits= { abstractPerformance, performance3, performance5, javaCore,
+				modelManager, harness, ordered, filtered };
+		context.assertCompiles(allUnits);
+		IType orderedType= ordered.findPrimaryType();
+		IType filteredType= filtered.findPrimaryType();
+		Snapshot orderedBefore= JUnitRuntimeTestTree.capture(orderedType);
+		Snapshot filteredBefore= JUnitRuntimeTestTree.capture(filteredType);
+		assertTrue(orderedBefore.successful(), () -> "Ordered JUnit 3 baseline failed: " + orderedBefore.entries()); //$NON-NLS-1$
+		assertTrue(filteredBefore.successful(), () -> "Filtered JUnit 3 baseline failed: " + filteredBefore.entries()); //$NON-NLS-1$
+		assertEquals(List.of("testZulu", "testMiddle", "testAlpha"), testMethods(orderedBefore)); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		assertEquals(List.of("testCase002"), testMethods(filteredBefore)); //$NON-NLS-1$
+
+		enableMigration();
+		RefactoringStatus status= context.migrate(harness, ordered, filtered);
+		assertFalse(status.hasError(), status::toString);
+		context.assertCompiles(allUnits);
+
+		Snapshot orderedAfter= JUnitRuntimeTestTree.capture(orderedType);
+		Snapshot filteredAfter= JUnitRuntimeTestTree.capture(filteredType);
+		assertTrue(orderedAfter.successful(), () -> "Ordered Jupiter migration failed: " + orderedAfter.entries()); //$NON-NLS-1$
+		assertTrue(filteredAfter.successful(), () -> "Filtered Jupiter migration failed: " + filteredAfter.entries()); //$NON-NLS-1$
+		assertEquals(orderedBefore.entries(), orderedAfter.entries(),
+				"Order, identity, nesting and multiplicity must be unchanged."); //$NON-NLS-1$
+		assertEquals(filteredBefore.entries(), filteredAfter.entries(),
+				"The configured JDT Core method filter must select the same runtime tree."); //$NON-NLS-1$
+		assertEquals(List.of("testZulu", "testMiddle", "testAlpha"), testMethods(orderedAfter)); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		assertEquals(List.of("testCase002"), testMethods(filteredAfter)); //$NON-NLS-1$
+	}
+
+	private ICompilationUnit javaCoreStub() throws CoreException {
+		return unit("org.eclipse.jdt.core", "JavaCore.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package org.eclipse.jdt.core;
+				public final class JavaCore {
+					private JavaCore() {}
+					public static Object getPlugin() { return new Object(); }
+				}
+				""");
+	}
+
+	private ICompilationUnit javaModelManagerStub() throws CoreException {
+		return unit("org.eclipse.jdt.internal.core", "JavaModelManager.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package org.eclipse.jdt.internal.core;
+				public final class JavaModelManager {
+					private static final JavaModelManager INSTANCE= new JavaModelManager();
+					private final IndexManager indexManager= new IndexManager();
+					private JavaModelManager() {}
+					public static JavaModelManager getJavaModelManager() { return INSTANCE; }
+					public IndexManager getIndexManager() { return this.indexManager; }
+					public static final class IndexManager {
+						private boolean enabled= true;
+						public boolean isEnabled() { return this.enabled; }
+						public void disable() { this.enabled= false; }
+						public void enable() { this.enabled= true; }
+					}
+				}
+				""");
+	}
+
+	private ICompilationUnit harnessUsingTargetPerformanceBundle() throws CoreException {
+		return unit("org.eclipse.jdt.core.tests.junit.extension", "TestCase.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package org.eclipse.jdt.core.tests.junit.extension;
+				public abstract class TestCase extends org.eclipse.test.performance.PerformanceTestCase {
+					public static final int NO_ORDER= 0;
+					public static final int ALPHABETICAL_SORT= 1;
+					public static final int ALPHA_REVERSE_SORT= 2;
+					public static final int BYTECODE_DECLARATION_ORDER= 5;
+					public static long ORDERING= ALPHABETICAL_SORT;
+					public static final String METHOD_PREFIX= "test";
+					public static String RUN_ONLY_ID= "ONLY_";
+					public static String TESTS_PREFIX;
+					public static String[] TESTS_NAMES;
+					public static int[] TESTS_NUMBERS;
+					public static int[] TESTS_RANGE;
+					private static final int MAX_GC= 1;
+					private static final int TIME_GC= 1;
+					private static java.io.File MEM_LOG_FILE;
+					private static Class<?> CURRENT_CLASS;
+					private static String CURRENT_CLASS_NAME;
+					private static String STORE_MEMORY;
+					private static boolean ALL_TESTS_LOG;
+					private static boolean RUN_GC;
+					public TestCase(String name) { super(name); }
+				}
+				""");
+	}
+
+	private ICompilationUnit instrumentedHarness() throws CoreException {
+		return unit("org.eclipse.jdt.core.tests.junit.extension", "TestCase.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package org.eclipse.jdt.core.tests.junit.extension;
+				public abstract class TestCase extends org.eclipse.test.performance.PerformanceTestCase {
+					public static final int NO_ORDER= 0;
+					public static final int ALPHABETICAL_SORT= 1;
+					public static final int ALPHA_REVERSE_SORT= 2;
+					public static final int BYTECODE_DECLARATION_ORDER= 5;
+					public static long ORDERING= ALPHABETICAL_SORT;
+					public static final String METHOD_PREFIX= "test";
+					public static String RUN_ONLY_ID= "ONLY_";
+					public static String TESTS_PREFIX;
+					public static String[] TESTS_NAMES;
+					public static int[] TESTS_NUMBERS;
+					public static int[] TESTS_RANGE;
+					private static final int MAX_GC= 1;
+					private static final int TIME_GC= 1;
+					private static java.io.File MEM_LOG_FILE;
+					private static Class<?> CURRENT_CLASS;
+					private static String CURRENT_CLASS_NAME;
+					private static String STORE_MEMORY;
+					private static boolean ALL_TESTS_LOG;
+					private static boolean RUN_GC;
+					protected boolean indexDisabledForTest= true;
+
+					public TestCase(String name) { super(name); }
+
+					public static junit.framework.Test buildTestSuite(Class<?> type) {
+						junit.framework.TestSuite suite= new junit.framework.TestSuite(type.getName());
+						java.util.List<String> names= java.util.Arrays.stream(type.getDeclaredMethods())
+								.filter(method -> java.lang.reflect.Modifier.isPublic(method.getModifiers()))
+								.filter(method -> !java.lang.reflect.Modifier.isStatic(method.getModifiers()))
+								.map(java.lang.reflect.Method::getName)
+								.filter(name -> name.startsWith(METHOD_PREFIX)).distinct()
+								.collect(java.util.stream.Collectors.toCollection(java.util.ArrayList::new));
+						java.util.List<String> onlyNames= RUN_ONLY_ID == null ? java.util.List.of()
+								: names.stream().filter(name -> name.substring(METHOD_PREFIX.length())
+										.startsWith(RUN_ONLY_ID)).toList();
+						names= onlyNames.isEmpty() ? names.stream().filter(TestCase::selected).collect(
+								java.util.stream.Collectors.toCollection(java.util.ArrayList::new))
+								: new java.util.ArrayList<>(onlyNames);
+						if (ORDERING == ALPHABETICAL_SORT) {
+							java.util.Collections.sort(names);
+						} else if (ORDERING == ALPHA_REVERSE_SORT) {
+							names.sort(java.util.Collections.reverseOrder());
+						}
+						try {
+							java.lang.reflect.Constructor<?> constructor= type.getConstructor(String.class);
+							for (String name : names) {
+								suite.addTest((junit.framework.Test) constructor.newInstance(name));
+							}
+						} catch (ReflectiveOperationException exception) {
+							throw new IllegalStateException(exception);
+						}
+						return suite;
+					}
+
+					private static boolean selected(String name) {
+						if (TESTS_PREFIX == null && TESTS_NAMES == null && TESTS_NUMBERS == null && TESTS_RANGE == null) {
+							return true;
+						}
+						if (TESTS_PREFIX != null && !name.startsWith(TESTS_PREFIX)) {
+							return false;
+						}
+						if (TESTS_NAMES != null && java.util.Arrays.stream(TESTS_NAMES).anyMatch(name::contains)) {
+							return true;
+						}
+						int number= testNumber(name);
+						if (TESTS_NUMBERS != null && java.util.Arrays.stream(TESTS_NUMBERS).anyMatch(value -> value == number)) {
+							return true;
+						}
+						if (TESTS_RANGE != null && TESTS_RANGE.length == 2 && number >= 0
+								&& (TESTS_RANGE[0] == -1 || number >= TESTS_RANGE[0])
+								&& (TESTS_RANGE[1] == -1 || number <= TESTS_RANGE[1])) {
+							return true;
+						}
+						return TESTS_NAMES == null && TESTS_NUMBERS == null && TESTS_RANGE == null;
+					}
+
+					private static int testNumber(String name) {
+						int index= TESTS_PREFIX == null ? METHOD_PREFIX.length() : TESTS_PREFIX.length();
+						while (index < name.length() && !Character.isDigit(name.charAt(index))) index++;
+						while (index < name.length() && name.charAt(index) == '0') index++;
+						int end= index;
+						while (end < name.length() && Character.isDigit(name.charAt(end))) end++;
+						return end == index ? -1 : Integer.parseInt(name.substring(index, end));
+					}
+
+					@Override
+					protected void setUp() throws Exception {
+						if (org.eclipse.jdt.core.JavaCore.getPlugin() != null && isIndexDisabledForTest()) disableIndexer();
+						super.setUp();
+					}
+
+					@Override
+					protected void tearDown() throws Exception {
+						super.tearDown();
+						if (org.eclipse.jdt.core.JavaCore.getPlugin() != null && isIndexDisabledForTest()) enableIndexer();
+					}
+
+					@Override
+					protected void runTest() throws Throwable {
+						try { super.runTest(); } finally { Thread.interrupted(); }
+					}
+
+					public boolean isIndexDisabledForTest() { return this.indexDisabledForTest; }
+					protected void disableIndexer() {
+						while (org.eclipse.jdt.internal.core.JavaModelManager.getJavaModelManager()
+								.getIndexManager().isEnabled()) {
+							org.eclipse.jdt.internal.core.JavaModelManager.getJavaModelManager()
+									.getIndexManager().disable();
+						}
+					}
+					protected void enableIndexer() {
+						while (!org.eclipse.jdt.internal.core.JavaModelManager.getJavaModelManager()
+								.getIndexManager().isEnabled()) {
+							org.eclipse.jdt.internal.core.JavaModelManager.getJavaModelManager()
+									.getIndexManager().enable();
+						}
+					}
+				}
+				""");
+	}
+
+	private static String performanceBaseSource(String typeName) {
+		return """
+				package org.eclipse.test.performance;
+				public class %s {
+					protected int starts;
+					protected int stops;
+					protected int commits;
+					protected int assertions;
+					protected void startMeasuring() { this.starts++; }
+					protected void stopMeasuring() { this.stops++; }
+					protected void commitMeasurements() { this.commits++; }
+					protected void assertPerformance() {
+						this.assertions++;
+						if (this.starts != 1 || this.stops != 1 || this.commits != 1 || this.assertions != 1) {
+							throw new AssertionError("performance calls were not preserved");
+						}
+					}
+				}
+				""".formatted(typeName);
+	}
+
+	private static String orderedFamilySource() {
+		return """
+				package direct;
+				import junit.framework.Test;
+				import org.eclipse.jdt.core.tests.junit.extension.TestCase;
+				public class OrderedHarnessTests extends TestCase {
+					static {
+						TestCase.ORDERING= TestCase.ALPHA_REVERSE_SORT;
+						TestCase.RUN_ONLY_ID= "ONLY_";
+						TestCase.TESTS_PREFIX= null;
+						TestCase.TESTS_NAMES= null;
+						TestCase.TESTS_NUMBERS= null;
+						TestCase.TESTS_RANGE= null;
+					}
+					private final boolean indexEnabledAtConstruction= assertIndexerEnabled();
+					public OrderedHarnessTests(String name) { super(name); }
+					public static Test suite() { return buildTestSuite(OrderedHarnessTests.class); }
+					public void testZulu() {
+						assertHarnessState(false);
+						startMeasuring();
+						stopMeasuring();
+						commitMeasurements();
+						assertPerformance();
+						Thread.currentThread().interrupt();
+					}
+					public void testMiddle() {
+						assertHarnessState(true);
+						startMeasuring();
+						stopMeasuring();
+						commitMeasurements();
+						assertPerformance();
+					}
+					public void testAlpha() {
+						assertHarnessState(true);
+						startMeasuring();
+						stopMeasuring();
+						commitMeasurements();
+						assertPerformance();
+					}
+					private static boolean assertIndexerEnabled() {
+						if (!org.eclipse.jdt.internal.core.JavaModelManager.getJavaModelManager()
+								.getIndexManager().isEnabled()) {
+							throw new AssertionError("indexer was not restored before constructing the next test");
+						}
+						return true;
+					}
+					private void assertHarnessState(boolean interruptMustBeClear) {
+						if (!this.indexEnabledAtConstruction) throw new AssertionError("constructor probe failed");
+						if (org.eclipse.jdt.internal.core.JavaModelManager.getJavaModelManager()
+								.getIndexManager().isEnabled()) {
+							throw new AssertionError("indexer was not disabled during the test");
+						}
+						if (interruptMustBeClear && Thread.currentThread().isInterrupted()) {
+							throw new AssertionError("interrupt status leaked from the previous test");
+						}
+					}
+				}
+				""";
+	}
+
+	private static String filteredFamilySource() {
+		return """
+				package direct;
+				import junit.framework.Test;
+				import org.eclipse.jdt.core.tests.junit.extension.TestCase;
+				public class FilteredHarnessTests extends TestCase {
+					static {
+						TestCase.ORDERING= TestCase.ALPHABETICAL_SORT;
+						TestCase.RUN_ONLY_ID= "ONLY_";
+						TestCase.TESTS_PREFIX= "testCase";
+						TestCase.TESTS_NAMES= null;
+						TestCase.TESTS_NUMBERS= new int[] { 2 };
+						TestCase.TESTS_RANGE= null;
+					}
+					public FilteredHarnessTests(String name) { super(name); }
+					public static Test suite() { return buildTestSuite(FilteredHarnessTests.class); }
+					public void testCase001() {}
+					public void testCase002() {}
+					public void testOther003() {}
+				}
+				""";
+	}
+
+	private static List<String> testMethods(Snapshot snapshot) {
+		return snapshot.entries().stream().filter(entry -> entry.contains(":test:")) //$NON-NLS-1$
+				.map(entry -> entry.substring(entry.indexOf('#') + 1, entry.lastIndexOf('='))).toList();
+	}
+
+	private ICompilationUnit unit(String packageName, String fileName, String source) throws CoreException {
+		IPackageFragment fragment= root.createPackageFragment(packageName, true, null);
+		return fragment.createCompilationUnit(fileName, source, false, null);
+	}
+
+	private void enableMigration() throws CoreException {
+		context.enable(MYCleanUpConstants.JUNIT3_CLEANUP);
+		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_3_TEST);
+	}
+}

--- a/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/JdtCoreDirectHarnessMigrationTest.java
+++ b/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/JdtCoreDirectHarnessMigrationTest.java
@@ -1,0 +1,209 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.quickfix.Java8;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaCore;
+
+import org.eclipse.jdt.junit.JUnitCore;
+
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+
+import org.sandbox.jdt.internal.corext.fix2.MYCleanUpConstants;
+import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
+
+import org.eclipse.jdt.ui.tests.quickfix.Java8.JUnitRuntimeTestTree.Snapshot;
+
+/** End-to-end contract for the first direct Eclipse JDT Core harness slice. */
+public class JdtCoreDirectHarnessMigrationTest {
+
+	private static final class HarnessEclipseJava extends AbstractEclipseJava {
+		HarnessEclipseJava() {
+			super("testresources/rtstubs_17.jar", JavaCore.VERSION_17); //$NON-NLS-1$
+		}
+
+		RefactoringStatus migrate(ICompilationUnit... units) throws CoreException {
+			return performRefactoring(units, null);
+		}
+
+		void assertCompiles(ICompilationUnit... units) {
+			for (ICompilationUnit unit : units) {
+				assertNoCompilationError(unit);
+			}
+		}
+	}
+
+	@RegisterExtension
+	HarnessEclipseJava context= new HarnessEclipseJava();
+
+	private IPackageFragmentRoot root;
+
+	@BeforeEach
+	public void setup() throws CoreException {
+		root= context.createClasspathForJUnit(JUnitCore.JUNIT5_CONTAINER_PATH);
+	}
+
+	@Test
+	public void migratesDirectNamedTestFamilyAndPreservesRuntimeTree() throws CoreException {
+		ICompilationUnit abstractPerformance= unit("org.eclipse.test.performance", //$NON-NLS-1$
+				"AbstractPerformanceTestCase.java", //$NON-NLS-1$
+				"""
+				package org.eclipse.test.performance;
+				public abstract class AbstractPerformanceTestCase {
+					protected void startMeasuring() {}
+					protected void stopMeasuring() {}
+					protected void commitMeasurements() {}
+					protected void assertPerformance() {}
+				}
+				""");
+		ICompilationUnit performance3= unit("org.eclipse.test.performance", "PerformanceTestCase.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package org.eclipse.test.performance;
+				public class PerformanceTestCase extends junit.framework.TestCase {
+					public PerformanceTestCase() {}
+					public PerformanceTestCase(String name) { super(name); }
+				}
+				""");
+		ICompilationUnit performance5= unit("org.eclipse.test.performance", //$NON-NLS-1$
+				"PerformanceTestCaseJunit5.java", //$NON-NLS-1$
+				"""
+				package org.eclipse.test.performance;
+				public class PerformanceTestCaseJunit5 extends AbstractPerformanceTestCase {
+					@org.junit.jupiter.api.BeforeEach
+					public void setUp(org.junit.jupiter.api.TestInfo testInfo) throws Exception {}
+					@org.junit.jupiter.api.AfterEach
+					public void tearDown() throws Exception {}
+				}
+				""");
+		ICompilationUnit javaCore= unit("org.eclipse.jdt.core", "JavaCore.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package org.eclipse.jdt.core;
+				public final class JavaCore {
+					private JavaCore() {}
+					public static Object getPlugin() { return new Object(); }
+				}
+				""");
+		ICompilationUnit modelManager= unit("org.eclipse.jdt.internal.core", "JavaModelManager.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package org.eclipse.jdt.internal.core;
+				public final class JavaModelManager {
+					private static final JavaModelManager INSTANCE= new JavaModelManager();
+					private final IndexManager indexManager= new IndexManager();
+					private JavaModelManager() {}
+					public static JavaModelManager getJavaModelManager() { return INSTANCE; }
+					public IndexManager getIndexManager() { return this.indexManager; }
+					public static final class IndexManager {
+						private boolean enabled= true;
+						public boolean isEnabled() { return this.enabled; }
+						public void disable() { this.enabled= false; }
+						public void enable() { this.enabled= true; }
+					}
+				}
+				""");
+		ICompilationUnit harness= unit("org.eclipse.jdt.core.tests.junit.extension", "TestCase.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package org.eclipse.jdt.core.tests.junit.extension;
+				public abstract class TestCase extends org.eclipse.test.performance.PerformanceTestCase {
+					public static final int NO_ORDER= 0;
+					public static final int ALPHABETICAL_SORT= 1;
+					public static final int ALPHA_REVERSE_SORT= 2;
+					public static final int BYTECODE_DECLARATION_ORDER= 3;
+					public static long ORDERING= ALPHABETICAL_SORT;
+					public static final String METHOD_PREFIX= "test";
+					public static String RUN_ONLY_ID;
+					public static String TESTS_PREFIX;
+					public static String[] TESTS_NAMES;
+					public static int[] TESTS_NUMBERS;
+					public static int[] TESTS_RANGE;
+					private static final int MAX_GC= 5;
+					private static final int TIME_GC= 1;
+					private static final int DELTA_GC= 0;
+					private static java.io.File MEM_LOG_FILE;
+					private static Class<?> CURRENT_CLASS;
+					private static String CURRENT_CLASS_NAME;
+					private static String STORE_MEMORY;
+					private static boolean ALL_TESTS_LOG;
+					private static boolean RUN_GC;
+
+					public TestCase(String name) { super(name); }
+					public static junit.framework.Test buildTestSuite(Class<?> type) {
+						return new junit.framework.TestSuite(type.asSubclass(junit.framework.TestCase.class));
+					}
+				}
+				""");
+		ICompilationUnit direct= unit("direct", "DirectTests.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package direct;
+				import junit.framework.Test;
+				import org.eclipse.jdt.core.tests.junit.extension.TestCase;
+				public class DirectTests extends TestCase {
+					public DirectTests(String name) { super(name); }
+					public static Test suite() { return buildTestSuite(DirectTests.class); }
+					public void testOne() { assertEquals("message", 1, 1); }
+				}
+				""");
+
+		ICompilationUnit[] allUnits= { abstractPerformance, performance3, performance5, javaCore,
+				modelManager, harness, direct };
+		context.assertCompiles(allUnits);
+		IType launchTarget= direct.findPrimaryType();
+		assertNotNull(launchTarget);
+		Snapshot before= JUnitRuntimeTestTree.capture(launchTarget);
+		assertTrue(before.successful(), () -> "JUnit 3 harness baseline failed: " + before.entries()); //$NON-NLS-1$
+
+		enableMigration();
+		RefactoringStatus status= context.migrate(harness, direct);
+		assertFalse(status.hasError(), status::toString);
+		context.assertCompiles(allUnits);
+
+		String harnessSource= harness.getBuffer().getContents();
+		String directSource= direct.getBuffer().getContents();
+		assertTrue(harnessSource.contains("class Jupiter extends org.eclipse.test.performance.PerformanceTestCaseJunit5")); //$NON-NLS-1$
+		assertTrue(harnessSource.contains("JdtCoreFilterCondition")); //$NON-NLS-1$
+		assertTrue(harnessSource.contains("JdtCoreMethodOrderer")); //$NON-NLS-1$
+		assertTrue(directSource.contains("extends TestCase.Jupiter")); //$NON-NLS-1$
+		assertTrue(directSource.contains("@Test")); //$NON-NLS-1$
+		assertTrue(directSource.contains("Assertions.assertEquals(1, 1, \"message\")")); //$NON-NLS-1$
+		assertFalse(directSource.contains("DirectTests(String name)")); //$NON-NLS-1$
+		assertFalse(directSource.contains("static Test suite()")); //$NON-NLS-1$
+
+		Snapshot after= JUnitRuntimeTestTree.capture(launchTarget);
+		assertTrue(after.successful(), () -> "Migrated JDT Core Jupiter run failed: " + after.entries()); //$NON-NLS-1$
+		assertEquals(before.entries(), after.entries(),
+				"The same JDT launch must preserve direct harness test identity, nesting and multiplicity."); //$NON-NLS-1$
+	}
+
+	private ICompilationUnit unit(String packageName, String fileName, String source) throws CoreException {
+		IPackageFragment fragment= root.createPackageFragment(packageName, true, null);
+		return fragment.createCompilationUnit(fileName, source, false, null);
+	}
+
+	private void enableMigration() throws CoreException {
+		context.enable(MYCleanUpConstants.JUNIT3_CLEANUP);
+		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_3_TEST);
+	}
+}

--- a/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/JdtCoreSeededOrderingMigrationTest.java
+++ b/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/JdtCoreSeededOrderingMigrationTest.java
@@ -1,0 +1,227 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.quickfix.Java8;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.junit.JUnitCore;
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+
+import org.sandbox.jdt.internal.corext.fix2.MYCleanUpConstants;
+import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
+
+import org.eclipse.jdt.ui.tests.quickfix.Java8.JUnitRuntimeTestTree.Snapshot;
+
+/** Proves seeded JDT Core ordering against the same before/after JDT launch. */
+public class JdtCoreSeededOrderingMigrationTest {
+
+	private static final class HarnessEclipseJava extends AbstractEclipseJava {
+		HarnessEclipseJava() {
+			super("testresources/rtstubs_17.jar", JavaCore.VERSION_17); //$NON-NLS-1$
+		}
+
+		RefactoringStatus migrate(ICompilationUnit... units) throws CoreException {
+			return performRefactoring(units, null);
+		}
+
+		void assertCompiles(ICompilationUnit... units) {
+			for (ICompilationUnit unit : units) {
+				assertNoCompilationError(unit);
+			}
+		}
+	}
+
+	@RegisterExtension
+	HarnessEclipseJava context= new HarnessEclipseJava();
+
+	private IPackageFragmentRoot root;
+
+	@BeforeEach
+	public void setup() throws CoreException {
+		root= context.createClasspathForJUnit(JUnitCore.JUNIT5_CONTAINER_PATH);
+	}
+
+	@Test
+	public void preservesSeededShuffleFromReflectionOrder() throws CoreException {
+		ICompilationUnit abstractPerformance= unit("org.eclipse.test.performance", //$NON-NLS-1$
+				"AbstractPerformanceTestCase.java", //$NON-NLS-1$
+				"""
+				package org.eclipse.test.performance;
+				public class AbstractPerformanceTestCase {
+					protected void startMeasuring() {}
+					protected void stopMeasuring() {}
+					protected void commitMeasurements() {}
+					protected void assertPerformance() {}
+				}
+				""");
+		ICompilationUnit performance3= unit("org.eclipse.test.performance", "PerformanceTestCase.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package org.eclipse.test.performance;
+				public class PerformanceTestCase extends junit.framework.TestCase {
+					public PerformanceTestCase() {}
+					public PerformanceTestCase(String name) { super(name); }
+				}
+				""");
+		ICompilationUnit performance5= unit("org.eclipse.test.performance", //$NON-NLS-1$
+				"PerformanceTestCaseJunit5.java", //$NON-NLS-1$
+				"""
+				package org.eclipse.test.performance;
+				public class PerformanceTestCaseJunit5 extends AbstractPerformanceTestCase {
+					@org.junit.jupiter.api.BeforeEach
+					public void setUp(org.junit.jupiter.api.TestInfo testInfo) throws Exception {}
+					@org.junit.jupiter.api.AfterEach
+					public void tearDown() throws Exception {}
+				}
+				""");
+		ICompilationUnit javaCore= unit("org.eclipse.jdt.core", "JavaCore.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package org.eclipse.jdt.core;
+				public final class JavaCore {
+					private JavaCore() {}
+					public static Object getPlugin() { return null; }
+				}
+				""");
+		ICompilationUnit modelManager= unit("org.eclipse.jdt.internal.core", "JavaModelManager.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package org.eclipse.jdt.internal.core;
+				public final class JavaModelManager {
+					private static final JavaModelManager INSTANCE= new JavaModelManager();
+					private final IndexManager indexManager= new IndexManager();
+					private JavaModelManager() {}
+					public static JavaModelManager getJavaModelManager() { return INSTANCE; }
+					public IndexManager getIndexManager() { return this.indexManager; }
+					public static final class IndexManager {
+						private boolean enabled= true;
+						public boolean isEnabled() { return this.enabled; }
+						public void disable() { this.enabled= false; }
+						public void enable() { this.enabled= true; }
+					}
+				}
+				""");
+		ICompilationUnit harness= unit("org.eclipse.jdt.core.tests.junit.extension", "TestCase.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package org.eclipse.jdt.core.tests.junit.extension;
+				public abstract class TestCase extends org.eclipse.test.performance.PerformanceTestCase {
+					public static final int NO_ORDER= 0;
+					public static final int ALPHABETICAL_SORT= 1;
+					public static final int ALPHA_REVERSE_SORT= 2;
+					public static final int BYTECODE_DECLARATION_ORDER= 5;
+					public static long ORDERING= ALPHABETICAL_SORT;
+					public static final String METHOD_PREFIX= "test";
+					public static String RUN_ONLY_ID= "ONLY_";
+					public static String TESTS_PREFIX;
+					public static String[] TESTS_NAMES;
+					public static int[] TESTS_NUMBERS;
+					public static int[] TESTS_RANGE;
+					private static final int MAX_GC= 1;
+					private static final int TIME_GC= 1;
+					private static java.io.File MEM_LOG_FILE;
+					private static Class<?> CURRENT_CLASS;
+					private static String CURRENT_CLASS_NAME;
+					private static String STORE_MEMORY;
+					private static boolean ALL_TESTS_LOG;
+					private static boolean RUN_GC;
+					public TestCase(String name) { super(name); }
+					public static junit.framework.Test buildTestSuite(Class<?> type) {
+						junit.framework.TestSuite suite= new junit.framework.TestSuite(type.getName());
+						java.util.List<String> names= java.util.Arrays.stream(type.getDeclaredMethods())
+								.filter(method -> java.lang.reflect.Modifier.isPublic(method.getModifiers()))
+								.filter(method -> !java.lang.reflect.Modifier.isStatic(method.getModifiers()))
+								.map(java.lang.reflect.Method::getName)
+								.filter(name -> name.startsWith(METHOD_PREFIX)).distinct()
+								.collect(java.util.stream.Collectors.toCollection(java.util.ArrayList::new));
+						if (ORDERING == ALPHABETICAL_SORT) {
+							java.util.Collections.sort(names);
+						} else if (ORDERING == ALPHA_REVERSE_SORT) {
+							names.sort(java.util.Collections.reverseOrder());
+						} else if (ORDERING != NO_ORDER && ORDERING != BYTECODE_DECLARATION_ORDER) {
+							java.util.Collections.shuffle(names, new java.util.Random(ORDERING));
+						}
+						try {
+							java.lang.reflect.Constructor<?> constructor= type.getConstructor(String.class);
+							for (String name : names) {
+								suite.addTest((junit.framework.Test) constructor.newInstance(name));
+							}
+						} catch (ReflectiveOperationException exception) {
+							throw new IllegalStateException(exception);
+						}
+						return suite;
+					}
+				}
+				""");
+		ICompilationUnit family= unit("direct", "SeededHarnessTests.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package direct;
+				import junit.framework.Test;
+				import org.eclipse.jdt.core.tests.junit.extension.TestCase;
+				public class SeededHarnessTests extends TestCase {
+					static {
+						TestCase.ORDERING= 8675309L;
+						TestCase.RUN_ONLY_ID= "ONLY_";
+						TestCase.TESTS_PREFIX= null;
+						TestCase.TESTS_NAMES= null;
+						TestCase.TESTS_NUMBERS= null;
+						TestCase.TESTS_RANGE= null;
+					}
+					public SeededHarnessTests(String name) { super(name); }
+					public static Test suite() { return buildTestSuite(SeededHarnessTests.class); }
+					public void testKilo() {}
+					public void testAlpha() {}
+					public void testZulu() {}
+					public void testBravo() {}
+					public void testMike() {}
+				}
+				""");
+
+		ICompilationUnit[] allUnits= { abstractPerformance, performance3, performance5, javaCore,
+				modelManager, harness, family };
+		context.assertCompiles(allUnits);
+		IType familyType= family.findPrimaryType();
+		Snapshot before= JUnitRuntimeTestTree.capture(familyType);
+		assertTrue(before.successful(), () -> "Seeded JUnit 3 baseline failed: " + before.entries()); //$NON-NLS-1$
+		assertEquals(5, testCount(before));
+
+		context.enable(MYCleanUpConstants.JUNIT3_CLEANUP);
+		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_3_TEST);
+		RefactoringStatus status= context.migrate(harness, family);
+		assertFalse(status.hasError(), status::toString);
+		context.assertCompiles(allUnits);
+		assertTrue(family.getBuffer().getContents().contains("extends TestCase.Jupiter")); //$NON-NLS-1$
+
+		Snapshot after= JUnitRuntimeTestTree.capture(familyType);
+		assertTrue(after.successful(), () -> "Seeded Jupiter migration failed: " + after.entries()); //$NON-NLS-1$
+		assertEquals(before.entries(), after.entries(),
+				"The seeded shuffle must use the same reflected starting order before and after migration."); //$NON-NLS-1$
+		assertEquals(5, testCount(after));
+	}
+
+	private static long testCount(Snapshot snapshot) {
+		return snapshot.entries().stream().filter(entry -> entry.contains(":test:")).count(); //$NON-NLS-1$
+	}
+
+	private ICompilationUnit unit(String packageName, String fileName, String source) throws CoreException {
+		IPackageFragment fragment= root.createPackageFragment(packageName, true, null);
+		return fragment.createCompilationUnit(fileName, source, false, null);
+	}
+}

--- a/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/JdtCoreTargetBridgeCompilationTest.java
+++ b/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/JdtCoreTargetBridgeCompilationTest.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.quickfix.Java8;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.junit.JUnitCore;
+
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+
+import org.sandbox.jdt.internal.corext.fix2.MYCleanUpConstants;
+import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
+
+/** Compiles the generated compatibility bridge against the actual repository target bundles. */
+public class JdtCoreTargetBridgeCompilationTest {
+
+	private static final class TargetEclipseJava extends AbstractEclipseJava {
+		TargetEclipseJava() {
+			super("testresources/rtstubs_17.jar", JavaCore.VERSION_17); //$NON-NLS-1$
+		}
+
+		RefactoringStatus migrate(ICompilationUnit... units) throws CoreException {
+			return performRefactoring(units, null);
+		}
+
+		void assertCompiles(ICompilationUnit... units) {
+			for (ICompilationUnit unit : units) {
+				assertNoCompilationError(unit);
+			}
+		}
+	}
+
+	@RegisterExtension
+	TargetEclipseJava context= new TargetEclipseJava();
+
+	private IPackageFragmentRoot root;
+
+	@BeforeEach
+	public void setup() throws CoreException {
+		root= context.createClasspathForJUnit(JUnitCore.JUNIT5_CONTAINER_PATH);
+		context.addBundleToClasspath("org.eclipse.test.performance"); //$NON-NLS-1$
+		context.addBundleToClasspath("org.eclipse.jdt.core"); //$NON-NLS-1$
+	}
+
+	@Test
+	public void compilesGeneratedBridgeAgainstActualJdtAndPerformanceApis() throws CoreException {
+		ICompilationUnit harness= unit("org.eclipse.jdt.core.tests.junit.extension", "TestCase.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package org.eclipse.jdt.core.tests.junit.extension;
+				public abstract class TestCase extends org.eclipse.test.performance.PerformanceTestCase {
+					public static final int NO_ORDER= 0;
+					public static final int ALPHABETICAL_SORT= 1;
+					public static final int ALPHA_REVERSE_SORT= 2;
+					public static final int BYTECODE_DECLARATION_ORDER= 5;
+					public static long ORDERING= ALPHABETICAL_SORT;
+					public static final String METHOD_PREFIX= "test";
+					public static String RUN_ONLY_ID= "ONLY_";
+					public static String TESTS_PREFIX;
+					public static String[] TESTS_NAMES;
+					public static int[] TESTS_NUMBERS;
+					public static int[] TESTS_RANGE;
+					private static final int MAX_GC= 1;
+					private static final int TIME_GC= 1;
+					private static java.io.File MEM_LOG_FILE;
+					private static Class<?> CURRENT_CLASS;
+					private static String CURRENT_CLASS_NAME;
+					private static String STORE_MEMORY;
+					private static boolean ALL_TESTS_LOG;
+					private static boolean RUN_GC;
+					public TestCase(String name) { super(name); }
+				}
+				""");
+		ICompilationUnit direct= unit("target", "TargetBundleTests.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package target;
+				public class TargetBundleTests
+						extends org.eclipse.jdt.core.tests.junit.extension.TestCase {
+					public TargetBundleTests(String name) { super(name); }
+					public void testCompiles() {
+						startMeasuring();
+						stopMeasuring();
+						commitMeasurements();
+						assertPerformance();
+					}
+				}
+				""");
+
+		context.assertCompiles(harness, direct);
+		enableMigration();
+		RefactoringStatus status= context.migrate(harness, direct);
+		assertFalse(status.hasError(), status::toString);
+		context.assertCompiles(harness, direct);
+		assertTrue(harness.getBuffer().getContents().contains(
+				"extends org.eclipse.test.performance.PerformanceTestCaseJunit5")); //$NON-NLS-1$
+	}
+
+	private ICompilationUnit unit(String packageName, String fileName, String source) throws CoreException {
+		IPackageFragment fragment= root.createPackageFragment(packageName, true, null);
+		return fragment.createCompilationUnit(fileName, source, false, null);
+	}
+
+	private void enableMigration() throws CoreException {
+		context.enable(MYCleanUpConstants.JUNIT3_CLEANUP);
+		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_3_TEST);
+	}
+}

--- a/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreExternalHarnessOwnerTest.java
+++ b/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreExternalHarnessOwnerTest.java
@@ -1,0 +1,122 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.corext.fix.multifile;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.ASTRequestor;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
+import org.eclipse.jdt.internal.corext.refactoring.util.RefactoringASTParser;
+import org.eclipse.jdt.junit.JUnitCore;
+
+import org.sandbox.jdt.internal.corext.fix.multifile.JdtCoreHarnessInventory.Family;
+import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
+import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava17;
+
+/** Regression for locally hidden aggregate/external JDT Core suite ownership. */
+public class JdtCoreExternalHarnessOwnerTest {
+
+	@RegisterExtension
+	AbstractEclipseJava context= new EclipseJava17();
+
+	private IPackageFragmentRoot root;
+
+	@BeforeEach
+	public void setup() throws CoreException {
+		root= context.createClasspathForJUnit(JUnitCore.JUNIT5_CONTAINER_PATH);
+	}
+
+	@Test
+	public void rejectsLocalSuiteDelegatingToExternalHarnessOwner() throws Exception {
+		ICompilationUnit performance= unit("org.eclipse.test.performance", "PerformanceTestCase.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package org.eclipse.test.performance;
+				public class PerformanceTestCase extends junit.framework.TestCase {
+					public PerformanceTestCase() {}
+					public PerformanceTestCase(String name) { super(name); }
+				}
+				""");
+		ICompilationUnit harness= unit("org.eclipse.jdt.core.tests.junit.extension", "TestCase.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package org.eclipse.jdt.core.tests.junit.extension;
+				public class TestCase extends org.eclipse.test.performance.PerformanceTestCase {
+					public TestCase(String name) { super(name); }
+				}
+				""");
+		ICompilationUnit external= unit("external", "ForeignHarness.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package external;
+				public final class ForeignHarness {
+					private ForeignHarness() {}
+					public static junit.framework.Test buildTestSuite(Class<?> type) {
+						return new junit.framework.TestSuite(type.asSubclass(junit.framework.TestCase.class));
+					}
+				}
+				""");
+		ICompilationUnit direct= unit("direct", "DirectTests.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package direct;
+				public class DirectTests extends org.eclipse.jdt.core.tests.junit.extension.TestCase {
+					public DirectTests(String name) { super(name); }
+					public static junit.framework.Test suite() {
+						return external.ForeignHarness.buildTestSuite(DirectTests.class);
+					}
+					public void testOne() {}
+				}
+				""");
+
+		ICompilationUnit[] units= { performance, harness, external, direct };
+		JdtCoreHarnessPlanner.Result result= JdtCoreHarnessPlanner.create(context.getJavaProject(), units,
+				parse(units), true, null);
+		Family family= result.inventory().families().stream()
+				.filter(candidate -> "direct.DirectTests".equals(candidate.typeName())) //$NON-NLS-1$
+				.findFirst().orElseThrow();
+		assertFalse(family.directSliceApplicable());
+		assertEquals("UNSUPPORTED_JDT_CORE_ASSERTION_OR_EXECUTION", family.reasonCode()); //$NON-NLS-1$
+	}
+
+	private ICompilationUnit unit(String packageName, String fileName, String source) throws CoreException {
+		IPackageFragment fragment= root.createPackageFragment(packageName, true, null);
+		return fragment.createCompilationUnit(fileName, source, false, null);
+	}
+
+	private Map<String, CompilationUnit> parse(ICompilationUnit[] units) {
+		Map<String, CompilationUnit> roots= new LinkedHashMap<>();
+		ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
+		parser.setProject(context.getJavaProject());
+		parser.setResolveBindings(true);
+		parser.setBindingsRecovery(IASTSharedValues.SHARED_BINDING_RECOVERY);
+		parser.setStatementsRecovery(IASTSharedValues.SHARED_AST_STATEMENT_RECOVERY);
+		parser.setCompilerOptions(RefactoringASTParser.getCompilerOptions(context.getJavaProject()));
+		parser.createASTs(units, new String[0], new ASTRequestor() {
+			@Override
+			public void acceptAST(ICompilationUnit source, CompilationUnit ast) {
+				roots.put(source.getPrimary().getHandleIdentifier(), ast);
+			}
+		}, null);
+		return roots;
+	}
+}

--- a/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessAccessibilityTest.java
+++ b/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessAccessibilityTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.eclipse.core.runtime.CoreException;
 
 import org.eclipse.jdt.core.ICompilationUnit;
-import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.dom.ASTParser;

--- a/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessAccessibilityTest.java
+++ b/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessAccessibilityTest.java
@@ -1,0 +1,126 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.corext.fix.multifile;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.ASTRequestor;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
+import org.eclipse.jdt.internal.corext.refactoring.util.RefactoringASTParser;
+import org.eclipse.jdt.junit.JUnitCore;
+
+import org.sandbox.jdt.internal.corext.fix.multifile.JdtCoreHarnessInventory.Family;
+import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
+import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava17;
+
+/** Proves that Slice A preserves the JUnit 3 reflective accessibility contract. */
+public class JdtCoreHarnessAccessibilityTest {
+
+	@RegisterExtension
+	AbstractEclipseJava context= new EclipseJava17();
+
+	private IPackageFragmentRoot root;
+
+	@BeforeEach
+	public void setup() throws CoreException {
+		root= context.createClasspathForJUnit(JUnitCore.JUNIT5_CONTAINER_PATH);
+	}
+
+	@Test
+	public void rejectsClassesAndConstructorsThatTheJunit3HarnessCannotReflectivelyConstruct() throws Exception {
+		ICompilationUnit performance= unit("org.eclipse.test.performance", "PerformanceTestCase.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package org.eclipse.test.performance;
+				public class PerformanceTestCase extends junit.framework.TestCase {
+					public PerformanceTestCase() {}
+					public PerformanceTestCase(String name) { super(name); }
+				}
+				""");
+		ICompilationUnit harness= unit("org.eclipse.jdt.core.tests.junit.extension", "TestCase.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package org.eclipse.jdt.core.tests.junit.extension;
+				public class TestCase extends org.eclipse.test.performance.PerformanceTestCase {
+					public TestCase(String name) { super(name); }
+				}
+				""");
+		ICompilationUnit packagePrivateFamily= unit("direct", "PackagePrivateTests.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package direct;
+				class PackagePrivateTests extends org.eclipse.jdt.core.tests.junit.extension.TestCase {
+					public PackagePrivateTests(String name) { super(name); }
+					public void testInvisibleClass() {}
+				}
+				""");
+		ICompilationUnit hiddenConstructorFamily= unit("direct", "HiddenConstructorTests.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package direct;
+				public class HiddenConstructorTests extends org.eclipse.jdt.core.tests.junit.extension.TestCase {
+					HiddenConstructorTests(String name) { super(name); }
+					public void testInvisibleConstructor() {}
+				}
+				""");
+
+		ICompilationUnit[] units= { performance, harness, packagePrivateFamily, hiddenConstructorFamily };
+		JdtCoreHarnessPlanner.Result result= JdtCoreHarnessPlanner.create(context.getJavaProject(), units,
+				parse(units), true, null);
+
+		Family packagePrivate= family(result, "direct.PackagePrivateTests"); //$NON-NLS-1$
+		assertFalse(packagePrivate.directSliceApplicable());
+		assertEquals("JDT_CORE_PUBLIC_FAMILY_REQUIRED", packagePrivate.reasonCode()); //$NON-NLS-1$
+
+		Family hiddenConstructor= family(result, "direct.HiddenConstructorTests"); //$NON-NLS-1$
+		assertFalse(hiddenConstructor.directSliceApplicable());
+		assertEquals("JDT_CORE_NAMED_CONSTRUCTOR_REQUIRED", hiddenConstructor.reasonCode()); //$NON-NLS-1$
+	}
+
+	private ICompilationUnit unit(String packageName, String fileName, String source) throws CoreException {
+		IPackageFragment fragment= root.createPackageFragment(packageName, true, null);
+		return fragment.createCompilationUnit(fileName, source, false, null);
+	}
+
+	private Map<String, CompilationUnit> parse(ICompilationUnit[] units) {
+		Map<String, CompilationUnit> roots= new LinkedHashMap<>();
+		ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
+		parser.setProject(context.getJavaProject());
+		parser.setResolveBindings(true);
+		parser.setBindingsRecovery(IASTSharedValues.SHARED_BINDING_RECOVERY);
+		parser.setStatementsRecovery(IASTSharedValues.SHARED_AST_STATEMENT_RECOVERY);
+		parser.setCompilerOptions(RefactoringASTParser.getCompilerOptions(context.getJavaProject()));
+		parser.createASTs(units, new String[0], new ASTRequestor() {
+			@Override
+			public void acceptAST(ICompilationUnit source, CompilationUnit ast) {
+				roots.put(source.getPrimary().getHandleIdentifier(), ast);
+			}
+		}, null);
+		return roots;
+	}
+
+	private static Family family(JdtCoreHarnessPlanner.Result result, String typeName) {
+		return result.inventory().families().stream().filter(candidate -> typeName.equals(candidate.typeName()))
+				.findFirst().orElseThrow();
+	}
+}

--- a/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessExecutionHookRejectionTest.java
+++ b/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessExecutionHookRejectionTest.java
@@ -36,7 +36,7 @@ import org.sandbox.jdt.internal.corext.fix.multifile.JdtCoreHarnessInventory.Fam
 import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
 import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava17;
 
-/** Verifies that JUnit 3 execution-hook declarations cannot be flattened. */
+/** Verifies that JUnit 3 execution hooks and inherited harness state cannot be flattened. */
 public class JdtCoreHarnessExecutionHookRejectionTest {
 
 	@RegisterExtension
@@ -79,6 +79,32 @@ public class JdtCoreHarnessExecutionHookRejectionTest {
 			assertFalse(family.directSliceApplicable(), family::typeName);
 			assertEquals("JDT_CORE_LIFECYCLE_OR_RUN_HOOK_REQUIRED", family.reasonCode()); //$NON-NLS-1$
 		}
+		assertEquals(0, result.directMigrations().size());
+	}
+
+	@Test
+	public void rejectsInheritedHarnessFieldNotRepresentedByBridge() throws Exception {
+		ICompilationUnit harness= unit("org.eclipse.jdt.core.tests.junit.extension", "TestCase.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package org.eclipse.jdt.core.tests.junit.extension;
+				public class TestCase extends junit.framework.TestCase {
+					protected boolean abortOnFailure= true;
+					public TestCase(String name) { super(name); }
+					public static junit.framework.Test buildTestSuite(Class<?> type) {
+						return new junit.framework.TestSuite(type);
+					}
+				}
+				""");
+		ICompilationUnit fieldUser= family("InheritedFieldTests.java", "InheritedFieldTests", //$NON-NLS-1$ //$NON-NLS-2$
+				"public void configure() { this.abortOnFailure= false; }"); //$NON-NLS-1$
+
+		ICompilationUnit[] units= { harness, fieldUser };
+		JdtCoreHarnessPlanner.Result result= JdtCoreHarnessPlanner.create(context.getJavaProject(), units,
+				parse(units), true, null);
+		Family family= result.inventory().families().get(0);
+
+		assertFalse(family.directSliceApplicable(), family::typeName);
+		assertEquals("UNSUPPORTED_JDT_CORE_ASSERTION_OR_EXECUTION", family.reasonCode()); //$NON-NLS-1$
 		assertEquals(0, result.directMigrations().size());
 	}
 

--- a/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessExecutionHookRejectionTest.java
+++ b/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessExecutionHookRejectionTest.java
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.corext.fix.multifile;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.ASTRequestor;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
+import org.eclipse.jdt.internal.corext.refactoring.util.RefactoringASTParser;
+import org.eclipse.jdt.junit.JUnitCore;
+
+import org.sandbox.jdt.internal.corext.fix.multifile.JdtCoreHarnessInventory.Family;
+import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
+import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava17;
+
+/** Verifies that JUnit 3 execution-hook declarations cannot be flattened. */
+public class JdtCoreHarnessExecutionHookRejectionTest {
+
+	@RegisterExtension
+	AbstractEclipseJava context= new EclipseJava17();
+
+	private IPackageFragmentRoot root;
+
+	@BeforeEach
+	public void setup() throws CoreException {
+		root= context.createClasspathForJUnit(JUnitCore.JUNIT5_CONTAINER_PATH);
+	}
+
+	@Test
+	public void rejectsNameResultAndCountHooks() throws Exception {
+		ICompilationUnit harness= unit("org.eclipse.jdt.core.tests.junit.extension", "TestCase.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package org.eclipse.jdt.core.tests.junit.extension;
+				public class TestCase extends junit.framework.TestCase {
+					public TestCase(String name) { super(name); }
+					public static junit.framework.Test buildTestSuite(Class<?> type) {
+						return new junit.framework.TestSuite(type);
+					}
+				}
+				""");
+		ICompilationUnit createResult= family("CreateResultTests.java", "CreateResultTests", //$NON-NLS-1$ //$NON-NLS-2$
+				"protected junit.framework.TestResult createResult() { return super.createResult(); }"); //$NON-NLS-1$
+		ICompilationUnit count= family("CountTests.java", "CountTests", //$NON-NLS-1$ //$NON-NLS-2$
+				"public int countTestCases() { return 1; }"); //$NON-NLS-1$
+		ICompilationUnit getName= family("GetNameTests.java", "GetNameTests", //$NON-NLS-1$ //$NON-NLS-2$
+				"public String getName() { return super.getName(); }"); //$NON-NLS-1$
+		ICompilationUnit setName= family("SetNameTests.java", "SetNameTests", //$NON-NLS-1$ //$NON-NLS-2$
+				"public void setName(String name) { super.setName(name); }"); //$NON-NLS-1$
+
+		ICompilationUnit[] units= { harness, createResult, count, getName, setName };
+		JdtCoreHarnessPlanner.Result result= JdtCoreHarnessPlanner.create(context.getJavaProject(), units,
+				parse(units), true, null);
+
+		assertEquals(4, result.inventory().families().size());
+		for (Family family : result.inventory().families()) {
+			assertFalse(family.directSliceApplicable(), family::typeName);
+			assertEquals("JDT_CORE_LIFECYCLE_OR_RUN_HOOK_REQUIRED", family.reasonCode()); //$NON-NLS-1$
+		}
+		assertEquals(0, result.directMigrations().size());
+	}
+
+	private ICompilationUnit family(String fileName, String className, String hook) throws CoreException {
+		return unit("direct", fileName, //$NON-NLS-1$
+				"""
+				package direct;
+				public class %s extends org.eclipse.jdt.core.tests.junit.extension.TestCase {
+					public %s(String name) { super(name); }
+					%s
+					public void testOne() {}
+				}
+				""".formatted(className, className, hook));
+	}
+
+	private ICompilationUnit unit(String packageName, String fileName, String source) throws CoreException {
+		IPackageFragment fragment= root.createPackageFragment(packageName, true, null);
+		return fragment.createCompilationUnit(fileName, source, false, null);
+	}
+
+	private Map<String, CompilationUnit> parse(ICompilationUnit[] units) {
+		Map<String, CompilationUnit> roots= new LinkedHashMap<>();
+		ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
+		parser.setProject(context.getJavaProject());
+		parser.setResolveBindings(true);
+		parser.setBindingsRecovery(IASTSharedValues.SHARED_BINDING_RECOVERY);
+		parser.setStatementsRecovery(IASTSharedValues.SHARED_AST_STATEMENT_RECOVERY);
+		parser.setCompilerOptions(RefactoringASTParser.getCompilerOptions(context.getJavaProject()));
+		parser.createASTs(units, new String[0], new ASTRequestor() {
+			@Override
+			public void acceptAST(ICompilationUnit source, CompilationUnit ast) {
+				roots.put(source.getPrimary().getHandleIdentifier(), ast);
+			}
+		}, null);
+		return roots;
+	}
+}

--- a/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessFilterRejectionTest.java
+++ b/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessFilterRejectionTest.java
@@ -1,0 +1,153 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.corext.fix.multifile;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.ASTRequestor;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
+import org.eclipse.jdt.internal.corext.refactoring.util.RefactoringASTParser;
+import org.eclipse.jdt.junit.JUnitCore;
+
+import org.sandbox.jdt.internal.corext.fix.multifile.JdtCoreHarnessInventory.Family;
+import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
+import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava17;
+
+/** Proves that filters are not approximated through skipped Jupiter nodes. */
+public class JdtCoreHarnessFilterRejectionTest {
+
+	@RegisterExtension
+	AbstractEclipseJava context= new EclipseJava17();
+
+	private IPackageFragmentRoot root;
+
+	@BeforeEach
+	public void setup() throws CoreException {
+		root= context.createClasspathForJUnit(JUnitCore.JUNIT5_CONTAINER_PATH);
+	}
+
+	@Test
+	public void rejectsConfiguredFilterFieldsUntilDiscoveryTimeMappingExists() throws Exception {
+		ICompilationUnit performance= performance();
+		ICompilationUnit harness= harness();
+		ICompilationUnit filtered= unit("filtered", "FilteredTests.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package filtered;
+				public class FilteredTests extends org.eclipse.jdt.core.tests.junit.extension.TestCase {
+					static { TESTS_NUMBERS= new int[] { 2 }; }
+					public FilteredTests(String name) { super(name); }
+					public void test001() {}
+					public void test002() {}
+				}
+				""");
+
+		JdtCoreHarnessPlanner.Result result= plan(performance, harness, filtered);
+		Family family= family(result, "filtered.FilteredTests"); //$NON-NLS-1$
+		assertFalse(family.directSliceApplicable());
+		assertEquals("JDT_CORE_FILTER_MAPPING_REQUIRED", family.reasonCode()); //$NON-NLS-1$
+		assertTrue(result.directMigrations().isEmpty());
+	}
+
+	@Test
+	public void rejectsRunOnlyMethodNamesUntilDiscoveryTimeMappingExists() throws Exception {
+		ICompilationUnit performance= performance();
+		ICompilationUnit harness= harness();
+		ICompilationUnit filtered= unit("filtered", "RunOnlyTests.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package filtered;
+				public class RunOnlyTests extends org.eclipse.jdt.core.tests.junit.extension.TestCase {
+					public RunOnlyTests(String name) { super(name); }
+					public void testOrdinary() {}
+					public void testONLY_focus() {}
+				}
+				""");
+
+		JdtCoreHarnessPlanner.Result result= plan(performance, harness, filtered);
+		Family family= family(result, "filtered.RunOnlyTests"); //$NON-NLS-1$
+		assertFalse(family.directSliceApplicable());
+		assertEquals("JDT_CORE_FILTER_MAPPING_REQUIRED", family.reasonCode()); //$NON-NLS-1$
+		assertTrue(result.directMigrations().isEmpty());
+	}
+
+	private ICompilationUnit performance() throws CoreException {
+		return unit("org.eclipse.test.performance", "PerformanceTestCase.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package org.eclipse.test.performance;
+				public class PerformanceTestCase extends junit.framework.TestCase {
+					public PerformanceTestCase() {}
+					public PerformanceTestCase(String name) { super(name); }
+				}
+				""");
+	}
+
+	private ICompilationUnit harness() throws CoreException {
+		return unit("org.eclipse.jdt.core.tests.junit.extension", "TestCase.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package org.eclipse.jdt.core.tests.junit.extension;
+				public class TestCase extends org.eclipse.test.performance.PerformanceTestCase {
+					public static String RUN_ONLY_ID= "ONLY_";
+					public static String TESTS_PREFIX;
+					public static String[] TESTS_NAMES;
+					public static int[] TESTS_NUMBERS;
+					public static int[] TESTS_RANGE;
+					public TestCase(String name) { setName(name); }
+				}
+				""");
+	}
+
+	private JdtCoreHarnessPlanner.Result plan(ICompilationUnit... units) throws Exception {
+		return JdtCoreHarnessPlanner.create(context.getJavaProject(), units, parse(units), true, null);
+	}
+
+	private ICompilationUnit unit(String packageName, String fileName, String source) throws CoreException {
+		IPackageFragment fragment= root.createPackageFragment(packageName, true, null);
+		return fragment.createCompilationUnit(fileName, source, false, null);
+	}
+
+	private Map<String, CompilationUnit> parse(ICompilationUnit[] units) {
+		Map<String, CompilationUnit> roots= new LinkedHashMap<>();
+		ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
+		parser.setProject(context.getJavaProject());
+		parser.setResolveBindings(true);
+		parser.setBindingsRecovery(IASTSharedValues.SHARED_BINDING_RECOVERY);
+		parser.setStatementsRecovery(IASTSharedValues.SHARED_AST_STATEMENT_RECOVERY);
+		parser.setCompilerOptions(RefactoringASTParser.getCompilerOptions(context.getJavaProject()));
+		parser.createASTs(units, new String[0], new ASTRequestor() {
+			@Override
+			public void acceptAST(ICompilationUnit source, CompilationUnit ast) {
+				roots.put(source.getPrimary().getHandleIdentifier(), ast);
+			}
+		}, null);
+		return roots;
+	}
+
+	private static Family family(JdtCoreHarnessPlanner.Result result, String typeName) {
+		return result.inventory().families().stream().filter(candidate -> typeName.equals(candidate.typeName()))
+				.findFirst().orElseThrow();
+	}
+}

--- a/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessPerformanceCallTest.java
+++ b/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessPerformanceCallTest.java
@@ -1,0 +1,129 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.corext.fix.multifile;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.ASTRequestor;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
+import org.eclipse.jdt.internal.corext.refactoring.util.RefactoringASTParser;
+import org.eclipse.jdt.junit.JUnitCore;
+
+import org.sandbox.jdt.internal.corext.fix.multifile.JdtCoreHarnessInventory.Family;
+import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
+import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava17;
+
+/** Verifies calls whose bindings resolve to the real JDT Core performance wrappers. */
+public class JdtCoreHarnessPerformanceCallTest {
+
+	@RegisterExtension
+	AbstractEclipseJava context= new EclipseJava17();
+
+	private IPackageFragmentRoot root;
+
+	@BeforeEach
+	public void setup() throws CoreException {
+		root= context.createClasspathForJUnit(JUnitCore.JUNIT5_CONTAINER_PATH);
+	}
+
+	@Test
+	public void acceptsSupportedPerformanceCallsDeclaredOnCustomTestCase() throws Exception {
+		ICompilationUnit performance= unit("org.eclipse.test.performance", "PerformanceTestCase.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package org.eclipse.test.performance;
+				public class PerformanceTestCase extends junit.framework.TestCase {
+					public PerformanceTestCase() {}
+					public PerformanceTestCase(String name) { super(name); }
+					protected void startMeasuring() {}
+					protected void stopMeasuring() {}
+					protected void commitMeasurements() {}
+					protected void assertPerformance() {}
+				}
+				""");
+		ICompilationUnit harness= unit("org.eclipse.jdt.core.tests.junit.extension", "TestCase.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package org.eclipse.jdt.core.tests.junit.extension;
+				public class TestCase extends org.eclipse.test.performance.PerformanceTestCase {
+					public TestCase(String name) { super(name); }
+					public static junit.framework.Test buildTestSuite(Class<?> type) {
+						return new junit.framework.TestSuite(type);
+					}
+					public void startMeasuring() { super.startMeasuring(); }
+					public void stopMeasuring() { super.stopMeasuring(); }
+					public void commitMeasurements() { super.commitMeasurements(); }
+					public void assertPerformance() { super.assertPerformance(); }
+				}
+				""");
+		ICompilationUnit direct= unit("direct", "PerformanceCallsTests.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package direct;
+				public class PerformanceCallsTests
+						extends org.eclipse.jdt.core.tests.junit.extension.TestCase {
+					public PerformanceCallsTests(String name) { super(name); }
+					public void testPerformance() {
+						startMeasuring();
+						stopMeasuring();
+						commitMeasurements();
+						assertPerformance();
+					}
+				}
+				""");
+
+		ICompilationUnit[] units= { performance, harness, direct };
+		JdtCoreHarnessPlanner.Result result= JdtCoreHarnessPlanner.create(context.getJavaProject(), units,
+				parse(units), true, null);
+		Family family= result.inventory().families().stream()
+				.filter(candidate -> "direct.PerformanceCallsTests".equals(candidate.typeName())) //$NON-NLS-1$
+				.findFirst().orElseThrow();
+
+		assertTrue(family.directSliceApplicable(), family::message);
+		assertEquals("JDT_CORE_DIRECT_SLICE_APPLICABLE", family.reasonCode()); //$NON-NLS-1$
+		assertEquals(1, result.directMigrations().size());
+	}
+
+	private ICompilationUnit unit(String packageName, String fileName, String source) throws CoreException {
+		IPackageFragment fragment= root.createPackageFragment(packageName, true, null);
+		return fragment.createCompilationUnit(fileName, source, false, null);
+	}
+
+	private Map<String, CompilationUnit> parse(ICompilationUnit[] units) {
+		Map<String, CompilationUnit> roots= new LinkedHashMap<>();
+		ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
+		parser.setProject(context.getJavaProject());
+		parser.setResolveBindings(true);
+		parser.setBindingsRecovery(IASTSharedValues.SHARED_BINDING_RECOVERY);
+		parser.setStatementsRecovery(IASTSharedValues.SHARED_AST_STATEMENT_RECOVERY);
+		parser.setCompilerOptions(RefactoringASTParser.getCompilerOptions(context.getJavaProject()));
+		parser.createASTs(units, new String[0], new ASTRequestor() {
+			@Override
+			public void acceptAST(ICompilationUnit source, CompilationUnit ast) {
+				roots.put(source.getPrimary().getHandleIdentifier(), ast);
+			}
+		}, null);
+		return roots;
+	}
+}

--- a/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessPerformanceCallTest.java
+++ b/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessPerformanceCallTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.eclipse.core.runtime.CoreException;
 
 import org.eclipse.jdt.core.ICompilationUnit;
-import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.dom.ASTParser;

--- a/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessPlannerTest.java
+++ b/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/JdtCoreHarnessPlannerTest.java
@@ -1,0 +1,219 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.corext.fix.multifile;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.ASTRequestor;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
+import org.eclipse.jdt.internal.corext.refactoring.util.RefactoringASTParser;
+import org.eclipse.jdt.junit.JUnitCore;
+
+import org.sandbox.jdt.internal.corext.fix.multifile.JdtCoreHarnessInventory.Family;
+import org.sandbox.jdt.internal.corext.fix.multifile.JdtCoreHarnessInventory.FamilyKind;
+import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
+import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava17;
+
+/** Active binding-resolved classification tests for the JDT Core custom harness. */
+public class JdtCoreHarnessPlannerTest {
+
+	@RegisterExtension
+	AbstractEclipseJava context= new EclipseJava17();
+
+	private IPackageFragmentRoot root;
+
+	@BeforeEach
+	public void setup() throws CoreException {
+		root= context.createClasspathForJUnit(JUnitCore.JUNIT5_CONTAINER_PATH);
+	}
+
+	@Test
+	public void classifiesDirectSuiteStateAndComplianceFamiliesSeparately() throws Exception {
+		ICompilationUnit performance= unit("org.eclipse.test.performance", "PerformanceTestCase.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package org.eclipse.test.performance;
+				public class PerformanceTestCase extends junit.framework.TestCase {
+					public PerformanceTestCase() {}
+					public PerformanceTestCase(String name) { super(name); }
+				}
+				""");
+		ICompilationUnit harness= unit("org.eclipse.jdt.core.tests.junit.extension", "TestCase.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package org.eclipse.jdt.core.tests.junit.extension;
+				import java.util.List;
+				import junit.framework.Test;
+				import junit.framework.TestSuite;
+				import org.eclipse.test.performance.PerformanceTestCase;
+				public class TestCase extends PerformanceTestCase {
+					public TestCase(String name) { setName(name); }
+					public static Test buildTestSuite(Class<?> type) { return new TestSuite(type); }
+					public static List<?> buildTestsList(Class<?> type, int depth, long ordering) { return List.of(); }
+				}
+				""");
+		ICompilationUnit direct= unit("direct", "DirectTests.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package direct;
+				import junit.framework.Test;
+				import org.eclipse.jdt.core.tests.junit.extension.TestCase;
+				public class DirectTests extends TestCase {
+					public DirectTests(String name) { super(name); }
+					public static Test suite() { return buildTestSuite(DirectTests.class); }
+					public void testOne() {}
+				}
+				""");
+		ICompilationUnit suiteBase= unit("org.eclipse.jdt.core.tests.model", "SuiteOfTestCases.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package org.eclipse.jdt.core.tests.model;
+				import org.eclipse.jdt.core.tests.junit.extension.TestCase;
+				public class SuiteOfTestCases extends TestCase {
+					public SuiteOfTestCases(String name) { super(name); }
+					public void setUpSuite() throws Exception {}
+					public void tearDownSuite() throws Exception {}
+				}
+				""");
+		ICompilationUnit model= unit("model", "ModelTests.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package model;
+				import org.eclipse.jdt.core.tests.model.SuiteOfTestCases;
+				public class ModelTests extends SuiteOfTestCases {
+					public ModelTests(String name) { super(name); }
+					public void testStateful() {}
+				}
+				""");
+		ICompilationUnit compilerBase= unit("org.eclipse.jdt.core.tests.util", "AbstractCompilerTest.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package org.eclipse.jdt.core.tests.util;
+				import org.eclipse.jdt.core.tests.junit.extension.TestCase;
+				public abstract class AbstractCompilerTest extends TestCase {
+					public AbstractCompilerTest(String name) { super(name); }
+					public static junit.framework.Test buildAllCompliancesTestSuite(Class<?> type) { return null; }
+				}
+				""");
+		ICompilationUnit compiler= unit("compiler", "CompilerTests.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package compiler;
+				import org.eclipse.jdt.core.tests.util.AbstractCompilerTest;
+				public class CompilerTests extends AbstractCompilerTest {
+					public CompilerTests(String name) { super(name); }
+					public void testAtCompliance() {}
+				}
+				""");
+
+		ICompilationUnit[] units= { performance, harness, direct, suiteBase, model, compilerBase, compiler };
+		JdtCoreHarnessPlanner.Result result= JdtCoreHarnessPlanner.create(context.getJavaProject(), units,
+				parse(units), true, null);
+
+		assertEquals(3, result.inventory().families().size());
+		Family directFamily= family(result, "direct.DirectTests"); //$NON-NLS-1$
+		assertEquals(FamilyKind.DIRECT_TEST_CASE, directFamily.kind());
+		assertTrue(directFamily.directSliceApplicable());
+		assertEquals("JDT_CORE_DIRECT_SLICE_APPLICABLE", directFamily.reasonCode()); //$NON-NLS-1$
+
+		Family modelFamily= family(result, "model.ModelTests"); //$NON-NLS-1$
+		assertEquals(FamilyKind.SUITE_STATE, modelFamily.kind());
+		assertFalse(modelFamily.directSliceApplicable());
+		assertEquals("JDT_CORE_SUITE_STATE_REQUIRED", modelFamily.reasonCode()); //$NON-NLS-1$
+
+		Family compilerFamily= family(result, "compiler.CompilerTests"); //$NON-NLS-1$
+		assertEquals(FamilyKind.COMPILER_COMPLIANCE, compilerFamily.kind());
+		assertFalse(compilerFamily.directSliceApplicable());
+		assertEquals("JDT_CORE_COMPLIANCE_MATRIX_REQUIRED", compilerFamily.reasonCode()); //$NON-NLS-1$
+	}
+
+	@Test
+	public void rejectsDirectFamilyReferencedByAggregateSuite() throws Exception {
+		ICompilationUnit performance= unit("org.eclipse.test.performance", "PerformanceTestCase.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package org.eclipse.test.performance;
+				public class PerformanceTestCase extends junit.framework.TestCase {
+					public PerformanceTestCase() {}
+					public PerformanceTestCase(String name) { super(name); }
+				}
+				""");
+		ICompilationUnit harness= unit("org.eclipse.jdt.core.tests.junit.extension", "TestCase.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package org.eclipse.jdt.core.tests.junit.extension;
+				public class TestCase extends org.eclipse.test.performance.PerformanceTestCase {
+					public TestCase(String name) { setName(name); }
+					public static junit.framework.Test buildTestSuite(Class<?> type) { return new junit.framework.TestSuite(type); }
+				}
+				""");
+		ICompilationUnit direct= unit("direct", "DirectTests.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package direct;
+				public class DirectTests extends org.eclipse.jdt.core.tests.junit.extension.TestCase {
+					public DirectTests(String name) { super(name); }
+					public void testOne() {}
+				}
+				""");
+		ICompilationUnit aggregate= unit("aggregate", "AllTests.java", //$NON-NLS-1$ //$NON-NLS-2$
+				"""
+				package aggregate;
+				public class AllTests {
+					public static junit.framework.Test suite() {
+						return org.eclipse.jdt.core.tests.junit.extension.TestCase.buildTestSuite(direct.DirectTests.class);
+					}
+				}
+				""");
+
+		ICompilationUnit[] units= { performance, harness, direct, aggregate };
+		JdtCoreHarnessPlanner.Result result= JdtCoreHarnessPlanner.create(context.getJavaProject(), units,
+				parse(units), true, null);
+		Family family= family(result, "direct.DirectTests"); //$NON-NLS-1$
+		assertFalse(family.directSliceApplicable());
+		assertEquals("JDT_CORE_AGGREGATE_SUITE_REQUIRED", family.reasonCode()); //$NON-NLS-1$
+		assertTrue(family.relatedCompilationUnitHandles().contains(aggregate.getHandleIdentifier()));
+	}
+
+	private ICompilationUnit unit(String packageName, String fileName, String source) throws CoreException {
+		IPackageFragment fragment= root.createPackageFragment(packageName, true, null);
+		return fragment.createCompilationUnit(fileName, source, false, null);
+	}
+
+	private Map<String, CompilationUnit> parse(ICompilationUnit[] units) {
+		Map<String, CompilationUnit> roots= new LinkedHashMap<>();
+		ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
+		parser.setProject(context.getJavaProject());
+		parser.setResolveBindings(true);
+		parser.setBindingsRecovery(IASTSharedValues.SHARED_BINDING_RECOVERY);
+		parser.setStatementsRecovery(IASTSharedValues.SHARED_AST_STATEMENT_RECOVERY);
+		parser.setCompilerOptions(RefactoringASTParser.getCompilerOptions(context.getJavaProject()));
+		parser.createASTs(units, new String[0], new ASTRequestor() {
+			@Override
+			public void acceptAST(ICompilationUnit source, CompilationUnit ast) {
+				roots.put(source.getPrimary().getHandleIdentifier(), ast);
+			}
+		}, null);
+		return roots;
+	}
+
+	private static Family family(JdtCoreHarnessPlanner.Result result, String typeName) {
+		return result.inventory().families().stream().filter(candidate -> typeName.equals(candidate.typeName()))
+				.findFirst().orElseThrow();
+	}
+}

--- a/sandbox_target/eclipse.target
+++ b/sandbox_target/eclipse.target
@@ -15,27 +15,33 @@
             <unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
         </location>
 
-        <!-- 2. Orbit dependencies aligned with Eclipse 2026-06 / Platform 4.40 -->
+        <!-- 2. Eclipse test performance API used by the JDT Core Jupiter bridge -->
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/eclipse/updates/4.40/"/>
+            <unit id="org.eclipse.test.performance" version="0.0.0"/>
+        </location>
+
+        <!-- 3. Orbit dependencies aligned with Eclipse 2026-06 / Platform 4.40 -->
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2026-06/"/>
             <unit id="org.apache.commons.commons-io" version="0.0.0"/>
             <unit id="org.apache.commons.lang3" version="0.0.0"/>
         </location>
 
-        <!-- 3. Eclipse license information -->
+        <!-- 4. Eclipse license information -->
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <repository location="https://download.eclipse.org/cbi/updates/license"/>
             <unit id="org.eclipse.license.feature.group" version="0.0.0"/>
         </location>
 
-        <!-- 4. EGit (Eclipse Git Client) -->
+        <!-- 5. EGit (Eclipse Git Client) -->
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <repository location="https://download.eclipse.org/egit/updates/"/>
             <unit id="org.eclipse.egit.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.jgit.feature.group" version="0.0.0"/>
         </location>
 
-        <!-- 5. Bouncy Castle versions supplied by the Orbit 4.40 release -->
+        <!-- 6. Bouncy Castle versions supplied by the Orbit 4.40 release -->
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <repository location="https://download.eclipse.org/tools/orbit/simrel/maven-osgi/release/4.40.0"/>
             <unit id="bcutil" version="1.84.0"/>
@@ -44,7 +50,7 @@
             <unit id="bcpg" version="1.84.0"/>
         </location>
 
-        <!-- 6. SWTBot Testing Framework -->
+        <!-- 7. SWTBot Testing Framework -->
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <repository location="https://download.eclipse.org/technology/swtbot/releases/latest/"/>
             <unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>


### PR DESCRIPTION
## Problem

PR #1336 safely migrates ordinary closed JUnit 3 hierarchies, but deliberately rejects the custom Eclipse JDT Core test harness. That harness also owns named test construction, static selection filters, configurable ordering, indexer and performance hooks, interrupt cleanup, memory tracing, once-per-suite mutable state transfer and compiler-compliance multiplication.

Removing the custom base directly would lose behavior. This draft therefore implements only the first explicit framework slice and leaves every unsupported family on the unchanged JUnit 3 harness.

## Implemented Slice A: unfiltered direct custom-TestCase families

The implementation now:

- inventories source families through resolved bindings and separates `DIRECT_TEST_CASE`, `SUITE_STATE` and `COMPILER_COMPLIANCE` families;
- admits only a public concrete class that directly extends `org.eclipse.jdt.core.tests.junit.extension.TestCase`, has exactly the conventional public `String` constructor, declares exact public zero-argument `void test*` methods and uses at most the removable local `suite() -> TestCase.buildTestSuite(Self.class)` form;
- requires a closed source scope and rejects inaccessible classes or constructors, unresolved/binary references, external aggregate-suite owners, locally hidden external suite builders, abstract family bases, unsupported helper calls, inherited custom-TestCase instance fields not represented by the bridge and stale targets;
- rejects lifecycle and JUnit 3 execution-hook declarations including `setUp`, `tearDown`, `runTest`, `runBare`, `run`, `setUpTest`, `createResult`, `countTestCases`, `getName` and `setName` until each has an explicit Jupiter mapping;
- rejects `TESTS_PREFIX`, `TESTS_NAMES`, `TESTS_NUMBERS`, `TESTS_RANGE`, `RUN_ONLY_ID` use and `testONLY_*` methods until selection can be represented at Jupiter discovery time without retaining skipped nodes and changing tree multiplicity;
- adds a nested `TestCase.Jupiter` bridge while leaving the original JUnit 3 class available for all unmigrated families;
- extends Eclipse Platform's existing `org.eclipse.test.performance.PerformanceTestCaseJunit5`; no second performance framework is introduced;
- preserves configurable ordering for admitted unfiltered families, including bytecode order, by forcing the concrete test class to initialize before Jupiter discovery reads its static `ORDERING` configuration and by using the same reflected starting order before seeded shuffles;
- preserves same-thread execution, indexer disable/restore, interrupt cleanup, supported memory hooks and supported performance calls;
- rewrites only binding-stable planned superclass, constructor, optional local suite, exact test methods and assertion invocations;
- resolves every planned type, method and invocation again immediately before rewriting and fails closed on stale coverage;
- keeps method/assertion changes on the plan-aware `.sandbox-hint` backend introduced by #1336.

The public class and public constructor restrictions deliberately preserve the old harness's reflective `getConstructor(String.class)` behavior. A shape that JUnit 3 cannot instantiate is not converted into a newly executable Jupiter family. The bridge deliberately reproduces `indexDisabledForTest`; any other inherited custom-TestCase instance field use is rejected until that state has an explicit mapping.

## Active verification in this draft

- binding-resolved PDE tests classify direct, `SuiteOfTestCases` and `AbstractCompilerTest` families separately;
- package-private test classes and non-public named constructors are rejected so test multiplicity cannot increase during migration;
- aggregate suite ownership and a local `suite()` delegating to an external harness owner are rejected;
- configured filter fields and `testONLY_*` discovery explicitly fail closed instead of being approximated with Jupiter execution conditions;
- declaration regressions prove that custom result, count and name hooks remain rejected;
- a binding regression proves that inherited custom-TestCase instance state such as `abortOnFailure` remains rejected when it is not represented by the Jupiter bridge;
- an end-to-end fixture runs the same JDT JUnit 5/Vintage launch before and after an actual unfiltered direct-family rewrite and compares a non-empty successful runtime tree;
- a contract fixture uses three reverse-ordered tests to compare identity, order and multiplicity before and after the actual rewrite and actively checks indexer disable/restore, interrupt cleanup and supported performance call sequences;
- a second active launch fixture sets a numeric ordering seed and proves that the migrated Jupiter family shuffles the same reflected `getDeclaredMethods()` starting order as the JUnit 3 harness;
- a binding regression uses the real JDT Core declaration shape where `startMeasuring`, `stopMeasuring`, `commitMeasurements` and `assertPerformance` resolve to public wrappers on the custom `TestCase`, rather than directly to the Platform performance base;
- the filter contract also executes a configured-filter family before and after the cleanup, proves that it remains on the unchanged JUnit 3 harness, and compares the same non-empty successful filtered runtime tree; filter behavior is therefore preserved by fail-closed isolation, not claimed as migrated;
- a target-platform compilation fixture adds the real `org.eclipse.test.performance` and `org.eclipse.jdt.core` bundles and compiles the generated bridge against `PerformanceTestCaseJunit5` and the target JDT APIs, rather than substituting a performance implementation;
- the repository target includes the platform performance bundle from the matching Eclipse 4.40 repository so the test fragment resolves on every configured target environment.

## Explicitly rejected pending separate slices

1. Configured test-selection migration: exact discovery-time mapping for `TESTS_*`, `RUN_ONLY_ID` and `testONLY_*` without skipped-node multiplicity changes. Configured families remain unchanged and are covered by the fail-closed runtime-tree test above.
2. `SuiteOfTestCases`: once-per-suite setup/teardown, fresh instances, mutable non-static/non-final field transfer, freeze monitoring and standalone rerun setup.
3. `AbstractCompilerTest`: exact compliance-level multiplication, `INHERITED_DEPTH`, setup suites, preview exclusion and per-compliance runtime-tree multiplicity.
4. Aggregate `Run*`/`TestAll` suites, decorators and remaining external harness owners or project-specific callbacks.

## Draft status

This PR remains Draft and is not ready to merge. The implemented direct-family slice and the fail-closed preservation of configured-filter families still require all fresh Java CI with Maven, Distribution Smoke Test, CodeQL, Codacy, Test Source Inventory and applicable capability/core checks to be green, all review threads to be resolved, and the proven slice to be rebuilt as one clean commit on current `main`. Only then will #1334 be updated with the exact supported and rejected scope and a merge notification be sent.

Refs #1334 and #1217.