### PR TITLE
Migrate detachable JDT Core JUnit 3 leaves

### DIFF
--- a/docs/junit3-jdt-core-harness-migration.md
+++ b/docs/junit3-jdt-core-harness-migration.md
@@ -1,0 +1,48 @@
+# Staged JDT Core JUnit 3 harness migration
+
+The Eclipse JDT Core test harness is not a normal `junit.framework.TestCase`
+hierarchy. Its custom `org.eclipse.jdt.core.tests.junit.extension.TestCase`
+combines named construction, configurable method filtering and ordering,
+performance callbacks, indexer state, memory diagnostics and rerun hooks.
+`SuiteOfTestCases` additionally provides suite-scoped setup and teardown and
+copies instance state between separately constructed JUnit 3 test objects.
+
+A safe migration therefore proceeds in independently verified slices.
+
+## Slice 1: detachable single-test leaves
+
+The first supported custom-harness shape is deliberately narrow:
+
+- the concrete class directly extends the JDT Core custom `TestCase`;
+- it has no source subtype and no reference outside its own compilation unit;
+- it declares exactly one public, non-static, parameterless `void test*()` method;
+- its only constructor is `public Type(String name) { super(name); }`;
+- its only `suite()` method is `return buildTestSuite(Type.class);`;
+- it has no lifecycle override, name access, performance call, inherited field
+  access or other custom-harness API use;
+- assertion calls must resolve to the ordinary JUnit 3 assertion API, not to a
+  JDT-specific assertion overload.
+
+For this shape the constructor and suite method carry discovery mechanics only.
+The cleanup removes them and the custom superclass, materializes the Jupiter
+`@Test` method and rewrites the ordinary assertion call. An active regression
+runs the same type through JDT's JUnit 5/Vintage launch before and after and
+requires an identical, non-empty, successful runtime tree.
+
+Classes with more than one test remain rejected because the JDT harness can
+change their order through the `ordering` system property. Preserving only the
+default order would silently remove a supported debugging mode.
+
+## Remaining slices
+
+The following concepts still require explicit models and remain unchanged:
+
+1. configurable multi-test filtering and ordering (`TESTS_PREFIX`,
+   `TESTS_NAMES`, `TESTS_NUMBERS`, `TESTS_RANGE`, `RUN_ONLY_ID`, `ORDERING`);
+2. inherited-depth suite construction;
+3. `SuiteOfTestCases` suite-scoped setup, teardown and instance-field transfer;
+4. compliance-level multiplication and custom suite aggregators;
+5. performance meters, memory logging, indexer control and rerun callbacks.
+
+Each later slice must use the existing JDT launch as its before/after oracle and
+must fail closed when the complete source and runtime contract is unavailable.

--- a/docs/junit3-jdt-core-harness-migration.md
+++ b/docs/junit3-jdt-core-harness-migration.md
@@ -17,7 +17,9 @@ The first supported custom-harness shape is deliberately narrow:
 - it has no source subtype and no reference outside its own compilation unit;
 - it declares exactly one public, non-static, parameterless `void test*()` method;
 - its only constructor is `public Type(String name) { super(name); }`;
-- its only `suite()` method is `return buildTestSuite(Type.class);`;
+- its only `suite()` method is either `return buildTestSuite(Type.class);` or the
+  exact package-named wrapper used by real compiler tests such as
+  `IrritantSetTest`;
 - it has no lifecycle override, name access, performance call, inherited field
   access or other custom-harness API use;
 - assertion calls must resolve to the ordinary JUnit 3 assertion API, not to a
@@ -26,8 +28,9 @@ The first supported custom-harness shape is deliberately narrow:
 For this shape the constructor and suite method carry discovery mechanics only.
 The cleanup removes them and the custom superclass, materializes the Jupiter
 `@Test` method and rewrites the ordinary assertion call. An active regression
-runs the same type through JDT's JUnit 5/Vintage launch before and after and
-requires an identical, non-empty, successful runtime tree.
+models the real package-named `TestSuite` construction and runs the same type
+through JDT's JUnit 5/Vintage launch before and after. The migration is accepted
+only if the complete non-empty successful runtime tree remains identical.
 
 Classes with more than one test remain rejected because the JDT harness can
 change their order through the `ordering` system property. Preserving only the

--- a/docs/qa/jdt-core-custom-leaf-migration.md
+++ b/docs/qa/jdt-core-custom-leaf-migration.md
@@ -1,0 +1,17 @@
+# JDT Core custom leaf migration QA
+
+The first JDT Core harness slice is accepted only when all of the following hold:
+
+- the source class directly extends `org.eclipse.jdt.core.tests.junit.extension.TestCase`;
+- the class has exactly one executable JUnit 3 test method;
+- the named constructor and `buildTestSuite(This.class)` method are exact boilerplate;
+- the class has no source subtype and no external reference;
+- no method or field declared by the custom harness is used;
+- assertions resolve to the ordinary JUnit 3 assertion API;
+- the same JDT JUnit 5/Vintage launch succeeds before and after migration;
+- the non-empty runtime trees are identical;
+- a two-test fixture remains unchanged because configurable harness ordering would otherwise be lost.
+
+The QA intentionally does not claim support for `SuiteOfTestCases`, compliance
+multiplication, inherited-depth discovery, filters, performance callbacks,
+indexer control or state transfer between JUnit 3 instances.

--- a/docs/qa/jdt-core-custom-leaf-migration.md
+++ b/docs/qa/jdt-core-custom-leaf-migration.md
@@ -4,12 +4,14 @@ The first JDT Core harness slice is accepted only when all of the following hold
 
 - the source class directly extends `org.eclipse.jdt.core.tests.junit.extension.TestCase`;
 - the class has exactly one executable JUnit 3 test method;
-- the named constructor and `buildTestSuite(This.class)` method are exact boilerplate;
+- the named constructor is exact boilerplate;
+- the suite is either the exact inherited `buildTestSuite(This.class)` form or
+  the real package-named outer `TestSuite` plus inner class `TestSuite` form;
 - the class has no source subtype and no external reference;
 - no method or field declared by the custom harness is used;
 - assertions resolve to the ordinary JUnit 3 assertion API;
 - the same JDT JUnit 5/Vintage launch succeeds before and after migration;
-- the non-empty runtime trees are identical;
+- the complete non-empty runtime trees are identical;
 - a two-test fixture remains unchanged because configurable harness ordering would otherwise be lost.
 
 The QA intentionally does not claim support for `SuiteOfTestCases`, compliance

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/JUnitCleanUpFixCore.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/JUnitCleanUpFixCore.java
@@ -43,6 +43,7 @@ import org.sandbox.jdt.internal.corext.fix.helper.AssumeOptimizationJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.BeforeClassJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.BeforeJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.CategoryJUnitPlugin;
+import org.sandbox.jdt.internal.corext.fix.helper.CompositeJUnit3Plugin;
 import org.sandbox.jdt.internal.corext.fix.helper.ExternalResourceJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.FixMethodOrderJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.IgnoreJUnitPlugin;
@@ -56,7 +57,6 @@ import org.sandbox.jdt.internal.corext.fix.helper.RuleTimeoutJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.RunWithJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.TestExpectedAndTimeoutJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.TestExpectedJUnitPlugin;
-import org.sandbox.jdt.internal.corext.fix.helper.TestJUnit3Plugin;
 import org.sandbox.jdt.internal.corext.fix.helper.TestJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.TestTimeoutJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.ThrowingRunnableJUnitPlugin;
@@ -69,7 +69,7 @@ public enum JUnitCleanUpFixCore {
 	BEFORE(new BeforeJUnitPlugin()),
 	AFTER(new AfterJUnitPlugin()),
 	TEST(new TestJUnitPlugin()),
-	TEST3(new TestJUnit3Plugin()),
+	TEST3(new CompositeJUnit3Plugin()),
 	TEST_EXPECTED_TIMEOUT(new TestExpectedAndTimeoutJUnitPlugin()),
 	TEST_TIMEOUT(new TestTimeoutJUnitPlugin()),
 	TEST_EXPECTED(new TestExpectedJUnitPlugin()),

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/CompositeJUnit3Plugin.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/CompositeJUnit3Plugin.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.corext.fix.helper;
+
+import java.util.Set;
+
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
+
+import org.eclipse.text.edits.TextEditGroup;
+
+import org.sandbox.jdt.internal.common.ReferenceHolder;
+import org.sandbox.jdt.internal.corext.fix.JUnitCleanUpFixCore;
+import org.sandbox.jdt.internal.corext.fix.helper.lib.AbstractTool;
+import org.sandbox.jdt.internal.corext.fix.helper.lib.JunitHolder;
+
+/** Dispatches the shared JUnit 3 cleanup option to its fail-closed migration slices. */
+public final class CompositeJUnit3Plugin extends AbstractTool<ReferenceHolder<Integer, JunitHolder>> {
+
+	private final TestJUnit3Plugin standalone= new TestJUnit3Plugin();
+	private final JdtCoreLeafJUnitPlugin jdtCoreLeaf= new JdtCoreLeafJUnitPlugin();
+
+	@Override
+	public void find(JUnitCleanUpFixCore fixcore, CompilationUnit compilationUnit,
+			Set<CompilationUnitRewriteOperationWithSourceRange> operations, Set<ASTNode> nodesprocessed) {
+		standalone.find(fixcore, compilationUnit, operations, nodesprocessed);
+		jdtCoreLeaf.find(fixcore, compilationUnit, operations, nodesprocessed);
+	}
+
+	@Override
+	protected void process2Rewrite(TextEditGroup group, ASTRewrite rewriter, AST ast,
+			ImportRewrite importRewriter, JunitHolder holder) {
+		if (jdtCoreLeaf.handles(holder)) {
+			jdtCoreLeaf.process2Rewrite(group, rewriter, ast, importRewriter, holder);
+		} else {
+			standalone.process2Rewrite(group, rewriter, ast, importRewriter, holder);
+		}
+	}
+
+	@Override
+	public String getPreview(boolean afterRefactoring) {
+		return standalone.getPreview(afterRefactoring);
+	}
+
+	@Override
+	public String toString() {
+		return standalone.toString();
+	}
+}

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/JdtCoreLeafJUnitPlugin.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/JdtCoreLeafJUnitPlugin.java
@@ -1,0 +1,438 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.corext.fix.helper;
+
+import static org.sandbox.jdt.internal.corext.fix.helper.lib.JUnitConstants.ONEPARAM_ASSERTIONS;
+import static org.sandbox.jdt.internal.corext.fix.helper.lib.JUnitConstants.ORG_JUNIT_JUPITER_API_ASSERTIONS;
+import static org.sandbox.jdt.internal.corext.fix.helper.lib.JUnitConstants.TWOPARAM_ASSERTIONS;
+
+import java.util.Set;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.ITypeHierarchy;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.Annotation;
+import org.eclipse.jdt.core.dom.BodyDeclaration;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.IVariableBinding;
+import org.eclipse.jdt.core.dom.MarkerAnnotation;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.Modifier;
+import org.eclipse.jdt.core.dom.PrimitiveType;
+import org.eclipse.jdt.core.dom.ReturnStatement;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
+import org.eclipse.jdt.core.dom.SuperConstructorInvocation;
+import org.eclipse.jdt.core.dom.SuperFieldAccess;
+import org.eclipse.jdt.core.dom.SuperMethodInvocation;
+import org.eclipse.jdt.core.dom.Type;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.core.dom.TypeLiteral;
+import org.eclipse.jdt.core.dom.VariableDeclaration;
+import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
+import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
+import org.eclipse.jdt.core.search.IJavaSearchConstants;
+import org.eclipse.jdt.core.search.SearchEngine;
+import org.eclipse.jdt.core.search.SearchMatch;
+import org.eclipse.jdt.core.search.SearchParticipant;
+import org.eclipse.jdt.core.search.SearchPattern;
+import org.eclipse.jdt.core.search.SearchRequestor;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
+
+import org.eclipse.text.edits.TextEditGroup;
+
+import org.sandbox.jdt.internal.common.HelperVisitorFactory;
+import org.sandbox.jdt.internal.common.ReferenceHolder;
+import org.sandbox.jdt.internal.corext.fix.JUnitCleanUpFixCore;
+import org.sandbox.jdt.internal.corext.fix.helper.lib.AbstractTool;
+import org.sandbox.jdt.internal.corext.fix.helper.lib.JunitHolder;
+import org.sandbox.jdt.internal.corext.util.AnnotationUtils;
+
+/**
+ * Migrates the smallest provably detachable Eclipse JDT Core JUnit 3 harness
+ * leaf: one exact named constructor, one exact {@code buildTestSuite(This.class)}
+ * suite method and one ordinary test method that uses no custom harness API.
+ *
+ * <p>This intentionally does not support {@code SuiteOfTestCases}, inherited
+ * tests, configurable ordering, filters, performance callbacks or lifecycle
+ * overrides. Those shapes remain on Vintage until a dedicated harness model is
+ * available.</p>
+ */
+final class JdtCoreLeafJUnitPlugin extends AbstractTool<ReferenceHolder<Integer, JunitHolder>> {
+
+	private static final String MODE= "JDT_CORE_DETACHABLE_LEAF"; //$NON-NLS-1$
+	private static final String JDT_CORE_TEST_CASE=
+			"org.eclipse.jdt.core.tests.junit.extension.TestCase"; //$NON-NLS-1$
+	private static final String JUNIT3_ASSERT= "junit.framework.Assert"; //$NON-NLS-1$
+	private static final String JUNIT3_TEST= "junit.framework.Test"; //$NON-NLS-1$
+	private static final String JUNIT3_TEST_CASE= "junit.framework.TestCase"; //$NON-NLS-1$
+	private static final String JUNIT3_TEST_SUITE= "junit.framework.TestSuite"; //$NON-NLS-1$
+	private static final Set<String> ASSERTIONS= Set.of(
+			"assertEquals", "assertArrayEquals", "assertTrue", "assertFalse", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+			"assertNull", "assertNotNull", "assertSame", "assertNotSame", "fail"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+
+	@Override
+	public void find(JUnitCleanUpFixCore fixcore, CompilationUnit compilationUnit,
+			Set<CompilationUnitRewriteOperationWithSourceRange> operations, Set<ASTNode> nodesprocessed) {
+		ReferenceHolder<Integer, JunitHolder> dataHolder= ReferenceHolder.createIndexed();
+		HelperVisitorFactory.callTypeDeclarationVisitor(JDT_CORE_TEST_CASE, compilationUnit, dataHolder, nodesprocessed,
+				(visited, holder) -> processFoundNode(fixcore, operations, visited, holder, nodesprocessed));
+	}
+
+	boolean handles(JunitHolder holder) {
+		return MODE.equals(holder.getAdditionalInfo());
+	}
+
+	private boolean processFoundNode(JUnitCleanUpFixCore fixcore,
+			Set<CompilationUnitRewriteOperationWithSourceRange> operations, TypeDeclaration node,
+			ReferenceHolder<Integer, JunitHolder> dataHolder, Set<ASTNode> nodesprocessed) {
+		if (nodesprocessed.contains(node) || !isSafeCandidate(node)) {
+			return false;
+		}
+		nodesprocessed.add(node);
+		JunitHolder holder= new JunitHolder().setMinv(node).setAdditionalInfo(MODE);
+		dataHolder.put(dataHolder.size(), holder);
+		operations.add(fixcore.rewrite(dataHolder));
+		return false;
+	}
+
+	private boolean isSafeCandidate(TypeDeclaration node) {
+		ITypeBinding binding= node.resolveBinding();
+		ITypeBinding superclass= binding == null ? null : binding.getSuperclass();
+		if (binding == null || superclass == null || !node.isPackageMemberTypeDeclaration()
+				|| !Modifier.isPublic(node.getModifiers()) || Modifier.isAbstract(node.getModifiers())
+				|| !JDT_CORE_TEST_CASE.equals(superclass.getErasure().getQualifiedName())
+				|| hasJUnitAnnotation(node) || !hasSingleTopLevelType(node)
+				|| !(binding.getJavaElement() instanceof IType type)) {
+			return false;
+		}
+		if (hasKnownSubtypes(type) || hasReferencesOutsideOwnCompilationUnit(type)) {
+			return false;
+		}
+
+		MethodDeclaration constructor= null;
+		MethodDeclaration suite= null;
+		MethodDeclaration test= null;
+		for (MethodDeclaration method : node.getMethods()) {
+			if (hasJUnitAnnotation(method)) {
+				return false;
+			}
+			if (method.isConstructor()) {
+				if (constructor != null || !isTrivialNamedConstructor(method)) {
+					return false;
+				}
+				constructor= method;
+				continue;
+			}
+			String name= method.getName().getIdentifier();
+			if ("suite".equals(name)) { //$NON-NLS-1$
+				if (suite != null || !isTrivialSuite(method, binding)) {
+					return false;
+				}
+				suite= method;
+				continue;
+			}
+			if ("setUp".equals(name) || "tearDown".equals(name) || "runTest".equals(name) //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+					|| "runBare".equals(name) || "getName".equals(name) || "setName".equals(name) //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+					|| "setUpTest".equals(name)) { //$NON-NLS-1$
+				return false;
+			}
+			if (name.startsWith("test")) { //$NON-NLS-1$
+				if (test != null || !isExactTestMethod(method)) {
+					return false;
+				}
+				test= method;
+			}
+		}
+		return constructor != null && suite != null && test != null
+				&& !hasUnsupportedHarnessUsage(node, binding, constructor, suite);
+	}
+
+	private boolean isTrivialNamedConstructor(MethodDeclaration method) {
+		if (!Modifier.isPublic(method.getModifiers()) || method.parameters().size() != 1
+				|| method.getBody() == null || method.getBody().statements().size() != 1
+				|| !method.thrownExceptionTypes().isEmpty() || !method.typeParameters().isEmpty()) {
+			return false;
+		}
+		SingleVariableDeclaration parameter= (SingleVariableDeclaration) method.parameters().get(0);
+		ITypeBinding parameterType= parameter.getType().resolveBinding();
+		if (parameterType == null || !"java.lang.String".equals(parameterType.getErasure().getQualifiedName()) //$NON-NLS-1$
+				|| parameter.isVarargs()) {
+			return false;
+		}
+		Object statement= method.getBody().statements().get(0);
+		if (!(statement instanceof SuperConstructorInvocation invocation) || invocation.arguments().size() != 1) {
+			return false;
+		}
+		Object argument= invocation.arguments().get(0);
+		return argument instanceof SimpleName name
+				&& sameVariable(name.resolveBinding(), parameter.resolveBinding());
+	}
+
+	private boolean isTrivialSuite(MethodDeclaration method, ITypeBinding testType) {
+		if (!Modifier.isPublic(method.getModifiers()) || !Modifier.isStatic(method.getModifiers())
+				|| !method.parameters().isEmpty() || method.getBody() == null
+				|| method.getBody().statements().size() != 1 || !method.thrownExceptionTypes().isEmpty()) {
+			return false;
+		}
+		ITypeBinding returnType= method.getReturnType2() == null ? null : method.getReturnType2().resolveBinding();
+		if (returnType == null || !JUNIT3_TEST.equals(returnType.getErasure().getQualifiedName())) {
+			return false;
+		}
+		Object statement= method.getBody().statements().get(0);
+		if (!(statement instanceof ReturnStatement returnStatement)
+				|| !(returnStatement.getExpression() instanceof MethodInvocation invocation)
+				|| invocation.getExpression() != null || !"buildTestSuite".equals(invocation.getName().getIdentifier()) //$NON-NLS-1$
+				|| invocation.arguments().size() != 1) {
+			return false;
+		}
+		IMethodBinding binding= invocation.resolveMethodBinding();
+		ITypeBinding owner= binding == null ? null : binding.getMethodDeclaration().getDeclaringClass();
+		if (owner == null || !JDT_CORE_TEST_CASE.equals(owner.getErasure().getQualifiedName())
+				|| !Modifier.isStatic(binding.getModifiers())) {
+			return false;
+		}
+		Object argument= invocation.arguments().get(0);
+		if (!(argument instanceof TypeLiteral literal)) {
+			return false;
+		}
+		ITypeBinding literalType= literal.getType().resolveBinding();
+		return literalType != null && testType.getErasure().isEqualTo(literalType.getErasure());
+	}
+
+	private boolean hasUnsupportedHarnessUsage(TypeDeclaration node, ITypeBinding candidate,
+			MethodDeclaration constructor, MethodDeclaration suite) {
+		boolean[] unsupported= { false };
+		node.accept(new ASTVisitor() {
+			private MethodDeclaration current;
+
+			@Override
+			public boolean visit(MethodDeclaration method) {
+				current= method;
+				return method != constructor && method != suite;
+			}
+
+			@Override
+			public void endVisit(MethodDeclaration method) {
+				if (current == method) {
+					current= null;
+				}
+			}
+
+			@Override
+			public boolean visit(SuperMethodInvocation invocation) {
+				unsupported[0]= true;
+				return false;
+			}
+
+			@Override
+			public boolean visit(SuperFieldAccess access) {
+				unsupported[0]= true;
+				return false;
+			}
+
+			@Override
+			public boolean visit(MethodInvocation invocation) {
+				if (current == null) {
+					return true;
+				}
+				IMethodBinding method= invocation.resolveMethodBinding();
+				if (method == null) {
+					unsupported[0]= true;
+					return false;
+				}
+				ITypeBinding owner= method.getMethodDeclaration().getDeclaringClass();
+				String ownerName= owner == null ? "" : owner.getErasure().getQualifiedName(); //$NON-NLS-1$
+				String name= invocation.getName().getIdentifier();
+				if ((JUNIT3_ASSERT.equals(ownerName) || JUNIT3_TEST_CASE.equals(ownerName))
+						&& ASSERTIONS.contains(name)) {
+					return true;
+				}
+				if (owner != null && !candidate.getErasure().isEqualTo(owner.getErasure())
+						&& isSubtypeOf(owner, JUNIT3_TEST_CASE)) {
+					unsupported[0]= true;
+					return false;
+				}
+				return true;
+			}
+
+			@Override
+			public boolean visit(SimpleName name) {
+				if (current == null) {
+					return true;
+				}
+				IBinding binding= name.resolveBinding();
+				if (binding instanceof IVariableBinding variable && variable.isField()) {
+					ITypeBinding owner= variable.getDeclaringClass();
+					if (owner != null && !candidate.getErasure().isEqualTo(owner.getErasure())
+							&& isSubtypeOf(owner, JUNIT3_TEST_CASE)) {
+						unsupported[0]= true;
+						return false;
+					}
+				}
+				return true;
+			}
+		});
+		return unsupported[0];
+	}
+
+	private boolean hasKnownSubtypes(IType type) {
+		try {
+			ITypeHierarchy hierarchy= type.newTypeHierarchy(null);
+			return hierarchy.getAllSubtypes(type).length != 0;
+		} catch (JavaModelException e) {
+			return true;
+		}
+	}
+
+	private boolean hasReferencesOutsideOwnCompilationUnit(IType type) {
+		SearchPattern pattern= SearchPattern.createPattern(type, IJavaSearchConstants.REFERENCES);
+		ICompilationUnit ownUnit= type.getCompilationUnit();
+		if (pattern == null || ownUnit == null) {
+			return true;
+		}
+		boolean[] referenced= { false };
+		try {
+			new SearchEngine().search(pattern,
+					new SearchParticipant[] { SearchEngine.getDefaultSearchParticipant() },
+					SearchEngine.createWorkspaceScope(), new SearchRequestor() {
+						@Override
+						public void acceptSearchMatch(SearchMatch match) {
+							Object element= match.getElement();
+							if (element instanceof IJavaElement javaElement) {
+								IJavaElement ancestor= javaElement.getAncestor(IJavaElement.COMPILATION_UNIT);
+								if (ancestor instanceof ICompilationUnit unit
+										&& ownUnit.getPrimary().equals(unit.getPrimary())) {
+									return;
+								}
+							}
+							referenced[0]= true;
+						}
+					}, null);
+		} catch (CoreException e) {
+			return true;
+		}
+		return referenced[0];
+	}
+
+	private static boolean isSubtypeOf(ITypeBinding type, String expected) {
+		ITypeBinding current= type;
+		while (current != null) {
+			if (expected.equals(current.getErasure().getQualifiedName())) {
+				return true;
+			}
+			current= current.getSuperclass();
+		}
+		return false;
+	}
+
+	private static boolean sameVariable(IBinding first, IBinding second) {
+		return first instanceof IVariableBinding left && second instanceof IVariableBinding right
+				&& left.getVariableDeclaration().isEqualTo(right.getVariableDeclaration());
+	}
+
+	private static boolean hasSingleTopLevelType(TypeDeclaration node) {
+		return node.getRoot() instanceof CompilationUnit root && root.types().size() == 1;
+	}
+
+	private static boolean hasJUnitAnnotation(BodyDeclaration declaration) {
+		for (Object modifier : declaration.modifiers()) {
+			if (modifier instanceof Annotation annotation) {
+				ITypeBinding annotationType= annotation.resolveTypeBinding();
+				String name= annotationType == null ? annotation.getTypeName().getFullyQualifiedName()
+						: annotationType.getQualifiedName();
+				if (name.startsWith("org.junit.") || name.startsWith("junit.framework.")) { //$NON-NLS-1$ //$NON-NLS-2$
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	private static boolean isExactTestMethod(MethodDeclaration method) {
+		Type returnType= method.getReturnType2();
+		return !method.isConstructor() && method.getName().getIdentifier().startsWith("test") //$NON-NLS-1$
+				&& Modifier.isPublic(method.getModifiers()) && !Modifier.isStatic(method.getModifiers())
+				&& method.parameters().isEmpty() && returnType != null && returnType.isPrimitiveType()
+				&& PrimitiveType.VOID.equals(((org.eclipse.jdt.core.dom.PrimitiveType) returnType).getPrimitiveTypeCode());
+	}
+
+	@Override
+	protected void process2Rewrite(TextEditGroup group, ASTRewrite rewriter, AST ast,
+			ImportRewrite importRewriter, JunitHolder holder) {
+		TypeDeclaration type= holder.getTypeDeclaration();
+		Type superclass= type.getSuperclassType();
+		if (superclass != null) {
+			rewriter.remove(superclass, group);
+		}
+		importRewriter.removeImport(JDT_CORE_TEST_CASE);
+		importRewriter.removeImport(JUNIT3_TEST);
+		importRewriter.removeImport(JUNIT3_TEST_SUITE);
+
+		for (MethodDeclaration method : type.getMethods()) {
+			if (method.isConstructor() || "suite".equals(method.getName().getIdentifier())) { //$NON-NLS-1$
+				rewriter.remove(method, group);
+				continue;
+			}
+			if (isExactTestMethod(method)) {
+				ListRewrite modifiers= rewriter.getListRewrite(method, MethodDeclaration.MODIFIERS2_PROPERTY);
+				MarkerAnnotation annotation= AnnotationUtils.createMarkerAnnotation(ast, "Test"); //$NON-NLS-1$
+				modifiers.insertFirst(annotation, group);
+				importRewriter.addImport("org.junit.jupiter.api.Test"); //$NON-NLS-1$
+				rewriteAssertions(method, rewriter, ast, group, importRewriter);
+			}
+		}
+	}
+
+	private void rewriteAssertions(MethodDeclaration method, ASTRewrite rewriter, AST ast,
+			TextEditGroup group, ImportRewrite importRewriter) {
+		method.accept(new ASTVisitor() {
+			@Override
+			public boolean visit(MethodInvocation invocation) {
+				IMethodBinding binding= invocation.resolveMethodBinding();
+				ITypeBinding owner= binding == null ? null : binding.getMethodDeclaration().getDeclaringClass();
+				String ownerName= owner == null ? "" : owner.getErasure().getQualifiedName(); //$NON-NLS-1$
+				String name= invocation.getName().getIdentifier();
+				if ((JUNIT3_ASSERT.equals(ownerName) || JUNIT3_TEST_CASE.equals(ownerName))
+						&& ASSERTIONS.contains(name)) {
+					reorderParameters(invocation, rewriter, group, ONEPARAM_ASSERTIONS, TWOPARAM_ASSERTIONS);
+					rewriter.set(invocation, MethodInvocation.EXPRESSION_PROPERTY,
+							ast.newSimpleName("Assertions"), group); //$NON-NLS-1$
+					importRewriter.addImport(ORG_JUNIT_JUPITER_API_ASSERTIONS);
+				}
+				return true;
+			}
+		});
+	}
+
+	@Override
+	public String getPreview(boolean afterRefactoring) {
+		return afterRefactoring ? "import org.junit.jupiter.api.Test;\n" //$NON-NLS-1$
+				: "import org.eclipse.jdt.core.tests.junit.extension.TestCase;\n"; //$NON-NLS-1$
+	}
+
+	@Override
+	public String toString() {
+		return "JDT Core detachable TestCase leaf"; //$NON-NLS-1$
+	}
+}

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/JdtCoreLeafJUnitPlugin.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/JdtCoreLeafJUnitPlugin.java
@@ -28,7 +28,9 @@ import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.Annotation;
 import org.eclipse.jdt.core.dom.BodyDeclaration;
+import org.eclipse.jdt.core.dom.ClassInstanceCreation;
 import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.ExpressionStatement;
 import org.eclipse.jdt.core.dom.IBinding;
 import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
@@ -47,7 +49,8 @@ import org.eclipse.jdt.core.dom.SuperMethodInvocation;
 import org.eclipse.jdt.core.dom.Type;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.TypeLiteral;
-import org.eclipse.jdt.core.dom.VariableDeclaration;
+import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
 import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
@@ -70,13 +73,15 @@ import org.sandbox.jdt.internal.corext.util.AnnotationUtils;
 
 /**
  * Migrates the smallest provably detachable Eclipse JDT Core JUnit 3 harness
- * leaf: one exact named constructor, one exact {@code buildTestSuite(This.class)}
- * suite method and one ordinary test method that uses no custom harness API.
+ * leaf: one exact named constructor, one recognized discovery-only suite method
+ * and one ordinary test method that uses no custom harness API.
  *
- * <p>This intentionally does not support {@code SuiteOfTestCases}, inherited
- * tests, configurable ordering, filters, performance callbacks or lifecycle
- * overrides. Those shapes remain on Vintage until a dedicated harness model is
- * available.</p>
+ * <p>The recognized suite forms are the inherited
+ * {@code buildTestSuite(This.class)} call and the package-named wrapper used by
+ * real compiler tests such as {@code IrritantSetTest}. This intentionally does
+ * not support {@code SuiteOfTestCases}, inherited tests, configurable ordering,
+ * filters, performance callbacks or lifecycle overrides. Those shapes remain
+ * on Vintage until a dedicated harness model is available.</p>
  */
 final class JdtCoreLeafJUnitPlugin extends AbstractTool<ReferenceHolder<Integer, JunitHolder>> {
 
@@ -146,7 +151,7 @@ final class JdtCoreLeafJUnitPlugin extends AbstractTool<ReferenceHolder<Integer,
 			}
 			String name= method.getName().getIdentifier();
 			if ("suite".equals(name)) { //$NON-NLS-1$
-				if (suite != null || !isTrivialSuite(method, binding)) {
+				if (suite != null || !isDiscoveryOnlySuite(method, binding)) {
 					return false;
 				}
 				suite= method;
@@ -189,14 +194,21 @@ final class JdtCoreLeafJUnitPlugin extends AbstractTool<ReferenceHolder<Integer,
 				&& sameVariable(name.resolveBinding(), parameter.resolveBinding());
 	}
 
-	private boolean isTrivialSuite(MethodDeclaration method, ITypeBinding testType) {
+	private boolean isDiscoveryOnlySuite(MethodDeclaration method, ITypeBinding testType) {
 		if (!Modifier.isPublic(method.getModifiers()) || !Modifier.isStatic(method.getModifiers())
 				|| !method.parameters().isEmpty() || method.getBody() == null
-				|| method.getBody().statements().size() != 1 || !method.thrownExceptionTypes().isEmpty()) {
+				|| !method.thrownExceptionTypes().isEmpty()) {
 			return false;
 		}
 		ITypeBinding returnType= method.getReturnType2() == null ? null : method.getReturnType2().resolveBinding();
 		if (returnType == null || !JUNIT3_TEST.equals(returnType.getErasure().getQualifiedName())) {
+			return false;
+		}
+		return isBuildTestSuiteReturn(method, testType) || isPackageNamedTestSuite(method, testType);
+	}
+
+	private boolean isBuildTestSuiteReturn(MethodDeclaration method, ITypeBinding testType) {
+		if (method.getBody().statements().size() != 1) {
 			return false;
 		}
 		Object statement= method.getBody().statements().get(0);
@@ -208,16 +220,74 @@ final class JdtCoreLeafJUnitPlugin extends AbstractTool<ReferenceHolder<Integer,
 		}
 		IMethodBinding binding= invocation.resolveMethodBinding();
 		ITypeBinding owner= binding == null ? null : binding.getMethodDeclaration().getDeclaringClass();
-		if (owner == null || !JDT_CORE_TEST_CASE.equals(owner.getErasure().getQualifiedName())
-				|| !Modifier.isStatic(binding.getModifiers())) {
+		return owner != null && JDT_CORE_TEST_CASE.equals(owner.getErasure().getQualifiedName())
+				&& Modifier.isStatic(binding.getModifiers())
+				&& isClassLiteral(invocation.arguments().get(0), testType);
+	}
+
+	private boolean isPackageNamedTestSuite(MethodDeclaration method, ITypeBinding testType) {
+		if (method.getBody().statements().size() != 3
+				|| !(method.getBody().statements().get(0) instanceof VariableDeclarationStatement declaration)
+				|| declaration.fragments().size() != 1
+				|| !(declaration.fragments().get(0) instanceof VariableDeclarationFragment fragment)
+				|| !(fragment.getInitializer() instanceof ClassInstanceCreation outerSuite)
+				|| !isTestSuiteConstruction(outerSuite) || outerSuite.arguments().size() != 1
+				|| !isPackageNameCall(outerSuite.arguments().get(0), testType)
+				|| !(fragment.resolveBinding() instanceof IVariableBinding suiteVariable)) {
 			return false;
 		}
-		Object argument= invocation.arguments().get(0);
-		if (!(argument instanceof TypeLiteral literal)) {
+		ITypeBinding declaredType= declaration.getType().resolveBinding();
+		if (declaredType == null || !JUNIT3_TEST_SUITE.equals(declaredType.getErasure().getQualifiedName())) {
+			return false;
+		}
+
+		if (!(method.getBody().statements().get(1) instanceof ExpressionStatement expressionStatement)
+				|| !(expressionStatement.getExpression() instanceof MethodInvocation addTest)
+				|| !"addTest".equals(addTest.getName().getIdentifier()) || addTest.arguments().size() != 1 //$NON-NLS-1$
+				|| !(addTest.getExpression() instanceof SimpleName suiteReference)
+				|| !sameVariable(suiteReference.resolveBinding(), suiteVariable)
+				|| !(addTest.arguments().get(0) instanceof ClassInstanceCreation innerSuite)
+				|| !isTestSuiteConstruction(innerSuite) || innerSuite.arguments().size() != 1
+				|| !isClassLiteral(innerSuite.arguments().get(0), testType)) {
+			return false;
+		}
+		IMethodBinding addTestBinding= addTest.resolveMethodBinding();
+		ITypeBinding addTestOwner= addTestBinding == null ? null
+				: addTestBinding.getMethodDeclaration().getDeclaringClass();
+		if (addTestOwner == null || !JUNIT3_TEST_SUITE.equals(addTestOwner.getErasure().getQualifiedName())) {
+			return false;
+		}
+
+		Object last= method.getBody().statements().get(2);
+		return last instanceof ReturnStatement returnStatement
+				&& returnStatement.getExpression() instanceof SimpleName returnedSuite
+				&& sameVariable(returnedSuite.resolveBinding(), suiteVariable);
+	}
+
+	private static boolean isTestSuiteConstruction(ClassInstanceCreation creation) {
+		ITypeBinding type= creation.resolveTypeBinding();
+		return type != null && JUNIT3_TEST_SUITE.equals(type.getErasure().getQualifiedName());
+	}
+
+	private static boolean isPackageNameCall(Object expression, ITypeBinding testType) {
+		if (!(expression instanceof MethodInvocation invocation)
+				|| !"getPackageName".equals(invocation.getName().getIdentifier()) //$NON-NLS-1$
+				|| !invocation.arguments().isEmpty()
+				|| !(invocation.getExpression() instanceof TypeLiteral literal)
+				|| !isClassLiteral(literal, testType)) {
+			return false;
+		}
+		IMethodBinding binding= invocation.resolveMethodBinding();
+		ITypeBinding owner= binding == null ? null : binding.getMethodDeclaration().getDeclaringClass();
+		return owner != null && "java.lang.Class".equals(owner.getErasure().getQualifiedName()); //$NON-NLS-1$
+	}
+
+	private static boolean isClassLiteral(Object expression, ITypeBinding expectedType) {
+		if (!(expression instanceof TypeLiteral literal)) {
 			return false;
 		}
 		ITypeBinding literalType= literal.getType().resolveBinding();
-		return literalType != null && testType.getErasure().isEqualTo(literalType.getErasure());
+		return literalType != null && expectedType.getErasure().isEqualTo(literalType.getErasure());
 	}
 
 	private boolean hasUnsupportedHarnessUsage(TypeDeclaration node, ITypeBinding candidate,

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/JdtCoreLeafJUnitPlugin.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/JdtCoreLeafJUnitPlugin.java
@@ -232,12 +232,13 @@ final class JdtCoreLeafJUnitPlugin extends AbstractTool<ReferenceHolder<Integer,
 				|| !(declaration.fragments().get(0) instanceof VariableDeclarationFragment fragment)
 				|| !(fragment.getInitializer() instanceof ClassInstanceCreation outerSuite)
 				|| !isTestSuiteConstruction(outerSuite) || outerSuite.arguments().size() != 1
-				|| !isPackageNameCall(outerSuite.arguments().get(0), testType)
-				|| !(fragment.resolveBinding() instanceof IVariableBinding suiteVariable)) {
+				|| !isPackageNameCall(outerSuite.arguments().get(0), testType)) {
 			return false;
 		}
+		IVariableBinding suiteVariable= fragment.resolveBinding();
 		ITypeBinding declaredType= declaration.getType().resolveBinding();
-		if (declaredType == null || !JUNIT3_TEST_SUITE.equals(declaredType.getErasure().getQualifiedName())) {
+		if (suiteVariable == null || declaredType == null
+				|| !JUNIT3_TEST_SUITE.equals(declaredType.getErasure().getQualifiedName())) {
 			return false;
 		}
 

--- a/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/JdtCoreLeafMigrationTest.java
+++ b/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/JdtCoreLeafMigrationTest.java
@@ -47,13 +47,14 @@ public class JdtCoreLeafMigrationTest {
 	}
 
 	@Test
-	public void migratesSingleTestBuildTestSuiteLeafAndPreservesRuntimeTree() throws CoreException {
+	public void migratesRealPackageNamedSuiteLeafAndPreservesRuntimeTree() throws CoreException {
 		ICompilationUnit harness= createHarness();
 		IPackageFragment pack= root.createPackageFragment("sample", true, null); //$NON-NLS-1$
 		ICompilationUnit test= pack.createCompilationUnit("IrritantSetTest.java", //$NON-NLS-1$
 				"""
 				package sample;
 				import junit.framework.Test;
+				import junit.framework.TestSuite;
 				import org.eclipse.jdt.core.tests.junit.extension.TestCase;
 
 				public class IrritantSetTest extends TestCase {
@@ -62,7 +63,9 @@ public class JdtCoreLeafMigrationTest {
 					}
 
 					public static Test suite() {
-						return buildTestSuite(IrritantSetTest.class);
+						TestSuite suite = new TestSuite(IrritantSetTest.class.getPackageName());
+						suite.addTest(new TestSuite(IrritantSetTest.class));
+						return suite;
 					}
 
 					public void testGroup4() {
@@ -112,7 +115,7 @@ public class JdtCoreLeafMigrationTest {
 		Snapshot after= JUnitRuntimeTestTree.capture(launchTarget);
 		assertTrue(after.successful(), () -> "Migrated JDT Core leaf failed: " + after.entries()); //$NON-NLS-1$
 		assertEquals(before.entries(), after.entries(),
-				"The same JDT launch must preserve the single selected test and its suite path."); //$NON-NLS-1$
+				"The same JDT launch must preserve the real package-named suite path and test identity."); //$NON-NLS-1$
 	}
 
 	@Test

--- a/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/JdtCoreLeafMigrationTest.java
+++ b/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/JdtCoreLeafMigrationTest.java
@@ -1,0 +1,175 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.quickfix.Java8;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.IType;
+
+import org.eclipse.jdt.junit.JUnitCore;
+
+import org.sandbox.jdt.internal.corext.fix2.MYCleanUpConstants;
+import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
+import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava17;
+
+import org.eclipse.jdt.ui.tests.quickfix.Java8.JUnitRuntimeTestTree.Snapshot;
+
+/** Active migration contract for the first detachable Eclipse JDT Core harness leaf. */
+public class JdtCoreLeafMigrationTest {
+
+	@RegisterExtension
+	AbstractEclipseJava context= new EclipseJava17();
+
+	private IPackageFragmentRoot root;
+
+	@BeforeEach
+	public void setup() throws CoreException {
+		root= context.createClasspathForJUnit(JUnitCore.JUNIT5_CONTAINER_PATH);
+	}
+
+	@Test
+	public void migratesSingleTestBuildTestSuiteLeafAndPreservesRuntimeTree() throws CoreException {
+		ICompilationUnit harness= createHarness();
+		IPackageFragment pack= root.createPackageFragment("sample", true, null); //$NON-NLS-1$
+		ICompilationUnit test= pack.createCompilationUnit("IrritantSetTest.java", //$NON-NLS-1$
+				"""
+				package sample;
+				import junit.framework.Test;
+				import org.eclipse.jdt.core.tests.junit.extension.TestCase;
+
+				public class IrritantSetTest extends TestCase {
+					public IrritantSetTest(String name) {
+						super(name);
+					}
+
+					public static Test suite() {
+						return buildTestSuite(IrritantSetTest.class);
+					}
+
+					public void testGroup4() {
+						assertTrue(true);
+					}
+				}
+				""", false, null);
+
+		IType launchTarget= test.findPrimaryType();
+		assertNotNull(launchTarget);
+		Snapshot before= JUnitRuntimeTestTree.capture(launchTarget);
+		assertTrue(before.successful(), () -> "JDT Core-style JUnit 3 baseline failed: " + before.entries()); //$NON-NLS-1$
+
+		enableMigration();
+		context.assertRefactoringResultAsExpectedNormalizingWhitespace(
+				new ICompilationUnit[] { harness, test }, new String[] {
+						"""
+						package org.eclipse.jdt.core.tests.junit.extension;
+						import junit.framework.Test;
+						import junit.framework.TestSuite;
+
+						public class TestCase extends junit.framework.TestCase {
+							public TestCase(String name) {
+								super(name);
+							}
+
+							public static Test buildTestSuite(Class<?> type) {
+								return new TestSuite(type);
+							}
+						}
+						""",
+						"""
+						package sample;
+
+						import org.junit.jupiter.api.Assertions;
+						import org.junit.jupiter.api.Test;
+
+						public class IrritantSetTest {
+							@Test
+							public void testGroup4() {
+								Assertions.assertTrue(true);
+							}
+						}
+						"""
+				}, null);
+
+		Snapshot after= JUnitRuntimeTestTree.capture(launchTarget);
+		assertTrue(after.successful(), () -> "Migrated JDT Core leaf failed: " + after.entries()); //$NON-NLS-1$
+		assertEquals(before.entries(), after.entries(),
+				"The same JDT launch must preserve the single selected test and its suite path."); //$NON-NLS-1$
+	}
+
+	@Test
+	public void rejectsMultipleTestsBecauseConfigurableHarnessOrderingWouldBeLost() throws CoreException {
+		ICompilationUnit harness= createHarness();
+		IPackageFragment pack= root.createPackageFragment("sample", true, null); //$NON-NLS-1$
+		String source= """
+				package sample;
+				import junit.framework.Test;
+				import org.eclipse.jdt.core.tests.junit.extension.TestCase;
+
+				public class OrderedTests extends TestCase {
+					public OrderedTests(String name) {
+						super(name);
+					}
+
+					public static Test suite() {
+						return buildTestSuite(OrderedTests.class);
+					}
+
+					public void testA() {
+					}
+
+					public void testB() {
+					}
+				}
+				""";
+		ICompilationUnit test= pack.createCompilationUnit("OrderedTests.java", source, false, null); //$NON-NLS-1$
+
+		enableMigration();
+		context.assertRefactoringResultAsExpectedNormalizingWhitespace(
+				new ICompilationUnit[] { harness, test }, new String[] { harness.getSource(), source }, null);
+	}
+
+	private ICompilationUnit createHarness() throws CoreException {
+		IPackageFragment harnessPackage=
+				root.createPackageFragment("org.eclipse.jdt.core.tests.junit.extension", true, null); //$NON-NLS-1$
+		return harnessPackage.createCompilationUnit("TestCase.java", //$NON-NLS-1$
+				"""
+				package org.eclipse.jdt.core.tests.junit.extension;
+				import junit.framework.Test;
+				import junit.framework.TestSuite;
+
+				public class TestCase extends junit.framework.TestCase {
+					public TestCase(String name) {
+						super(name);
+					}
+
+					public static Test buildTestSuite(Class<?> type) {
+						return new TestSuite(type);
+					}
+				}
+				""", false, null);
+	}
+
+	private void enableMigration() throws CoreException {
+		context.enable(MYCleanUpConstants.JUNIT3_CLEANUP);
+		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_3_TEST);
+	}
+}


### PR DESCRIPTION
## Problem

PR #1336 safely migrates ordinary closed JUnit 3 hierarchies but deliberately rejects Eclipse JDT Core's custom harness. That harness combines named construction, suite builders, filters, configurable ordering, performance callbacks and stateful suite behavior, so flattening it wholesale would be unsafe.

## First harness slice

This PR adds one deliberately narrow, executable migration for a JDT Core-style class that is provably independent of the custom harness after discovery:

- directly extends `org.eclipse.jdt.core.tests.junit.extension.TestCase`;
- has no subtype and no reference outside its own compilation unit;
- contains exactly one exact public `void test*()` method;
- has only the boilerplate `public Type(String name) { super(name); }` constructor;
- has only `public static Test suite() { return buildTestSuite(Type.class); }`;
- uses no lifecycle, name, performance, inherited field or other custom-harness API;
- uses only assertion methods that resolve to the ordinary JUnit 3 assertion API.

For that shape the cleanup removes the custom superclass, named constructor and suite method, adds Jupiter `@Test`, and rewrites assertions. The existing direct `TestCase` cleanup and the coordinated hierarchy planner remain unchanged and are composed under the same JUnit 3 cleanup option.

## Verification

- an active fixture models the real JDT Core custom base and `buildTestSuite` pattern;
- the same JDT JUnit 5/Vintage launch runs before and after migration;
- both runs must succeed and produce an identical non-empty runtime tree;
- a two-test fixture remains unchanged because the JDT harness's configurable `ordering` property would otherwise be lost.

## Deliberate boundary

This does not yet migrate `SuiteOfTestCases`, inherited-depth discovery, filters, compliance multiplication, state transfer, performance callbacks, indexer control or rerun hooks. Those remain explicit follow-up slices under #1334.

The branch is one commit directly on the merged #1336 `main`. The PR remains Draft until all review threads are resolved and Core, Maven, Distribution, CodeQL, Codacy and inventory checks are green.

Refs #1334 and #1217.