### PR TITLE
Add composable predicates to the hint DSL

### DIFF
--- a/docs/generic-harness-contract-dsl.md
+++ b/docs/generic-harness-contract-dsl.md
@@ -1,0 +1,124 @@
+# Generic harness-contract DSL
+
+## Purpose
+
+Legacy test frameworks often encode discovery, construction, ordering, selection,
+lifecycle and matrix execution implicitly in Java inheritance and suite builders.
+The migration engine must not contain project names such as JDT Core. Instead,
+project-specific recipes describe those contracts using generic semantic facts,
+composable predicates and structured rewrite actions.
+
+The existing binding-resolved planner and JDT runtime-tree recorder remain the
+safety boundaries. The DSL describes reusable policy; it does not replace scope
+closure, binding resolution, atomic LTK changes or before/after execution.
+
+## Composable predicates
+
+Repeated guard expressions can be named and parameterized:
+
+```text
+<!predicate exactTest($method):
+    plannedRole($method, "TEST")
+    && isPublic($method)
+    && !isStatic($method)
+    && paramCount($method, 0)
+    && hasReturnType($method, "void")>
+
+public void $name() :: exactTest($name)
+=> @org.junit.jupiter.api.Test public void $name()
+;;
+```
+
+Predicates may compose other predicates. Expansion uses the parsed guard AST,
+not global textual replacement. Therefore a same-named Java call in a source or
+replacement pattern is not changed.
+
+Predicate contracts are deliberately closed:
+
+- parameters are explicit placeholders;
+- every parameter must be used;
+- undeclared placeholder captures are rejected;
+- duplicate names, wrong arity and direct or indirect recursion are rejected;
+- definitions retain source lines for editor diagnostics and trace output.
+
+These rules keep predicates locally understandable and safe to reuse or rename.
+
+## One language vocabulary
+
+`HintLanguageVocabulary` is the canonical source for:
+
+- metadata and declaration directives;
+- DSL operators;
+- built-in guard documentation used by content assist.
+
+Syntax highlighting no longer contains a manually maintained guard list.
+Identifier-shaped calls are highlighted structurally, so built-in guards,
+extension-contributed guards and local predicates behave consistently. Bare
+registered guards such as `otherwise` are obtained from the live registry.
+Content assist combines the same registry with local predicate declarations and
+de-duplicates by name.
+
+A unit test compares the canonical guard documentation with the complete
+built-in registration map. Adding a built-in without editor documentation is a
+test failure rather than silent language drift.
+
+## Parsing layers
+
+The large compatibility-oriented `HintFileParser` remains the stable rule
+parser. `HintProgramParser` is a small composition layer that:
+
+1. extracts high-level declarations;
+2. validates their contracts;
+3. expands them into ordinary guard ASTs;
+4. delegates the resulting program to the existing rule parser.
+
+This avoids mixing comment handling, NetBeans compatibility, map/foreach
+expansion, predicate composition and future harness-contract declarations in
+one parser class.
+
+## Next generic language slices
+
+Predicates reduce duplication but do not yet express the complete harness
+migration. The next extensions must stay generic and typed:
+
+```text
+contract legacy-tests/v1 {
+    discover methods where exactTest($method)
+    construct by namedConstructor(String methodName)
+    order by planValue("ordering")
+    select by planValue("selection")
+    lifecycle perSuite("setUpSuite", "tearDownSuite")
+    matrix dimension("compliance", planValue("levels"))
+}
+```
+
+Required engine concepts are:
+
+- typed semantic-plan values rather than untyped strings;
+- binding-based graph predicates such as source-subtype and external-reference
+  closure;
+- structured AST actions such as replacing a supertype, removing a validated
+  constructor, adding annotations and generating a nested adapter type;
+- reusable contract fragments for discovery, ordering, selection, suite state
+  and execution matrices;
+- a generic runtime oracle requiring an identical non-empty successful test
+  tree with configurable identity, nesting, order and multiplicity policies.
+
+Project-specific recipes then supply only type names, method patterns and the
+composition of these generic contracts.
+
+## Acceptance criteria
+
+Every language extension must include:
+
+- parser and model tests for valid composition;
+- negative tests for ambiguity, hidden capture, recursion and stale contracts;
+- syntax-highlighting tests for every new lexical form;
+- content-assist tests for declarations and references;
+- a vocabulary-drift test where applicable;
+- plan-aware end-to-end execution proving that the expanded program reaches the
+  existing rewrite backend;
+- at least one runtime-tree regression when execution semantics are affected.
+
+A feature is not complete when only the parser accepts it. Editor support,
+diagnostics, execution and tests are part of the language contract.

--- a/sandbox_common/src/org/sandbox/jdt/triggerpattern/cleanup/PlanAwareHintFileFixCore.java
+++ b/sandbox_common/src/org/sandbox/jdt/triggerpattern/cleanup/PlanAwareHintFileFixCore.java
@@ -48,6 +48,8 @@ import org.sandbox.jdt.triggerpattern.api.SemanticRewritePlan.NodeKey;
 import org.sandbox.jdt.triggerpattern.api.SemanticRewritePlanContext;
 import org.sandbox.jdt.triggerpattern.internal.GuardRegistry;
 import org.sandbox.jdt.triggerpattern.internal.HintFileParser;
+import org.sandbox.jdt.triggerpattern.internal.HintProgramParser;
+import org.sandbox.jdt.triggerpattern.internal.HintProgramParser.ParsedProgram;
 
 /**
  * Adds semantic-plan authorization and exact coverage checks around the existing
@@ -82,7 +84,9 @@ public final class PlanAwareHintFileFixCore {
 		if (hintFileContent.contains("$widestType")) { //$NON-NLS-1$
 			throw failure("Plan-aware hint programs may not use analysis-dependent $widestType replacements", null); //$NON-NLS-1$
 		}
-		HintFile hintFile= parse(hintFileContent);
+		ParsedProgram program= parse(hintFileContent);
+		HintFile hintFile= program.hintFile();
+		String executableContent= program.expandedSource();
 		BatchTransformationProcessor processor= new BatchTransformationProcessor(hintFile);
 		List<TransformationResult> authorized= processor.process(compilationUnit, compilerOptions, plan).stream()
 				.filter(TransformationResult::hasReplacement)
@@ -102,7 +106,7 @@ public final class PlanAwareHintFileFixCore {
 		Set<CompilationUnitRewriteOperation> delegated= new LinkedHashSet<>();
 		try (SemanticRewritePlanContext.Scope ignored=
 				SemanticRewritePlanContext.install(plan, compilerOptions)) {
-			HintFileFixCore.findOperationsFromContent(compilationUnit, hintFileContent, delegated);
+			HintFileFixCore.findOperationsFromContent(compilationUnit, executableContent, delegated);
 		}
 		if (delegated.size() != authorized.size()) {
 			throw failure("The existing hint backend produced " + delegated.size() //$NON-NLS-1$
@@ -133,9 +137,9 @@ public final class PlanAwareHintFileFixCore {
 		}
 	}
 
-	private static HintFile parse(String content) throws CoreException {
+	private static ParsedProgram parse(String content) throws CoreException {
 		try {
-			return new HintFileParser().parse(content);
+			return new HintProgramParser().parse(content);
 		} catch (HintFileParser.HintParseException e) {
 			throw failure("Cannot parse trusted plan-aware hint program", e); //$NON-NLS-1$
 		}

--- a/sandbox_common/src/org/sandbox/jdt/triggerpattern/editor/SandboxHintCodeScanner.java
+++ b/sandbox_common/src/org/sandbox/jdt/triggerpattern/editor/SandboxHintCodeScanner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2026 Carsten Hammer.
+ * Copyright (c) 2026 Carsten Hammer and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -7,15 +7,22 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     Carsten Hammer - initial API and implementation
  *******************************************************************************/
 package org.sandbox.jdt.triggerpattern.editor;
 
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
+import org.eclipse.core.runtime.Platform;
+
+import org.eclipse.jdt.internal.ui.JavaPlugin;
+
+import org.eclipse.jface.resource.ColorRegistry;
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.TextAttribute;
 import org.eclipse.jface.text.rules.IRule;
 import org.eclipse.jface.text.rules.IToken;
@@ -24,104 +31,115 @@ import org.eclipse.jface.text.rules.RuleBasedScanner;
 import org.eclipse.jface.text.rules.SingleLineRule;
 import org.eclipse.jface.text.rules.Token;
 import org.eclipse.jface.text.rules.WordRule;
+
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
-import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.graphics.RGB;
 
-/**
- * Scanner for code regions in {@code .sandbox-hint} files.
- *
- * <p>Highlights:</p>
- * <ul>
- *   <li>{@code <!...>} metadata directives – teal italic</li>
- *   <li>{@code ::} guard separator – purple bold</li>
- *   <li>{@code =>} rewrite arrow – purple bold</li>
- *   <li>{@code ;;} rule terminator – purple bold</li>
- *   <li>{@code $placeholder} – dark red</li>
- *   <li>{@code $variadic$} – dark red bold</li>
- *   <li>Guard function keywords – dark blue bold</li>
- *   <li>Import directive keywords – dark blue bold</li>
- * </ul>
- *
- * @since 1.3.6
- */
+import org.sandbox.jdt.triggerpattern.internal.GuardRegistry;
+import org.sandbox.jdt.triggerpattern.internal.HintLanguageVocabulary;
+import org.sandbox.jdt.triggerpattern.internal.HintPredicatePreprocessor;
+
+/** Scanner for code regions in {@code .sandbox-hint} files. */
 public class SandboxHintCodeScanner extends RuleBasedScanner {
 
-	/**
-	 * Guard function keywords known to the built-in registry.
-	 */
-	private static final String[] GUARD_KEYWORDS = {
-		"instanceof", //$NON-NLS-1$
-		"matchesAny", //$NON-NLS-1$
-		"matchesNone", //$NON-NLS-1$
-		"referencedIn", //$NON-NLS-1$
-		"hasNoSideEffect", //$NON-NLS-1$
-		"sourceVersionGE", //$NON-NLS-1$
-		"sourceVersionLE", //$NON-NLS-1$
-		"sourceVersionBetween", //$NON-NLS-1$
-		"elementKindMatches", //$NON-NLS-1$
-		"isStatic", //$NON-NLS-1$
-		"isFinal", //$NON-NLS-1$
-		"hasAnnotation", //$NON-NLS-1$
-		"isDeprecated", //$NON-NLS-1$
-		"otherwise", //$NON-NLS-1$
-		"contains", //$NON-NLS-1$
-		"notContains", //$NON-NLS-1$
-		"parent", //$NON-NLS-1$
-		"enclosingMethod", //$NON-NLS-1$
-	};
+	static final RGB OPERATOR_RGB= new RGB(128, 0, 128);
+	static final RGB PLACEHOLDER_RGB= new RGB(128, 0, 0);
+	static final RGB FUNCTION_RGB= new RGB(0, 0, 192);
+	static final RGB STRING_RGB= new RGB(42, 0, 255);
+	static final RGB METADATA_RGB= new RGB(64, 128, 128);
+	static final RGB DIRECTIVE_RGB= new RGB(0, 0, 128);
+
+	private static final String FALLBACK_COLOR_PREFIX= "org.sandbox.jdt.triggerpattern.color."; //$NON-NLS-1$
+
+	private final IToken operatorToken= token(OPERATOR_RGB, SWT.BOLD);
+	private final IToken placeholderToken= token(PLACEHOLDER_RGB, SWT.NORMAL);
+	private final IToken variadicToken= token(PLACEHOLDER_RGB, SWT.BOLD);
+	private final IToken functionToken= token(FUNCTION_RGB, SWT.BOLD);
+	private final IToken stringToken= token(STRING_RGB, SWT.NORMAL);
+	private final IToken metadataToken= token(METADATA_RGB, SWT.ITALIC);
+	private Set<String> localPredicateNames= Set.of();
 
 	public SandboxHintCodeScanner() {
-		Color operatorColor = new Color(Display.getDefault(), 128, 0, 128);
-		IToken operatorToken = new Token(new TextAttribute(operatorColor, null, SWT.BOLD));
+		configureRules();
+	}
 
-		Color placeholderColor = new Color(Display.getDefault(), 128, 0, 0);
-		IToken placeholderToken = new Token(new TextAttribute(placeholderColor));
-		IToken variadicToken = new Token(new TextAttribute(placeholderColor, null, SWT.BOLD));
+	@Override
+	public void setRange(IDocument document, int offset, int length) {
+		Set<String> discovered= HintPredicatePreprocessor.discover(document.get()).stream()
+				.map(predicate -> predicate.name())
+				.collect(java.util.stream.Collectors.toUnmodifiableSet());
+		if (!discovered.equals(localPredicateNames)) {
+			localPredicateNames= discovered;
+			configureRules();
+		}
+		super.setRange(document, offset, length);
+	}
 
-		Color keywordColor = new Color(Display.getDefault(), 0, 0, 192);
-		IToken keywordToken = new Token(new TextAttribute(keywordColor, null, SWT.BOLD));
-
-		Color stringColor = new Color(Display.getDefault(), 42, 0, 255);
-		IToken stringToken = new Token(new TextAttribute(stringColor));
-
-		Color metadataColor = new Color(Display.getDefault(), 64, 128, 128);
-		IToken metadataToken = new Token(new TextAttribute(metadataColor, null, SWT.ITALIC));
-
-		List<IRule> rules = new ArrayList<>();
-
-		// Metadata directives: <!id: ...>, <!description: ...>, etc.
+	private void configureRules() {
+		List<IRule> rules= new ArrayList<>();
 		rules.add(new SingleLineRule("<!", ">", metadataToken)); //$NON-NLS-1$ //$NON-NLS-2$
-
-		// String literals in guard expressions
 		rules.add(new SingleLineRule("\"", "\"", stringToken, '\\')); //$NON-NLS-1$ //$NON-NLS-2$
-
-		// Operators: =>, ::, ;;
-		rules.add(new OperatorRule("=>", operatorToken)); //$NON-NLS-1$
-		rules.add(new OperatorRule("::", operatorToken)); //$NON-NLS-1$
-		rules.add(new OperatorRule(";;", operatorToken)); //$NON-NLS-1$
-
-		// Placeholders: $name and $variadic$
+		HintLanguageVocabulary.operators().stream()
+				.sorted(Comparator.comparingInt(String::length).reversed())
+				.map(operator -> new OperatorRule(operator, operatorToken))
+				.forEach(rules::add);
 		rules.add(new PlaceholderRule(placeholderToken, variadicToken));
 
-		// Guard function keywords
-		WordRule keywordRule = new WordRule(new IWordDetector() {
+		WordRule guards= new WordRule(new IWordDetector() {
 			@Override
-			public boolean isWordStart(char c) {
-				return Character.isLetter(c);
+			public boolean isWordStart(char character) {
+				return Character.isJavaIdentifierStart(character);
 			}
 
 			@Override
-			public boolean isWordPart(char c) {
-				return Character.isLetterOrDigit(c) || c == '_';
+			public boolean isWordPart(char character) {
+				return Character.isJavaIdentifierPart(character);
 			}
 		}, Token.UNDEFINED);
+		Set<String> names= new LinkedHashSet<>(GuardRegistry.getInstance().getRegisteredNames());
+		names.addAll(localPredicateNames);
+		names.stream().sorted().forEach(name -> guards.addWord(name, functionToken));
+		rules.add(guards);
+		setRules(rules.toArray(IRule[]::new));
+	}
 
-		for (String keyword : GUARD_KEYWORDS) {
-			keywordRule.addWord(keyword, keywordToken);
+	IToken operatorToken() {
+		return operatorToken;
+	}
+
+	IToken placeholderToken() {
+		return placeholderToken;
+	}
+
+	IToken functionToken() {
+		return functionToken;
+	}
+
+	private static IToken token(RGB rgb, int style) {
+		return new Token(new TextAttribute(managedColor(rgb), null, style));
+	}
+
+	/**
+	 * Returns an editor-managed shared color. Plain Maven tests deliberately use
+	 * a null foreground so lexical scanner tests never initialize platform-specific
+	 * SWT native libraries.
+	 */
+	static Color managedColor(RGB rgb) {
+		if (!Platform.isRunning()) {
+			return null;
 		}
-		rules.add(keywordRule);
-
-		setRules(rules.toArray(new IRule[0]));
+		JavaPlugin plugin= JavaPlugin.getDefault();
+		if (plugin != null) {
+			return plugin.getJavaTextTools().getColorManager().getColor(rgb);
+		}
+		ColorRegistry registry= JFaceResources.getColorRegistry();
+		String key= FALLBACK_COLOR_PREFIX + rgb.red + '.' + rgb.green + '.' + rgb.blue;
+		synchronized (registry) {
+			if (!registry.hasValueFor(key)) {
+				registry.put(key, rgb);
+			}
+			return registry.get(key);
+		}
 	}
 }

--- a/sandbox_common/src/org/sandbox/jdt/triggerpattern/editor/SandboxHintContentAssistProcessor.java
+++ b/sandbox_common/src/org/sandbox/jdt/triggerpattern/editor/SandboxHintContentAssistProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2026 Carsten Hammer.
+ * Copyright (c) 2026 Carsten Hammer and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -7,14 +7,15 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     Carsten Hammer - initial API and implementation
  *******************************************************************************/
 package org.sandbox.jdt.triggerpattern.editor;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TreeSet;
 
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
@@ -24,97 +25,68 @@ import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.eclipse.jface.text.contentassist.IContentAssistProcessor;
 import org.eclipse.jface.text.contentassist.IContextInformation;
 import org.eclipse.jface.text.contentassist.IContextInformationValidator;
-import org.sandbox.jdt.triggerpattern.internal.GuardRegistry;
 
-/**
- * Content assist processor for {@code .sandbox-hint} files.
- *
- * <p>Provides completion proposals for guard function names after the
- * {@code ::} guard separator. Proposals are sourced from the
- * {@link GuardRegistry}.</p>
- *
- * @since 1.3.6
- */
+import org.sandbox.jdt.triggerpattern.api.HintPredicateDefinition;
+import org.sandbox.jdt.triggerpattern.internal.GuardRegistry;
+import org.sandbox.jdt.triggerpattern.internal.HintLanguageVocabulary;
+import org.sandbox.jdt.triggerpattern.internal.HintPredicatePreprocessor;
+
+/** Content assist for directives, registered guards and local predicates. */
 public class SandboxHintContentAssistProcessor implements IContentAssistProcessor {
 
-	/**
-	 * Guard function entries with name and description.
-	 */
-	private static final String[][] GUARD_PROPOSALS = {
-		{ "instanceof", "$x instanceof Type – type check" }, //$NON-NLS-1$ //$NON-NLS-2$
-		{ "matchesAny", "matchesAny($x, \"lit1\", \"lit2\") – value is one of the given literals" }, //$NON-NLS-1$ //$NON-NLS-2$
-		{ "matchesNone", "matchesNone($x, \"lit1\", ...) – value is none of the given literals" }, //$NON-NLS-1$ //$NON-NLS-2$
-		{ "referencedIn", "referencedIn($x, $y) – variable $x is referenced in expression $y" }, //$NON-NLS-1$ //$NON-NLS-2$
-		{ "hasNoSideEffect", "hasNoSideEffect($x) – expression has no side effects" }, //$NON-NLS-1$ //$NON-NLS-2$
-		{ "sourceVersionGE", "sourceVersionGE(n) – source version >= n" }, //$NON-NLS-1$ //$NON-NLS-2$
-		{ "sourceVersionLE", "sourceVersionLE(n) – source version <= n" }, //$NON-NLS-1$ //$NON-NLS-2$
-		{ "sourceVersionBetween", "sourceVersionBetween(min, max) – source version in range" }, //$NON-NLS-1$ //$NON-NLS-2$
-		{ "elementKindMatches", "elementKindMatches($x, KIND) – element is of a specific kind" }, //$NON-NLS-1$ //$NON-NLS-2$
-		{ "isStatic", "isStatic($x) – element has static modifier" }, //$NON-NLS-1$ //$NON-NLS-2$
-		{ "isFinal", "isFinal($x) – element has final modifier" }, //$NON-NLS-1$ //$NON-NLS-2$
-		{ "hasAnnotation", "hasAnnotation($x, \"fully.qualified.Annotation\")" }, //$NON-NLS-1$ //$NON-NLS-2$
-		{ "isDeprecated", "isDeprecated($x) – element is @Deprecated" }, //$NON-NLS-1$ //$NON-NLS-2$
-		{ "otherwise", "otherwise – catch-all guard (always true)" }, //$NON-NLS-1$ //$NON-NLS-2$
-		{ "parent", "parent($x, Type) – parent node is of the given type" }, //$NON-NLS-1$ //$NON-NLS-2$
-		{ "contains", "contains($x, \"text\") – enclosing method contains the text" }, //$NON-NLS-1$ //$NON-NLS-2$
-		{ "notContains", "notContains($x, \"text\") – enclosing method does not contain the text" }, //$NON-NLS-1$ //$NON-NLS-2$
-	};
+	/** Pure proposal description used by UI code and PDE unit tests. */
+	static record CompletionEntry(String name, String replacement,
+			int cursorPosition, String description) {
+	}
 
 	@Override
 	public ICompletionProposal[] computeCompletionProposals(ITextViewer viewer, int offset) {
-		IDocument document = viewer.getDocument();
-		String prefix = extractPrefix(document, offset);
-
-		// Check if we are after a :: guard separator
-		boolean afterGuard = isAfterGuardSeparator(document, offset - prefix.length());
-
-		if (!afterGuard && prefix.isEmpty()) {
+		IDocument document= viewer.getDocument();
+		String prefix= extractPrefix(document, offset);
+		int replacementOffset= offset - prefix.length();
+		String source= document.get();
+		boolean predicateGuardContext= isPredicateGuardContext(source, replacementOffset);
+		boolean directiveContext= !predicateGuardContext && isDirectiveContext(source, replacementOffset);
+		if (!directiveContext && !predicateGuardContext && !isGuardContext(source, replacementOffset)) {
 			return new ICompletionProposal[0];
 		}
 
-		List<ICompletionProposal> proposals = new ArrayList<>();
-		String lowerPrefix = prefix.toLowerCase();
-
-		for (String[] entry : GUARD_PROPOSALS) {
-			String name = entry[0];
-			String description = entry[1];
-			if (name.toLowerCase().startsWith(lowerPrefix)) {
-				String replacement = name;
-				int replacementOffset = offset - prefix.length();
-				int replacementLength = prefix.length();
-				int cursorPosition = replacement.length();
-				proposals.add(new CompletionProposal(
-						replacement, replacementOffset, replacementLength,
-						cursorPosition, null, name + " – " + description, //$NON-NLS-1$
-						null, description));
+		String lowerPrefix= prefix.toLowerCase(Locale.ROOT);
+		List<ICompletionProposal> proposals= new ArrayList<>();
+		for (CompletionEntry entry : completionEntries(source, directiveContext)) {
+			if (!entry.name().toLowerCase(Locale.ROOT).startsWith(lowerPrefix)) {
+				continue;
 			}
+			proposals.add(new CompletionProposal(entry.replacement(), replacementOffset,
+					prefix.length(), entry.cursorPosition(), null, entry.name(), null,
+					entry.description()));
+		}
+		return proposals.toArray(ICompletionProposal[]::new);
+	}
+
+	static List<CompletionEntry> completionEntries(String source, boolean directiveContext) {
+		if (directiveContext) {
+			return HintLanguageVocabulary.directives().stream().map(directive -> {
+				String syntax= directive.syntax();
+				String replacement= syntax.startsWith("<!") && syntax.endsWith(">") //$NON-NLS-1$ //$NON-NLS-2$
+						? syntax.substring(2, syntax.length() - 1) : syntax;
+				return new CompletionEntry(directive.name(), replacement, replacement.length(),
+						directive.description() + " — " + directive.syntax()); //$NON-NLS-1$
+			}).toList();
 		}
 
-		// Also propose guard functions from the registry
-		GuardRegistry registry = GuardRegistry.getInstance();
-		for (String guardName : registry.getRegisteredNames()) {
-			if (guardName.toLowerCase().startsWith(lowerPrefix)) {
-				boolean alreadyProposed = false;
-				for (String[] entry : GUARD_PROPOSALS) {
-					if (entry[0].equals(guardName)) {
-						alreadyProposed = true;
-						break;
-					}
-				}
-				if (!alreadyProposed) {
-					String replacement = guardName;
-					int replacementOffset = offset - prefix.length();
-					int replacementLength = prefix.length();
-					int cursorPosition = replacement.length();
-					proposals.add(new CompletionProposal(
-							replacement, replacementOffset, replacementLength,
-							cursorPosition, null, guardName,
-							null, "Custom guard function")); //$NON-NLS-1$
-				}
-			}
+		Map<String, CompletionEntry> entries= new LinkedHashMap<>();
+		for (String name : new TreeSet<>(GuardRegistry.getInstance().getRegisteredNames())) {
+			entries.put(name, new CompletionEntry(name, name, name.length(),
+					HintLanguageVocabulary.guardDescription(name)));
 		}
-
-		return proposals.toArray(new ICompletionProposal[0]);
+		for (HintPredicateDefinition predicate : HintPredicatePreprocessor.discover(source)) {
+			String description= "Local predicate " + predicate.signature() //$NON-NLS-1$
+					+ " declared on line " + predicate.lineNumber(); //$NON-NLS-1$
+			entries.put(predicate.name(), new CompletionEntry(predicate.name(), predicate.name(),
+					predicate.name().length(), description));
+		}
+		return List.copyOf(entries.values());
 	}
 
 	@Override
@@ -124,7 +96,7 @@ public class SandboxHintContentAssistProcessor implements IContentAssistProcesso
 
 	@Override
 	public char[] getCompletionProposalAutoActivationCharacters() {
-		return new char[] { ':' };
+		return new char[] { ':', '<' };
 	}
 
 	@Override
@@ -142,45 +114,56 @@ public class SandboxHintContentAssistProcessor implements IContentAssistProcesso
 		return null;
 	}
 
-	/**
-	 * Extracts the word prefix before the cursor position.
-	 */
-	private String extractPrefix(IDocument document, int offset) {
+	private static String extractPrefix(IDocument document, int offset) {
 		try {
-			int start = offset;
+			int start= offset;
 			while (start > 0) {
-				char c = document.getChar(start - 1);
-				if (!Character.isLetterOrDigit(c) && c != '_') {
+				char character= document.getChar(start - 1);
+				if (!Character.isJavaIdentifierPart(character)) {
 					break;
 				}
 				start--;
 			}
 			return document.get(start, offset - start);
-		} catch (BadLocationException e) {
+		} catch (BadLocationException exception) {
 			return ""; //$NON-NLS-1$
 		}
 	}
 
-	/**
-	 * Checks if the position is after a {@code ::} guard separator
-	 * (possibly with whitespace in between).
-	 */
-	private boolean isAfterGuardSeparator(IDocument document, int offset) {
-		try {
-			int pos = offset - 1;
-			// Skip whitespace
-			while (pos >= 0 && Character.isWhitespace(document.getChar(pos))) {
-				pos--;
-			}
-			// Check for '::'
-			if (pos >= 1
-					&& document.getChar(pos) == ':'
-					&& document.getChar(pos - 1) == ':') {
-				return true;
-			}
-		} catch (BadLocationException e) {
-			// ignore
+	static boolean isDirectiveContext(String source, int offset) {
+		int safeOffset= Math.max(0, Math.min(offset, source.length()));
+		int opening= source.lastIndexOf("<!", safeOffset); //$NON-NLS-1$
+		int closing= source.lastIndexOf('>', safeOffset);
+		return opening >= 0 && opening > closing;
+	}
+
+	static boolean isPredicateGuardContext(String source, int offset) {
+		int safeOffset= Math.max(0, Math.min(offset, source.length()));
+		int opening= source.lastIndexOf("<!", safeOffset); //$NON-NLS-1$
+		int closing= source.lastIndexOf('>', safeOffset);
+		if (opening < 0 || opening <= closing) {
+			return false;
 		}
-		return false;
+		int nameStart= opening + 2;
+		while (nameStart < safeOffset && Character.isWhitespace(source.charAt(nameStart))) {
+			nameStart++;
+		}
+		if (!source.startsWith("predicate", nameStart)) { //$NON-NLS-1$
+			return false;
+		}
+		int parametersEnd= source.indexOf(')', nameStart + "predicate".length()); //$NON-NLS-1$
+		if (parametersEnd < 0 || parametersEnd >= safeOffset) {
+			return false;
+		}
+		int colon= source.indexOf(':', parametersEnd + 1);
+		return colon >= 0 && colon < safeOffset;
+	}
+
+	private static boolean isGuardContext(String source, int offset) {
+		int safeOffset= Math.max(0, Math.min(offset, source.length()));
+		int guard= source.lastIndexOf("::", safeOffset); //$NON-NLS-1$
+		int rewrite= source.lastIndexOf("=>", safeOffset); //$NON-NLS-1$
+		int terminator= source.lastIndexOf(";;", safeOffset); //$NON-NLS-1$
+		return guard >= 0 && guard > Math.max(rewrite, terminator);
 	}
 }

--- a/sandbox_common/src/org/sandbox/jdt/triggerpattern/editor/SandboxHintFunctionCallRule.java
+++ b/sandbox_common/src/org/sandbox/jdt/triggerpattern/editor/SandboxHintFunctionCallRule.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.editor;
+
+import org.eclipse.jface.text.rules.ICharacterScanner;
+import org.eclipse.jface.text.rules.IRule;
+import org.eclipse.jface.text.rules.IToken;
+import org.eclipse.jface.text.rules.Token;
+
+/** Highlights every Java-identifier-shaped function call without a keyword list. */
+final class SandboxHintFunctionCallRule implements IRule {
+
+	private final IToken token;
+
+	SandboxHintFunctionCallRule(IToken token) {
+		this.token= token;
+	}
+
+	@Override
+	public IToken evaluate(ICharacterScanner scanner) {
+		int consumed= 0;
+		int identifierLength= 0;
+		int character= scanner.read();
+		consumed++;
+		if (character == ICharacterScanner.EOF
+				|| !Character.isJavaIdentifierStart((char) character)) {
+			unread(scanner, consumed);
+			return Token.UNDEFINED;
+		}
+		identifierLength= 1;
+		while (true) {
+			character= scanner.read();
+			consumed++;
+			if (character != ICharacterScanner.EOF
+					&& Character.isJavaIdentifierPart((char) character)) {
+				identifierLength++;
+				continue;
+			}
+			break;
+		}
+		while (character != ICharacterScanner.EOF && Character.isWhitespace((char) character)) {
+			character= scanner.read();
+			consumed++;
+		}
+		if (character == '(') {
+			unread(scanner, consumed - identifierLength);
+			return token;
+		}
+		unread(scanner, consumed);
+		return Token.UNDEFINED;
+	}
+
+	private static void unread(ICharacterScanner scanner, int count) {
+		for (int index= 0; index < count; index++) {
+			scanner.unread();
+		}
+	}
+}

--- a/sandbox_common/src/org/sandbox/jdt/triggerpattern/editor/SandboxHintMetadataScanner.java
+++ b/sandbox_common/src/org/sandbox/jdt/triggerpattern/editor/SandboxHintMetadataScanner.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.editor;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import org.eclipse.jface.text.TextAttribute;
+import org.eclipse.jface.text.rules.IRule;
+import org.eclipse.jface.text.rules.IToken;
+import org.eclipse.jface.text.rules.IWordDetector;
+import org.eclipse.jface.text.rules.RuleBasedScanner;
+import org.eclipse.jface.text.rules.SingleLineRule;
+import org.eclipse.jface.text.rules.Token;
+import org.eclipse.jface.text.rules.WordRule;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.RGB;
+
+import org.sandbox.jdt.triggerpattern.internal.HintLanguageVocabulary;
+
+/** Highlights directive names and embedded guard expressions in metadata blocks. */
+final class SandboxHintMetadataScanner extends RuleBasedScanner {
+
+	private final IToken directiveToken= token(SandboxHintCodeScanner.DIRECTIVE_RGB, SWT.BOLD);
+	private final IToken operatorToken= token(SandboxHintCodeScanner.OPERATOR_RGB, SWT.BOLD);
+	private final IToken placeholderToken= token(SandboxHintCodeScanner.PLACEHOLDER_RGB, SWT.NORMAL);
+	private final IToken variadicToken= token(SandboxHintCodeScanner.PLACEHOLDER_RGB, SWT.BOLD);
+	private final IToken functionToken= token(SandboxHintCodeScanner.FUNCTION_RGB, SWT.BOLD);
+	private final IToken stringToken= token(SandboxHintCodeScanner.STRING_RGB, SWT.NORMAL);
+
+	SandboxHintMetadataScanner() {
+		setDefaultReturnToken(directiveToken);
+
+		List<IRule> rules= new ArrayList<>();
+		rules.add(new SingleLineRule("\"", "\"", stringToken, '\\')); //$NON-NLS-1$ //$NON-NLS-2$
+		HintLanguageVocabulary.operators().stream()
+				.sorted(Comparator.comparingInt(String::length).reversed())
+				.map(operator -> new OperatorRule(operator, operatorToken))
+				.forEach(rules::add);
+		rules.add(new PlaceholderRule(placeholderToken, variadicToken));
+		rules.add(new SandboxHintFunctionCallRule(functionToken));
+
+		WordRule directives= new WordRule(new IWordDetector() {
+			@Override
+			public boolean isWordStart(char character) {
+				return Character.isJavaIdentifierStart(character);
+			}
+
+			@Override
+			public boolean isWordPart(char character) {
+				return Character.isJavaIdentifierPart(character) || character == '-';
+			}
+		}, Token.UNDEFINED);
+		HintLanguageVocabulary.directiveNames().stream().sorted()
+				.forEach(name -> directives.addWord(name, directiveToken));
+		rules.add(directives);
+		setRules(rules.toArray(IRule[]::new));
+	}
+
+	IToken operatorToken() {
+		return operatorToken;
+	}
+
+	IToken placeholderToken() {
+		return placeholderToken;
+	}
+
+	IToken functionToken() {
+		return functionToken;
+	}
+
+	private static IToken token(RGB rgb, int style) {
+		return new Token(new TextAttribute(SandboxHintCodeScanner.managedColor(rgb), null, style));
+	}
+}

--- a/sandbox_common/src/org/sandbox/jdt/triggerpattern/editor/SandboxHintReconcilingStrategy.java
+++ b/sandbox_common/src/org/sandbox/jdt/triggerpattern/editor/SandboxHintReconcilingStrategy.java
@@ -31,63 +31,46 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IFileEditorInput;
 import org.eclipse.ui.texteditor.ITextEditor;
+
 import org.sandbox.jdt.triggerpattern.api.EmbeddedJavaBlock;
 import org.sandbox.jdt.triggerpattern.api.HintFile;
 import org.sandbox.jdt.triggerpattern.internal.EmbeddedJavaCompiler;
 import org.sandbox.jdt.triggerpattern.internal.EmbeddedJavaCompiler.CompilationResult;
-import org.sandbox.jdt.triggerpattern.internal.HintFileParser;
 import org.sandbox.jdt.triggerpattern.internal.HintFileParser.HintParseException;
+import org.sandbox.jdt.triggerpattern.internal.HintProgramParser;
 
 /**
  * Reconciling strategy for {@code .sandbox-hint} files.
  *
- * <p>Validates the document content using {@link HintFileParser} and creates
- * error markers for parse errors. Also compiles embedded Java ({@code <? ?>})
- * blocks via {@link EmbeddedJavaCompiler} and maps compilation errors back to
- * the hint file line numbers.</p>
+ * <p>Validates complete composed programs using {@link HintProgramParser} and
+ * creates error markers for parse, predicate, arity and recursion errors. It
+ * also compiles embedded Java ({@code <? ?>}) blocks via
+ * {@link EmbeddedJavaCompiler} and maps compilation errors back to the hint
+ * file line numbers.</p>
  *
  * @since 1.3.6
  */
 public class SandboxHintReconcilingStrategy implements IReconcilingStrategy {
 
-	/**
-	 * Marker type for hint file parse errors.
-	 */
-	private static final String MARKER_TYPE = "org.eclipse.core.resources.problemmarker"; //$NON-NLS-1$
-
-	/**
-	 * Marker type for embedded Java compilation errors.
-	 *
-	 * @since 1.5.0
-	 */
-	private static final String EMBEDDED_JAVA_MARKER_TYPE = "sandbox_common.org.sandbox.jdt.triggerpattern.embeddedJavaProblem"; //$NON-NLS-1$
+	private static final String MARKER_TYPE= "org.eclipse.core.resources.problemmarker"; //$NON-NLS-1$
+	private static final String EMBEDDED_JAVA_MARKER_TYPE=
+			"sandbox_common.org.sandbox.jdt.triggerpattern.embeddedJavaProblem"; //$NON-NLS-1$
 
 	private IDocument document;
 	private ISourceViewer sourceViewer;
 	private SandboxHintEditor editor;
 
-	/**
-	 * Sets the source viewer for accessing the editor input.
-	 *
-	 * @param viewer the source viewer
-	 */
 	public void setSourceViewer(ISourceViewer viewer) {
-		this.sourceViewer = viewer;
+		this.sourceViewer= viewer;
 	}
 
-	/**
-	 * Sets the editor for triggering folding and outline updates after reconciliation.
-	 *
-	 * @param editor the hint editor
-	 * @since 1.5.0
-	 */
 	public void setEditor(SandboxHintEditor editor) {
-		this.editor = editor;
+		this.editor= editor;
 	}
 
 	@Override
 	public void setDocument(IDocument document) {
-		this.document = document;
+		this.document= document;
 	}
 
 	@Override
@@ -100,38 +83,29 @@ public class SandboxHintReconcilingStrategy implements IReconcilingStrategy {
 		if (document == null) {
 			return;
 		}
-
-		IFile file = getFile();
+		IFile file= getFile();
 		if (file == null || !file.exists()) {
 			return;
 		}
-
-		// Clear old markers
 		try {
 			file.deleteMarkers(MARKER_TYPE, true, IResource.DEPTH_ZERO);
 			file.deleteMarkers(EMBEDDED_JAVA_MARKER_TYPE, true, IResource.DEPTH_ZERO);
-		} catch (CoreException e) {
-			logError("Failed to clear markers", e); //$NON-NLS-1$
+		} catch (CoreException exception) {
+			logError("Failed to clear markers", exception); //$NON-NLS-1$
 		}
 
-		// Validate DSL
-		String content = document.get();
-		HintFileParser parser = new HintFileParser();
-		HintFile hintFile = null;
+		HintFile hintFile= null;
 		try {
-			hintFile = parser.parse(content);
-		} catch (HintParseException e) {
-			createErrorMarker(file, e);
+			hintFile= new HintProgramParser().parse(document.get()).hintFile();
+		} catch (HintParseException exception) {
+			createErrorMarker(file, exception);
 		}
-
-		// Validate embedded Java blocks
 		if (hintFile != null) {
 			validateEmbeddedJavaBlocks(file, hintFile);
 		}
 
-		// Update folding and outline after reconciliation
 		if (editor != null) {
-			Display display = Display.getDefault();
+			Display display= Display.getDefault();
 			if (display != null && !display.isDisposed()) {
 				display.asyncExec(() -> {
 					editor.updateFolding();
@@ -141,31 +115,20 @@ public class SandboxHintReconcilingStrategy implements IReconcilingStrategy {
 		}
 	}
 
-	/**
-	 * Compiles each embedded Java block and creates markers for compilation errors.
-	 *
-	 * @since 1.5.0
-	 */
 	private void validateEmbeddedJavaBlocks(IFile file, HintFile hintFile) {
-		List<EmbeddedJavaBlock> blocks = hintFile.getEmbeddedJavaBlocks();
-		String ruleId = hintFile.getId();
-
+		List<EmbeddedJavaBlock> blocks= hintFile.getEmbeddedJavaBlocks();
+		String ruleId= hintFile.getId();
 		for (EmbeddedJavaBlock block : blocks) {
 			if (block.getSource().isBlank()) {
 				continue;
 			}
-			CompilationResult result = EmbeddedJavaCompiler.compile(block, ruleId);
+			CompilationResult result= EmbeddedJavaCompiler.compile(block, ruleId);
 			if (result.hasErrors()) {
 				createEmbeddedJavaMarkers(file, block, result);
 			}
 		}
 	}
 
-	/**
-	 * Creates markers for compilation problems in an embedded Java block.
-	 * Maps synthetic class line numbers back to hint file line numbers and
-	 * adjusts character positions by subtracting the synthetic header length.
-	 */
 	private void createEmbeddedJavaMarkers(IFile file, EmbeddedJavaBlock block,
 			CompilationResult result) {
 		for (IProblem problem : result.problems()) {
@@ -173,86 +136,52 @@ public class SandboxHintReconcilingStrategy implements IReconcilingStrategy {
 				continue;
 			}
 			try {
-				IMarker marker = file.createMarker(EMBEDDED_JAVA_MARKER_TYPE);
+				IMarker marker= file.createMarker(EMBEDDED_JAVA_MARKER_TYPE);
 				marker.setAttribute(IMarker.SEVERITY, IMarker.SEVERITY_ERROR);
 				marker.setAttribute(IMarker.MESSAGE, problem.getMessage());
-
-				// Map synthetic class line back to hint file line
-				int syntheticLine = problem.getSourceLineNumber();
-				int hintLine = syntheticLine + result.lineOffset();
+				int hintLine= problem.getSourceLineNumber() + result.lineOffset();
 				if (hintLine > 0) {
 					marker.setAttribute(IMarker.LINE_NUMBER, hintLine);
 				}
-
-				// Map character positions: problem offsets are in the synthetic
-				// source which has a header before the embedded code. Subtract
-				// the header length and add the block's start offset plus the
-				// '<?' delimiter length to map back to the hint document.
-				int sourceStart = problem.getSourceStart();
-				int sourceEnd = problem.getSourceEnd();
+				int sourceStart= problem.getSourceStart();
+				int sourceEnd= problem.getSourceEnd();
 				if (sourceStart >= 0 && sourceEnd >= 0) {
-					int headerLength = result.syntheticHeaderLength();
-					int delimiterLength = 2; // length of '<?' delimiter
-					int hintStart = block.getStartOffset() + delimiterLength + (sourceStart - headerLength);
-					int hintEnd = block.getStartOffset() + delimiterLength + (sourceEnd - headerLength) + 1;
+					int delimiterLength= 2;
+					int hintStart= block.getStartOffset() + delimiterLength
+							+ sourceStart - result.syntheticHeaderLength();
+					int hintEnd= block.getStartOffset() + delimiterLength
+							+ sourceEnd - result.syntheticHeaderLength() + 1;
 					if (hintStart >= 0 && hintEnd > hintStart) {
 						marker.setAttribute(IMarker.CHAR_START, hintStart);
 						marker.setAttribute(IMarker.CHAR_END, hintEnd);
 					}
 				}
-			} catch (CoreException e) {
-				logError("Failed to create embedded Java marker", e); //$NON-NLS-1$
+			} catch (CoreException exception) {
+				logError("Failed to create embedded Java marker", exception); //$NON-NLS-1$
 			}
 		}
 	}
 
-	/**
-	 * Creates an error marker for a parse exception.
-	 */
-	private void createErrorMarker(IFile file, HintParseException e) {
+	private void createErrorMarker(IFile file, HintParseException exception) {
 		try {
-			IMarker marker = file.createMarker(MARKER_TYPE);
+			IMarker marker= file.createMarker(MARKER_TYPE);
 			marker.setAttribute(IMarker.SEVERITY, IMarker.SEVERITY_ERROR);
-			marker.setAttribute(IMarker.MESSAGE, e.getMessage());
-			int lineNumber = extractLineNumber(e.getMessage());
-			if (lineNumber > 0) {
-				marker.setAttribute(IMarker.LINE_NUMBER, lineNumber);
+			marker.setAttribute(IMarker.MESSAGE, exception.getMessage());
+			if (exception.getLineNumber() > 0) {
+				marker.setAttribute(IMarker.LINE_NUMBER, exception.getLineNumber());
 			}
-		} catch (CoreException ce) {
-			logError("Failed to create marker", ce); //$NON-NLS-1$
+		} catch (CoreException markerFailure) {
+			logError("Failed to create marker", markerFailure); //$NON-NLS-1$
 		}
 	}
 
-	/**
-	 * Extracts a line number from a parse error message.
-	 *
-	 * <p>The {@link HintFileParser} includes line numbers in its error messages
-	 * in the format "Line N: ...".</p>
-	 */
-	private int extractLineNumber(String message) {
-		if (message != null && message.startsWith("Line ")) { //$NON-NLS-1$
-			int colonIdx = message.indexOf(':');
-			if (colonIdx > 5) {
-				try {
-					return Integer.parseInt(message.substring(5, colonIdx).trim());
-				} catch (NumberFormatException e) {
-					// ignore
-				}
-			}
-		}
-		return -1;
-	}
-
-	/**
-	 * Gets the {@link IFile} associated with the current editor.
-	 */
 	private IFile getFile() {
 		if (sourceViewer == null) {
 			return null;
 		}
-		Object adapter = sourceViewer.getTextWidget().getData("org.eclipse.ui.texteditor"); //$NON-NLS-1$
+		Object adapter= sourceViewer.getTextWidget().getData("org.eclipse.ui.texteditor"); //$NON-NLS-1$
 		if (adapter instanceof ITextEditor textEditor) {
-			IEditorInput input = textEditor.getEditorInput();
+			IEditorInput input= textEditor.getEditorInput();
 			if (input instanceof IFileEditorInput fileInput) {
 				return fileInput.getFile();
 			}
@@ -260,8 +189,8 @@ public class SandboxHintReconcilingStrategy implements IReconcilingStrategy {
 		return null;
 	}
 
-	private void logError(String message, CoreException e) {
-		ILog log = Platform.getLog(SandboxHintReconcilingStrategy.class);
-		log.error(message, e);
+	private void logError(String message, CoreException exception) {
+		ILog log= Platform.getLog(SandboxHintReconcilingStrategy.class);
+		log.error(message, exception);
 	}
 }

--- a/sandbox_common/src/org/sandbox/jdt/triggerpattern/editor/SandboxHintSourceViewerConfiguration.java
+++ b/sandbox_common/src/org/sandbox/jdt/triggerpattern/editor/SandboxHintSourceViewerConfiguration.java
@@ -33,97 +33,62 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.RGB;
 
-/**
- * Source viewer configuration for the {@code .sandbox-hint} editor.
- *
- * <p>Provides:</p>
- * <ul>
- *   <li>Syntax highlighting via a {@link PresentationReconciler}</li>
- *   <li>Content assist for guard functions after {@code ::} and Java completions in {@code <? ?>} blocks</li>
- *   <li>Background reconciling for validation with error markers</li>
- *   <li>Annotation hover for embedded Java compile errors</li>
- *   <li>Hyperlink detection for navigating to guard function definitions</li>
- * </ul>
- *
- * @since 1.3.6
- */
+/** Source viewer configuration for the {@code .sandbox-hint} editor. */
 public class SandboxHintSourceViewerConfiguration extends SourceViewerConfiguration {
 
 	private SandboxHintEditor editor;
 
-	/**
-	 * Creates a source viewer configuration without an editor reference.
-	 */
 	public SandboxHintSourceViewerConfiguration() {
 	}
 
-	/**
-	 * Creates a source viewer configuration with an editor reference
-	 * for wiring reconciler-driven updates (folding, outline).
-	 *
-	 * @param editor the hint editor
-	 * @since 1.5.0
-	 */
 	public SandboxHintSourceViewerConfiguration(SandboxHintEditor editor) {
-		this.editor = editor;
+		this.editor= editor;
 	}
 
 	@Override
 	public String[] getConfiguredContentTypes(ISourceViewer sourceViewer) {
 		return new String[] {
-			IDocument.DEFAULT_CONTENT_TYPE,
-			SandboxHintPartitionScanner.COMMENT,
-			SandboxHintPartitionScanner.METADATA,
-			SandboxHintPartitionScanner.JAVA_CODE
+				IDocument.DEFAULT_CONTENT_TYPE,
+				SandboxHintPartitionScanner.COMMENT,
+				SandboxHintPartitionScanner.METADATA,
+				SandboxHintPartitionScanner.JAVA_CODE
 		};
 	}
 
 	@Override
 	public IPresentationReconciler getPresentationReconciler(ISourceViewer sourceViewer) {
-		PresentationReconciler reconciler = new PresentationReconciler();
+		PresentationReconciler reconciler= new PresentationReconciler();
 
-		// Default content (code) – uses the code scanner for keywords
-		ITokenScanner codeScanner = new SandboxHintCodeScanner();
-		DefaultDamagerRepairer codeDR = new DefaultDamagerRepairer(codeScanner);
+		DefaultDamagerRepairer codeDR= new DefaultDamagerRepairer(new SandboxHintCodeScanner());
 		reconciler.setDamager(codeDR, IDocument.DEFAULT_CONTENT_TYPE);
 		reconciler.setRepairer(codeDR, IDocument.DEFAULT_CONTENT_TYPE);
 
-		// Comments – green italic (use JDT's shared color manager)
-		Color commentColor = JavaPlugin.getDefault().getJavaTextTools()
+		Color commentColor= JavaPlugin.getDefault().getJavaTextTools()
 				.getColorManager().getColor(new RGB(63, 127, 95));
-		TextAttribute commentAttr = new TextAttribute(commentColor, null, SWT.ITALIC);
-		DefaultDamagerRepairer commentDR = new DefaultDamagerRepairer(
+		TextAttribute commentAttr= new TextAttribute(commentColor, null, SWT.ITALIC);
+		DefaultDamagerRepairer commentDR= new DefaultDamagerRepairer(
 				new SingleTokenScanner(new Token(commentAttr)));
 		reconciler.setDamager(commentDR, SandboxHintPartitionScanner.COMMENT);
 		reconciler.setRepairer(commentDR, SandboxHintPartitionScanner.COMMENT);
 
-		// Metadata directives – dark blue bold
-		Color metadataColor = JavaPlugin.getDefault().getJavaTextTools()
-				.getColorManager().getColor(new RGB(0, 0, 128));
-		TextAttribute metadataAttr = new TextAttribute(metadataColor, null, SWT.BOLD);
-		DefaultDamagerRepairer metadataDR = new DefaultDamagerRepairer(
-				new SingleTokenScanner(new Token(metadataAttr)));
+		DefaultDamagerRepairer metadataDR= new DefaultDamagerRepairer(new SandboxHintMetadataScanner());
 		reconciler.setDamager(metadataDR, SandboxHintPartitionScanner.METADATA);
 		reconciler.setRepairer(metadataDR, SandboxHintPartitionScanner.METADATA);
 
-		// Embedded Java code – reuses JDT's Java code scanner for full keyword,
-		// string, annotation, and operator highlighting with theme/preference support
-		ITokenScanner javaScanner = JavaPlugin.getDefault().getJavaTextTools().getCodeScanner();
-		DefaultDamagerRepairer javaDR = new DefaultDamagerRepairer(javaScanner);
+		ITokenScanner javaScanner= JavaPlugin.getDefault().getJavaTextTools().getCodeScanner();
+		DefaultDamagerRepairer javaDR= new DefaultDamagerRepairer(javaScanner);
 		reconciler.setDamager(javaDR, SandboxHintPartitionScanner.JAVA_CODE);
 		reconciler.setRepairer(javaDR, SandboxHintPartitionScanner.JAVA_CODE);
-
 		return reconciler;
 	}
 
 	@Override
 	public IContentAssistant getContentAssistant(ISourceViewer sourceViewer) {
-		ContentAssistant assistant = new ContentAssistant();
-		assistant.setContentAssistProcessor(
-				new SandboxHintContentAssistProcessor(),
-				IDocument.DEFAULT_CONTENT_TYPE);
-		assistant.setContentAssistProcessor(
-				new EmbeddedJavaContentAssistProcessor(),
+		ContentAssistant assistant= new ContentAssistant();
+		SandboxHintContentAssistProcessor hintProcessor= new SandboxHintContentAssistProcessor();
+		assistant.setContentAssistProcessor(hintProcessor, IDocument.DEFAULT_CONTENT_TYPE);
+		assistant.setContentAssistProcessor(hintProcessor, SandboxHintPartitionScanner.METADATA);
+		assistant.setContentAssistProcessor(new EmbeddedJavaContentAssistProcessor(),
 				SandboxHintPartitionScanner.JAVA_CODE);
 		assistant.enableAutoActivation(true);
 		assistant.setAutoActivationDelay(500);
@@ -137,28 +102,25 @@ public class SandboxHintSourceViewerConfiguration extends SourceViewerConfigurat
 
 	@Override
 	public IReconciler getReconciler(ISourceViewer sourceViewer) {
-		SandboxHintReconcilingStrategy strategy = new SandboxHintReconcilingStrategy();
+		SandboxHintReconcilingStrategy strategy= new SandboxHintReconcilingStrategy();
 		strategy.setSourceViewer(sourceViewer);
 		if (editor != null) {
 			strategy.setEditor(editor);
 		}
-		MonoReconciler reconciler = new MonoReconciler(strategy, false);
+		MonoReconciler reconciler= new MonoReconciler(strategy, false);
 		reconciler.setDelay(500);
 		return reconciler;
 	}
 
 	@Override
 	public IHyperlinkDetector[] getHyperlinkDetectors(ISourceViewer sourceViewer) {
-		// Keep default detectors and add the guard function hyperlink detector
-		IHyperlinkDetector[] defaults = super.getHyperlinkDetectors(sourceViewer);
-		IHyperlinkDetector[] result;
-		if (defaults != null) {
-			result = new IHyperlinkDetector[defaults.length + 1];
-			System.arraycopy(defaults, 0, result, 0, defaults.length);
-			result[defaults.length] = new SandboxHintHyperlinkDetector();
-		} else {
-			result = new IHyperlinkDetector[] { new SandboxHintHyperlinkDetector() };
+		IHyperlinkDetector[] defaults= super.getHyperlinkDetectors(sourceViewer);
+		if (defaults == null) {
+			return new IHyperlinkDetector[] { new SandboxHintHyperlinkDetector() };
 		}
+		IHyperlinkDetector[] result= new IHyperlinkDetector[defaults.length + 1];
+		System.arraycopy(defaults, 0, result, 0, defaults.length);
+		result[defaults.length]= new SandboxHintHyperlinkDetector();
 		return result;
 	}
 }

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/api/HintPredicateDefinition.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/api/HintPredicateDefinition.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.api;
+
+import java.util.List;
+import java.util.Objects;
+
+/** Immutable declaration model shared by core parsing and editor tooling. */
+public record HintPredicateDefinition(String name, List<String> parameters,
+		String expression, int lineNumber) {
+
+	public HintPredicateDefinition {
+		name= requireIdentifier(name, "predicate name"); //$NON-NLS-1$
+		parameters= List.copyOf(Objects.requireNonNull(parameters, "parameters")); //$NON-NLS-1$
+		for (String parameter : parameters) {
+			if (parameter == null || parameter.length() < 2 || parameter.charAt(0) != '$') {
+				throw new IllegalArgumentException("Predicate parameters must be placeholders: " + parameter); //$NON-NLS-1$
+			}
+			int end= parameter.endsWith("$") ? parameter.length() - 1 : parameter.length(); //$NON-NLS-1$
+			if (end <= 1) {
+				throw new IllegalArgumentException("Predicate parameters must be placeholders: " + parameter); //$NON-NLS-1$
+			}
+			requireIdentifier(parameter.substring(1, end), "predicate parameter"); //$NON-NLS-1$
+		}
+		if (parameters.stream().distinct().count() != parameters.size()) {
+			throw new IllegalArgumentException("Predicate parameters must be unique: " + parameters); //$NON-NLS-1$
+		}
+		expression= Objects.requireNonNull(expression, "expression").trim(); //$NON-NLS-1$
+		if (expression.isEmpty()) {
+			throw new IllegalArgumentException("Predicate expression must not be blank"); //$NON-NLS-1$
+		}
+		if (lineNumber < 1) {
+			throw new IllegalArgumentException("Predicate line number must be positive"); //$NON-NLS-1$
+		}
+	}
+
+	/** Returns a compact signature suitable for outline and content-assist labels. */
+	public String signature() {
+		return name + '(' + String.join(", ", parameters) + ')'; //$NON-NLS-1$
+	}
+
+	private static String requireIdentifier(String value, String label) {
+		String identifier= Objects.requireNonNull(value, label).trim();
+		if (identifier.isEmpty() || !Character.isJavaIdentifierStart(identifier.charAt(0))) {
+			throw new IllegalArgumentException("Invalid " + label + ": " + value); //$NON-NLS-1$ //$NON-NLS-2$
+		}
+		for (int index= 1; index < identifier.length(); index++) {
+			if (!Character.isJavaIdentifierPart(identifier.charAt(index))) {
+				throw new IllegalArgumentException("Invalid " + label + ": " + value); //$NON-NLS-1$ //$NON-NLS-2$
+			}
+		}
+		return identifier;
+	}
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/HintLanguageVocabulary.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/HintLanguageVocabulary.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.internal;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import org.sandbox.jdt.triggerpattern.api.GuardFunction;
+
+/** Canonical internal vocabulary shared by parser tooling and the editor. */
+public final class HintLanguageVocabulary {
+
+	/** One metadata/declaration directive and its concise editor documentation. */
+	public record Directive(String name, String syntax, String description) {
+	}
+
+	private static final List<Directive> DIRECTIVES= List.of(
+			new Directive("id", "<!id: rule.id>", "Stable hint-program identifier"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			new Directive("description", "<!description: text>", "Human-readable description"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			new Directive("severity", "<!severity: info|warning|error|hint>", "Reported severity"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			new Directive("minJavaVersion", "<!minJavaVersion: 17>", "Minimum Java source version"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			new Directive("tags", "<!tags: a, b>", "Searchable program tags"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			new Directive("include", "<!include: other.program>", "Compose rules from another program"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			new Directive("caseInsensitive", "<!caseInsensitive>", "Case-insensitive literal matching"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			new Directive("suppressWarnings", "<!suppressWarnings: key>", "Recognized suppression keys"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			new Directive("treeKind", "<!treeKind: METHOD_DECLARATION>", "AST kinds considered by the matcher"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			new Directive("requires-plan", "<!requires-plan: contract-id>", "Required semantic-plan contract"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			new Directive("foreach", "<!foreach NAME: source -> target>", "Generate rules from key/value pairs"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			new Directive("map", "<!map NAME: source => target>", "Reusable source/replacement mapping"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			new Directive("predicate", "<!predicate name($node): guard-expression>", //$NON-NLS-1$ //$NON-NLS-2$
+					"Named parameterized guard expression; predicates may compose other predicates")); //$NON-NLS-1$
+
+	private static final List<String> OPERATORS= List.of("=>", "::", ";;", "&&", "||", "!"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$
+
+	private static final Map<String, String> DESCRIPTION_OVERRIDES= Map.ofEntries(
+			Map.entry("plannedRole", "Matched or bound node has the supplied semantic-plan role"), //$NON-NLS-1$ //$NON-NLS-2$
+			Map.entry("enclosingPlannedRole", "An enclosing node has the supplied semantic-plan role"), //$NON-NLS-1$ //$NON-NLS-2$
+			Map.entry("referencedIn", "A variable is referenced in another bound node"), //$NON-NLS-1$ //$NON-NLS-2$
+			Map.entry("hasNoSideEffect", "Expression is side-effect free"), //$NON-NLS-1$ //$NON-NLS-2$
+			Map.entry("sourceVersionBetween", "Source version is within the supplied range"), //$NON-NLS-1$ //$NON-NLS-2$
+			Map.entry("genericTypeIs", "Generic type argument at an index matches a type"), //$NON-NLS-1$ //$NON-NLS-2$
+			Map.entry("otherwise", "Always true catch-all alternative")); //$NON-NLS-1$ //$NON-NLS-2$
+
+	private static final Set<String> BUILT_IN_GUARD_NAMES= loadBuiltInGuardNames();
+
+	private HintLanguageVocabulary() {
+	}
+
+	public static List<Directive> directives() {
+		return DIRECTIVES;
+	}
+
+	public static Set<String> directiveNames() {
+		return DIRECTIVES.stream().map(Directive::name)
+				.collect(java.util.stream.Collectors.toUnmodifiableSet());
+	}
+
+	public static List<String> operators() {
+		return OPERATORS;
+	}
+
+	public static String guardDescription(String name) {
+		return DESCRIPTION_OVERRIDES.getOrDefault(name, humanize(name));
+	}
+
+	public static Set<String> builtInGuardNames() {
+		return Set.copyOf(BUILT_IN_GUARD_NAMES);
+	}
+
+	private static Set<String> loadBuiltInGuardNames() {
+		Map<String, GuardFunction> functions= new LinkedHashMap<>();
+		BuiltInGuardRegistration.registerAll(functions);
+		return Set.copyOf(functions.keySet());
+	}
+
+	private static String humanize(String name) {
+		if (name == null || name.isBlank()) {
+			return "Registered guard or local predicate"; //$NON-NLS-1$
+		}
+		String words= name.replaceAll("([a-z0-9])([A-Z])", "$1 $2") //$NON-NLS-1$ //$NON-NLS-2$
+				.replace('_', ' ').toLowerCase(Locale.ROOT);
+		return Character.toUpperCase(words.charAt(0)) + words.substring(1);
+	}
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/HintPredicatePreprocessor.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/HintPredicatePreprocessor.java
@@ -1,0 +1,412 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.internal;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.sandbox.jdt.triggerpattern.api.GuardExpression;
+import org.sandbox.jdt.triggerpattern.api.HintPredicateDefinition;
+import org.sandbox.jdt.triggerpattern.internal.HintFileParser.HintParseException;
+
+/** Extracts and expands declarative {@code <!predicate ...>} definitions. */
+public final class HintPredicatePreprocessor {
+
+	private static final String PREDICATE_KEYWORD= "predicate"; //$NON-NLS-1$
+
+	/** Preprocessed source plus the immutable local predicate model. */
+	public record Result(String expandedSource, List<HintPredicateDefinition> predicates) {
+		public Result {
+			predicates= List.copyOf(predicates);
+		}
+	}
+
+	private record Extraction(String sourceWithoutDefinitions,
+			Map<String, HintPredicateDefinition> definitions) {
+	}
+
+	private HintPredicatePreprocessor() {
+	}
+
+	public static Result preprocess(String source) throws HintParseException {
+		if (source == null || source.isBlank()) {
+			throw new HintParseException("Hint file content is empty", 0); //$NON-NLS-1$
+		}
+		Extraction extraction= extractDefinitions(source);
+		ParsedPredicates predicates= new ParsedPredicates(extraction.definitions());
+		predicates.validate();
+		String expanded= expandGuardFragments(extraction.sourceWithoutDefinitions(), predicates);
+		return new Result(expanded, new ArrayList<>(extraction.definitions().values()));
+	}
+
+	/** Returns local definitions without requiring the remaining program to be valid. */
+	public static List<HintPredicateDefinition> discover(String source) {
+		if (source == null || source.isBlank()) {
+			return List.of();
+		}
+		try {
+			return new ArrayList<>(extractDefinitions(source).definitions().values());
+		} catch (HintParseException exception) {
+			return List.of();
+		}
+	}
+
+	private static Extraction extractDefinitions(String source) throws HintParseException {
+		StringBuilder cleaned= new StringBuilder(source);
+		Map<String, HintPredicateDefinition> definitions= new LinkedHashMap<>();
+		int cursor= 0;
+		while (cursor < source.length()) {
+			int start= nextPredicateDirective(source, cursor);
+			if (start < 0) {
+				break;
+			}
+			int end= directiveEnd(source, start + 2);
+			int line= lineNumber(source, start);
+			if (end < 0) {
+				throw new HintParseException("Unterminated predicate directive", line); //$NON-NLS-1$
+			}
+			HintPredicateDefinition definition= parseDefinition(source.substring(start + 2, end), line);
+			if (definitions.putIfAbsent(definition.name(), definition) != null) {
+				throw new HintParseException("Duplicate predicate " + definition.name(), line); //$NON-NLS-1$
+			}
+			blankExceptLineDelimiters(cleaned, start, end);
+			cursor= end + 1;
+		}
+		return new Extraction(cleaned.toString(),
+				Collections.unmodifiableMap(new LinkedHashMap<>(definitions)));
+	}
+
+	private static HintPredicateDefinition parseDefinition(String directive, int line)
+			throws HintParseException {
+		String text= directive.trim();
+		int nameStart= PREDICATE_KEYWORD.length();
+		boolean keywordBoundary= text.length() > nameStart
+				&& Character.isWhitespace(text.charAt(nameStart));
+		int open= text.indexOf('(', nameStart);
+		int close= open < 0 ? -1 : text.indexOf(')', open + 1);
+		int colon= close < 0 ? -1 : text.indexOf(':', close + 1);
+		if (!text.startsWith(PREDICATE_KEYWORD) || !keywordBoundary
+				|| open <= nameStart || close < open || colon < close) {
+			throw new HintParseException(
+					"Predicate syntax is <!predicate name($arg): guard-expression>", line); //$NON-NLS-1$
+		}
+		String name= text.substring(nameStart, open).trim();
+		List<String> parameters= new ArrayList<>();
+		String parameterText= text.substring(open + 1, close).trim();
+		if (!parameterText.isEmpty()) {
+			for (String parameter : parameterText.split(",")) { //$NON-NLS-1$
+				parameters.add(parameter.trim());
+			}
+		}
+		String expression= text.substring(colon + 1).trim();
+		try {
+			return new HintPredicateDefinition(name, parameters, expression, line);
+		} catch (IllegalArgumentException exception) {
+			throw parseFailure(exception.getMessage(), line, exception);
+		}
+	}
+
+	private static String expandGuardFragments(String source, ParsedPredicates predicates)
+			throws HintParseException {
+		if (predicates.isEmpty()) {
+			return source;
+		}
+		StringBuilder result= new StringBuilder(source.length());
+		int offset= 0;
+		int lineNumber= 1;
+		while (offset < source.length()) {
+			int lineEnd= source.indexOf('\n', offset);
+			if (lineEnd < 0) {
+				lineEnd= source.length();
+			}
+			result.append(expandLine(source.substring(offset, lineEnd), predicates, lineNumber));
+			if (lineEnd < source.length()) {
+				result.append('\n');
+			}
+			offset= lineEnd + 1;
+			lineNumber++;
+		}
+		return result.toString();
+	}
+
+	private static String expandLine(String line, ParsedPredicates predicates, int lineNumber)
+			throws HintParseException {
+		int comment= commentStart(line);
+		String code= comment < 0 ? line : line.substring(0, comment);
+		String suffix= comment < 0 ? "" : line.substring(comment); //$NON-NLS-1$
+		StringBuilder result= new StringBuilder(code.length());
+		int cursor= 0;
+		while (cursor < code.length()) {
+			int separator= findOutsideString(code, "::", cursor); //$NON-NLS-1$
+			if (separator < 0) {
+				result.append(code, cursor, code.length());
+				break;
+			}
+			result.append(code, cursor, separator + 2);
+			int guardStart= separator + 2;
+			int guardEnd= nextBoundary(code, guardStart);
+			String guard= code.substring(guardStart, guardEnd);
+			result.append(predicates.expandAndFormat(guard, lineNumber));
+			cursor= guardEnd;
+		}
+		return result.append(suffix).toString();
+	}
+
+	private static int nextBoundary(String line, int start) {
+		int arrow= findOutsideString(line, "=>", start); //$NON-NLS-1$
+		int terminator= findOutsideString(line, ";;", start); //$NON-NLS-1$
+		if (arrow < 0) {
+			return terminator < 0 ? line.length() : terminator;
+		}
+		return terminator < 0 ? arrow : Math.min(arrow, terminator);
+	}
+
+	private static final class ParsedPredicates {
+		private final Map<String, HintPredicateDefinition> definitions;
+		private final Map<String, GuardExpression> expressions;
+		private final GuardExpressionParser parser= new GuardExpressionParser();
+
+		ParsedPredicates(Map<String, HintPredicateDefinition> definitions) throws HintParseException {
+			this.definitions= Collections.unmodifiableMap(new LinkedHashMap<>(definitions));
+			this.expressions= new LinkedHashMap<>(mapCapacity(this.definitions.size()));
+			for (HintPredicateDefinition definition : this.definitions.values()) {
+				try {
+					GuardExpression expression= parser.parse(definition.expression());
+					validateParameterContract(definition, expression);
+					expressions.put(definition.name(), expression);
+				} catch (IllegalArgumentException exception) {
+					throw parseFailure("Invalid predicate " + definition.signature() + ": " //$NON-NLS-1$ //$NON-NLS-2$
+							+ exception.getMessage(), definition.lineNumber(), exception);
+				}
+			}
+		}
+
+		boolean isEmpty() {
+			return definitions.isEmpty();
+		}
+
+		void validate() throws HintParseException {
+			for (HintPredicateDefinition definition : definitions.values()) {
+				expand(expressions.get(definition.name()), Map.of(),
+						new ArrayDeque<>(List.of(definition.name())), definition.lineNumber());
+			}
+		}
+
+		String expandAndFormat(String guard, int lineNumber) throws HintParseException {
+			if (guard.isBlank()) {
+				return guard;
+			}
+			try {
+				GuardExpression parsed= parser.parse(guard.trim());
+				return " " + format(expand(parsed, Map.of(), new ArrayDeque<>(), lineNumber)) + " "; //$NON-NLS-1$ //$NON-NLS-2$
+			} catch (IllegalArgumentException exception) {
+				throw parseFailure("Invalid guard expression: " + exception.getMessage(), //$NON-NLS-1$
+						lineNumber, exception);
+			}
+		}
+
+		private GuardExpression expand(GuardExpression expression, Map<String, String> substitutions,
+				Deque<String> stack, int lineNumber) throws HintParseException {
+			return switch (expression) {
+				case GuardExpression.And and -> new GuardExpression.And(
+						expand(and.left(), substitutions, stack, lineNumber),
+						expand(and.right(), substitutions, stack, lineNumber));
+				case GuardExpression.Or or -> new GuardExpression.Or(
+						expand(or.left(), substitutions, stack, lineNumber),
+						expand(or.right(), substitutions, stack, lineNumber));
+				case GuardExpression.Not not -> new GuardExpression.Not(
+						expand(not.operand(), substitutions, stack, lineNumber));
+				case GuardExpression.FunctionCall call -> expandCall(call, substitutions, stack, lineNumber);
+			};
+		}
+
+		private GuardExpression expandCall(GuardExpression.FunctionCall call,
+				Map<String, String> substitutions, Deque<String> stack, int lineNumber)
+				throws HintParseException {
+			List<String> arguments= call.args().stream()
+					.map(argument -> substitutions.getOrDefault(argument, argument)).toList();
+			HintPredicateDefinition definition= definitions.get(call.name());
+			if (definition == null) {
+				return new GuardExpression.FunctionCall(call.name(), arguments);
+			}
+			if (arguments.size() != definition.parameters().size()) {
+				throw new HintParseException("Predicate " + definition.signature() + " expects " //$NON-NLS-1$ //$NON-NLS-2$
+						+ definition.parameters().size() + " arguments but received " + arguments.size(), lineNumber); //$NON-NLS-1$
+			}
+			if (stack.contains(definition.name())) {
+				List<String> cycle= new ArrayList<>(stack);
+				cycle.add(definition.name());
+				throw new HintParseException("Recursive predicate cycle: " + String.join(" -> ", cycle), //$NON-NLS-1$ //$NON-NLS-2$
+						definition.lineNumber());
+			}
+			Map<String, String> nested= new LinkedHashMap<>(mapCapacity(arguments.size()));
+			for (int index= 0; index < arguments.size(); index++) {
+				nested.put(definition.parameters().get(index), arguments.get(index));
+			}
+			stack.addLast(definition.name());
+			GuardExpression expanded= expand(expressions.get(definition.name()), nested, stack,
+					definition.lineNumber());
+			stack.removeLast();
+			return expanded;
+		}
+
+		private static void validateParameterContract(HintPredicateDefinition definition,
+				GuardExpression expression) {
+			Set<String> referenced= new LinkedHashSet<>();
+			collectPlaceholders(expression, referenced);
+			Set<String> undeclared= new LinkedHashSet<>(referenced);
+			undeclared.removeAll(definition.parameters());
+			if (!undeclared.isEmpty()) {
+				throw new IllegalArgumentException("undeclared placeholder references " + undeclared); //$NON-NLS-1$
+			}
+			Set<String> unused= new LinkedHashSet<>(definition.parameters());
+			unused.removeAll(referenced);
+			if (!unused.isEmpty()) {
+				throw new IllegalArgumentException("unused parameters " + unused); //$NON-NLS-1$
+			}
+		}
+
+		private static void collectPlaceholders(GuardExpression expression, Set<String> target) {
+			switch (expression) {
+				case GuardExpression.And and -> {
+					collectPlaceholders(and.left(), target);
+					collectPlaceholders(and.right(), target);
+				}
+				case GuardExpression.Or or -> {
+					collectPlaceholders(or.left(), target);
+					collectPlaceholders(or.right(), target);
+				}
+				case GuardExpression.Not not -> collectPlaceholders(not.operand(), target);
+				case GuardExpression.FunctionCall call -> call.args().stream()
+						.filter(argument -> argument.startsWith("$")) //$NON-NLS-1$
+						.forEach(target::add);
+			}
+		}
+	}
+
+	private static String format(GuardExpression expression) {
+		return switch (expression) {
+			case GuardExpression.And and -> '(' + format(and.left()) + " && " + format(and.right()) + ')'; //$NON-NLS-1$
+			case GuardExpression.Or or -> '(' + format(or.left()) + " || " + format(or.right()) + ')'; //$NON-NLS-1$
+			case GuardExpression.Not not -> "!(" + format(not.operand()) + ')'; //$NON-NLS-1$
+			case GuardExpression.FunctionCall call -> call.name() + '(' + String.join(", ", call.args()) + ')'; //$NON-NLS-1$
+		};
+	}
+
+	private static int nextPredicateDirective(String source, int start) {
+		boolean inString= false;
+		boolean escaped= false;
+		boolean lineComment= false;
+		boolean blockComment= false;
+		for (int index= start; index < source.length(); index++) {
+			char current= source.charAt(index);
+			char next= index + 1 < source.length() ? source.charAt(index + 1) : '\0';
+			if (lineComment) {
+				if (current == '\n' || current == '\r') {
+					lineComment= false;
+				}
+			} else if (blockComment) {
+				if (current == '*' && next == '/') {
+					blockComment= false;
+					index++;
+				}
+			} else if (inString) {
+				if (escaped) {
+					escaped= false;
+				} else if (current == '\\') {
+					escaped= true;
+				} else if (current == '"') {
+					inString= false;
+				}
+			} else if (current == '"') {
+				inString= true;
+			} else if (current == '/' && next == '/') {
+				lineComment= true;
+				index++;
+			} else if (current == '/' && next == '*') {
+				blockComment= true;
+				index++;
+			} else if (source.startsWith("<!" + PREDICATE_KEYWORD, index)) { //$NON-NLS-1$
+				int boundary= index + 2 + PREDICATE_KEYWORD.length();
+				if (boundary < source.length() && Character.isWhitespace(source.charAt(boundary))) {
+					return index;
+				}
+			}
+		}
+		return -1;
+	}
+
+	private static int directiveEnd(String source, int start) {
+		return findOutsideString(source, ">", start); //$NON-NLS-1$
+	}
+
+	private static int findOutsideString(String source, String token, int start) {
+		boolean inString= false;
+		boolean escaped= false;
+		for (int index= start; index + token.length() <= source.length(); index++) {
+			char current= source.charAt(index);
+			if (inString) {
+				if (escaped) {
+					escaped= false;
+				} else if (current == '\\') {
+					escaped= true;
+				} else if (current == '"') {
+					inString= false;
+				}
+			} else if (current == '"') {
+				inString= true;
+			} else if (source.startsWith(token, index)) {
+				return index;
+			}
+		}
+		return -1;
+	}
+
+	private static int commentStart(String line) {
+		return findOutsideString(line, "//", 0); //$NON-NLS-1$
+	}
+
+	private static void blankExceptLineDelimiters(StringBuilder source, int start, int end) {
+		for (int index= start; index <= end; index++) {
+			char character= source.charAt(index);
+			if (character != '\n' && character != '\r') {
+				source.setCharAt(index, ' ');
+			}
+		}
+	}
+
+	private static int lineNumber(String source, int offset) {
+		int line= 1;
+		for (int index= 0; index < Math.min(offset, source.length()); index++) {
+			if (source.charAt(index) == '\n') {
+				line++;
+			}
+		}
+		return line;
+	}
+
+	private static int mapCapacity(int expectedSize) {
+		return Math.max(1, (int) Math.ceil(expectedSize / 0.75d));
+	}
+
+	private static HintParseException parseFailure(String message, int line, Throwable cause) {
+		HintParseException failure= new HintParseException(message, line);
+		failure.initCause(cause);
+		return failure;
+	}
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/HintProgramParser.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/HintProgramParser.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.internal;
+
+import java.util.List;
+
+import org.sandbox.jdt.triggerpattern.api.HintFile;
+import org.sandbox.jdt.triggerpattern.api.HintPredicateDefinition;
+import org.sandbox.jdt.triggerpattern.internal.HintFileParser.HintParseException;
+
+/**
+ * Composes high-level declarative language features before delegating ordinary
+ * rule parsing to the stable {@link HintFileParser}.
+ */
+public final class HintProgramParser {
+
+	/**
+	 * Immutable local declarations and expanded executable source. The mutable
+	 * compatibility {@link HintFile} model is reconstructed on demand rather than
+	 * exposed from parser-owned state.
+	 */
+	public record ParsedProgram(List<HintPredicateDefinition> predicates, String expandedSource) {
+		public ParsedProgram {
+			predicates= List.copyOf(predicates);
+		}
+
+		/** Returns a fresh compatibility rule model for the validated expanded source. */
+		public HintFile hintFile() {
+			try {
+				return new HintFileParser().parse(expandedSource);
+			} catch (HintParseException exception) {
+				throw new IllegalStateException("Validated expanded hint source can no longer be parsed", exception); //$NON-NLS-1$
+			}
+		}
+	}
+
+	private record PreparedProgram(List<HintPredicateDefinition> predicates, String expandedSource) {
+		PreparedProgram {
+			predicates= List.copyOf(predicates);
+		}
+	}
+
+	private final HintFileParser ruleParser;
+
+	public HintProgramParser() {
+		this(new HintFileParser());
+	}
+
+	HintProgramParser(HintFileParser ruleParser) {
+		this.ruleParser= ruleParser;
+	}
+
+	public ParsedProgram parse(String source) throws HintParseException {
+		PreparedProgram prepared= prepare(source);
+		ruleParser.parse(prepared.expandedSource());
+		return new ParsedProgram(prepared.predicates(), prepared.expandedSource());
+	}
+
+	/** Convenience for consumers that only need the existing rule model. */
+	public HintFile parseHintFile(String source) throws HintParseException {
+		PreparedProgram prepared= prepare(source);
+		return ruleParser.parse(prepared.expandedSource());
+	}
+
+	private static PreparedProgram prepare(String source) throws HintParseException {
+		HintPredicatePreprocessor.Result preprocessed= HintPredicatePreprocessor.preprocess(source);
+		validatePredicateNames(preprocessed.predicates());
+		return new PreparedProgram(preprocessed.predicates(), preprocessed.expandedSource());
+	}
+
+	private static void validatePredicateNames(Iterable<HintPredicateDefinition> predicates)
+			throws HintParseException {
+		for (HintPredicateDefinition predicate : predicates) {
+			if (HintLanguageVocabulary.builtInGuardNames().contains(predicate.name())) {
+				throw new HintParseException("Predicate name shadows built-in guard " //$NON-NLS-1$
+						+ predicate.name(), predicate.lineNumber());
+			}
+		}
+	}
+}

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/internal/HintDirectiveVocabularyContractTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/internal/HintDirectiveVocabularyContractTest.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import org.eclipse.jdt.core.dom.ASTNode;
+
+import org.sandbox.jdt.triggerpattern.api.HintFile;
+
+class HintDirectiveVocabularyContractTest {
+
+	@Test
+	void everyDocumentedDirectiveHasAnAcceptedRepresentativeSyntax() throws Exception {
+		Map<String, String> examples= Map.ofEntries(
+				Map.entry("id", "<!id: vocabulary-contract>"), //$NON-NLS-1$ //$NON-NLS-2$
+				Map.entry("description", "<!description: language contract>"), //$NON-NLS-1$ //$NON-NLS-2$
+				Map.entry("severity", "<!severity: warning>"), //$NON-NLS-1$ //$NON-NLS-2$
+				Map.entry("minJavaVersion", "<!minJavaVersion: 17>"), //$NON-NLS-1$ //$NON-NLS-2$
+				Map.entry("tags", "<!tags: dsl, contract>"), //$NON-NLS-1$ //$NON-NLS-2$
+				Map.entry("include", "<!include: shared-rules>"), //$NON-NLS-1$ //$NON-NLS-2$
+				Map.entry("caseInsensitive", "<!caseInsensitive>"), //$NON-NLS-1$ //$NON-NLS-2$
+				Map.entry("suppressWarnings", "<!suppressWarnings: deprecation>"), //$NON-NLS-1$ //$NON-NLS-2$
+				Map.entry("treeKind", "<!treeKind: METHOD_DECLARATION>"), //$NON-NLS-1$ //$NON-NLS-2$
+				Map.entry("requires-plan", "<!requires-plan: semantic-contract>"), //$NON-NLS-1$ //$NON-NLS-2$
+				Map.entry("foreach", "<!foreach SAMPLE: source -> target>"), //$NON-NLS-1$ //$NON-NLS-2$
+				Map.entry("map", "<!map SAMPLE: source => target>"), //$NON-NLS-1$ //$NON-NLS-2$
+				Map.entry("predicate", "<!predicate selected($node): matchesAny($node)>") //$NON-NLS-1$ //$NON-NLS-2$
+		);
+		assertEquals(HintLanguageVocabulary.directiveNames(), examples.keySet(),
+				"Adding or removing a documented directive requires a parser-contract example."); //$NON-NLS-1$
+
+		String source= String.join("\n", examples.values()) + """
+				
+				foo($node) :: selected($node)
+				=> bar($node)
+				;;
+				""";
+		HintFile hint= new HintProgramParser().parseHintFile(source);
+
+		assertEquals("vocabulary-contract", hint.getId()); //$NON-NLS-1$
+		assertEquals("language contract", hint.getDescription()); //$NON-NLS-1$
+		assertEquals(17, hint.getMinJavaVersion());
+		assertTrue(hint.getTags().containsAll(Set.of("dsl", "contract"))); //$NON-NLS-1$ //$NON-NLS-2$
+		assertTrue(hint.getIncludes().contains("shared-rules")); //$NON-NLS-1$
+		assertTrue(hint.isCaseInsensitive());
+		assertTrue(hint.getSuppressWarnings().contains("deprecation")); //$NON-NLS-1$
+		assertTrue(hint.getTreeKindNodeTypes().contains(ASTNode.METHOD_DECLARATION));
+		assertEquals(1, hint.getRules().size());
+	}
+}

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/internal/HintLanguageVocabularyTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/internal/HintLanguageVocabularyTest.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.sandbox.jdt.triggerpattern.api.GuardFunction;
+
+class HintLanguageVocabularyTest {
+
+	@Test
+	void directiveAndOperatorVocabularyIsUniqueAndIncludesCompositionSyntax() {
+		assertEquals(HintLanguageVocabulary.directives().size(),
+				HintLanguageVocabulary.directiveNames().size());
+		assertTrue(HintLanguageVocabulary.directiveNames().contains("predicate")); //$NON-NLS-1$
+		assertTrue(HintLanguageVocabulary.directiveNames().contains("requires-plan")); //$NON-NLS-1$
+		assertEquals(HintLanguageVocabulary.operators().size(),
+				HintLanguageVocabulary.operators().stream().distinct().count());
+		assertTrue(HintLanguageVocabulary.operators().containsAll(
+				java.util.List.of("=>", "::", ";;", "&&", "||", "!"))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$
+	}
+
+	@Test
+	void builtInGuardVocabularyIsDerivedFromTheExecutableRegistration() {
+		Map<String, GuardFunction> guards= new LinkedHashMap<>();
+		BuiltInGuardRegistration.registerAll(guards);
+
+		assertEquals(guards.keySet(), HintLanguageVocabulary.builtInGuardNames());
+		for (String name : guards.keySet()) {
+			assertFalse(HintLanguageVocabulary.guardDescription(name).isBlank(), name);
+		}
+	}
+}

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/internal/HintPredicateContractTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/internal/HintPredicateContractTest.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import org.sandbox.jdt.triggerpattern.internal.HintFileParser.HintParseException;
+
+class HintPredicateContractTest {
+
+	@Test
+	void rejectsImplicitPlaceholderCapture() {
+		HintParseException failure= assertThrows(HintParseException.class,
+				() -> new HintProgramParser().parse("""
+						<!id: hidden-capture>
+						<!predicate exact($method): isPublic($method) && paramCount($other, 0)>
+						foo($node) :: exact($node)
+						=> bar($node)
+						;;
+						"""));
+
+		assertTrue(failure.getMessage().contains("undeclared placeholder references [$other]")); //$NON-NLS-1$
+	}
+
+	@Test
+	void rejectsUnusedParameters() {
+		HintParseException failure= assertThrows(HintParseException.class,
+				() -> new HintProgramParser().parse("""
+						<!id: unused>
+						<!predicate exact($method, $unused): isPublic($method)>
+						foo($node) :: exact($node, $node)
+						=> bar($node)
+						;;
+						"""));
+
+		assertTrue(failure.getMessage().contains("unused parameters [$unused]")); //$NON-NLS-1$
+	}
+
+	@Test
+	void rejectsPredicateThatShadowsBuiltInGuard() {
+		HintParseException failure= assertThrows(HintParseException.class,
+				() -> new HintProgramParser().parse("""
+						<!id: shadowing>
+						<!predicate isPublic($method): matchesAny($method)>
+						foo($node) :: isPublic($node)
+						=> bar($node)
+						;;
+						"""));
+
+		assertEquals(2, failure.getLineNumber());
+		assertTrue(failure.getMessage().contains("shadows built-in guard isPublic")); //$NON-NLS-1$
+	}
+}

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/internal/HintPredicatePreprocessorTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/internal/HintPredicatePreprocessorTest.java
@@ -1,0 +1,180 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import org.sandbox.jdt.triggerpattern.internal.HintFileParser.HintParseException;
+
+class HintPredicatePreprocessorTest {
+
+	@Test
+	void expandsNamedPredicateIntoOrdinaryGuardAst() throws Exception {
+		String source= """
+				<!id: composed>
+				<!predicate exactTest($method):
+				    isPublic($method) && !isStatic($method) && paramCount($method, 0)>
+				foo($method) :: exactTest($method)
+				=> bar($method)
+				;;
+				""";
+
+		HintProgramParser.ParsedProgram program= new HintProgramParser().parse(source);
+
+		assertEquals(1, program.predicates().size());
+		assertEquals("exactTest($method)", program.predicates().get(0).signature()); //$NON-NLS-1$
+		assertEquals(1, program.hintFile().getRules().size());
+		assertFalse(program.expandedSource().contains("<!predicate")); //$NON-NLS-1$
+		assertFalse(program.expandedSource().contains("exactTest($method)")); //$NON-NLS-1$
+		assertTrue(program.expandedSource().contains("isPublic($method)")); //$NON-NLS-1$
+		assertTrue(program.expandedSource().contains("paramCount($method, 0)")); //$NON-NLS-1$
+	}
+
+	@Test
+	void composesPredicatesAndSubstitutesArgumentsStructurally() throws Exception {
+		String source= """
+				<!id: nested>
+				<!predicate visible($member): isPublic($member) && !isStatic($member)>
+				<!predicate exactTest($candidate): visible($candidate) && paramCount($candidate, 0)>
+				foo($node) :: exactTest($node)
+				=> bar($node)
+				;;
+				""";
+
+		String expanded= new HintProgramParser().parse(source).expandedSource();
+
+		assertFalse(expanded.contains("visible(")); //$NON-NLS-1$
+		assertFalse(expanded.contains("exactTest(")); //$NON-NLS-1$
+		assertTrue(expanded.contains("isPublic($node)")); //$NON-NLS-1$
+		assertTrue(expanded.contains("isStatic($node)")); //$NON-NLS-1$
+	}
+
+	@Test
+	void preservesWhitespaceInsideStringLiteralArguments() throws Exception {
+		String source= """
+				<!id: literal-whitespace>
+				<!predicate containsExactText($node): contains($node, "two  spaces")>
+				foo($node) :: containsExactText($node)
+				=> bar($node)
+				;;
+				""";
+
+		HintProgramParser.ParsedProgram program= new HintProgramParser().parse(source);
+
+		assertEquals("contains($node, \"two  spaces\")", //$NON-NLS-1$
+				program.predicates().get(0).expression());
+		assertTrue(program.expandedSource().contains("\"two  spaces\"")); //$NON-NLS-1$
+	}
+
+	@Test
+	void doesNotRewriteSameNamedCallInSourcePattern() throws Exception {
+		String source= """
+				<!id: source-call>
+				<!predicate selected($node): matchesAny($node)>
+				selected($node) :: selected($node)
+				=> replacement($node)
+				;;
+				""";
+
+		String expanded= new HintProgramParser().parse(source).expandedSource();
+
+		assertTrue(expanded.contains("selected($node) :: matchesAny($node)")); //$NON-NLS-1$
+	}
+
+	@Test
+	void ignoresPredicateTextInsideComments() throws Exception {
+		String source= """
+				<!id: comments>
+				// <!predicate ignored($x): isPublic($x)>
+				foo($x) :: matchesAny($x)
+				=> bar($x)
+				;;
+				""";
+
+		HintProgramParser.ParsedProgram program= new HintProgramParser().parse(source);
+
+		assertTrue(program.predicates().isEmpty());
+		assertEquals(1, program.hintFile().getRules().size());
+	}
+
+	@Test
+	void doesNotTreatLongerMetadataNameAsPredicateDeclaration() throws Exception {
+		String source= """
+				<!id: boundary>
+				<!predicateFactory: ignored-for-forward-compatibility>
+				foo($x) :: matchesAny($x)
+				=> bar($x)
+				;;
+				""";
+
+		HintProgramParser.ParsedProgram program= new HintProgramParser().parse(source);
+
+		assertTrue(program.predicates().isEmpty());
+		assertEquals(1, program.hintFile().getRules().size());
+	}
+
+	@Test
+	void rejectsDuplicatePredicateNamesWithSourceLine() {
+		HintParseException failure= assertThrows(HintParseException.class, () -> new HintProgramParser().parse("""
+				<!id: duplicate>
+				<!predicate reusable($x): matchesAny($x)>
+				<!predicate reusable($x): matchesNone($x)>
+				foo($x) :: reusable($x)
+				=> bar($x)
+				;;
+				"""));
+
+		assertEquals(3, failure.getLineNumber());
+		assertTrue(failure.getMessage().contains("Duplicate predicate reusable")); //$NON-NLS-1$
+	}
+
+	@Test
+	void rejectsWrongPredicateArity() {
+		HintParseException failure= assertThrows(HintParseException.class, () -> new HintProgramParser().parse("""
+				<!id: arity>
+				<!predicate pair($left, $right): referencedIn($left, $right)>
+				foo($x) :: pair($x)
+				=> bar($x)
+				;;
+				"""));
+
+		assertTrue(failure.getMessage().contains("expects 2 arguments but received 1")); //$NON-NLS-1$
+	}
+
+	@Test
+	void rejectsDirectAndIndirectPredicateCycles() {
+		HintParseException direct= assertThrows(HintParseException.class,
+				() -> new HintProgramParser().parse("""
+						<!id: direct-cycle>
+						<!predicate loop($x): loop($x)>
+						foo($x) :: loop($x)
+						=> bar($x)
+						;;
+						"""));
+		assertTrue(direct.getMessage().contains("Recursive predicate cycle")); //$NON-NLS-1$
+
+		HintParseException indirect= assertThrows(HintParseException.class,
+				() -> new HintProgramParser().parse("""
+						<!id: indirect-cycle>
+						<!predicate first($x): second($x)>
+						<!predicate second($x): first($x)>
+						foo($x) :: first($x)
+						=> bar($x)
+						;;
+						"""));
+		assertTrue(indirect.getMessage().contains("first -> second -> first")); //$NON-NLS-1$
+	}
+}

--- a/sandbox_common_test/src/org/sandbox/jdt/triggerpattern/editor/SandboxHintEditorLanguageTest.java
+++ b/sandbox_common_test/src/org/sandbox/jdt/triggerpattern/editor/SandboxHintEditorLanguageTest.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.editor;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.TextAttribute;
+import org.eclipse.jface.text.rules.IToken;
+import org.eclipse.jface.text.rules.Token;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.RGB;
+
+import org.sandbox.jdt.triggerpattern.editor.SandboxHintContentAssistProcessor.CompletionEntry;
+
+class SandboxHintEditorLanguageTest {
+
+	@Test
+	void highlightsDeclaredPredicatesRegisteredGuardsAndLogicalOperators() {
+		String source= """
+				<!predicate exactTest($method): isPublic($method) && paramCount($method, 0)>
+				foo($x) :: exactTest($x) && plannedRole($x, "TEST") || otherwise
+				=> bar($x)
+				;;
+				""";
+		SandboxHintCodeScanner scanner= new SandboxHintCodeScanner();
+		Document document= new Document(source);
+		scanner.setRange(document, 0, document.getLength());
+
+		assertToken(scanner, source, "exactTest", scanner.functionToken(), SWT.BOLD); //$NON-NLS-1$
+		assertToken(scanner, source, "plannedRole", scanner.functionToken(), SWT.BOLD); //$NON-NLS-1$
+		assertToken(scanner, source, "otherwise", scanner.functionToken(), SWT.BOLD); //$NON-NLS-1$
+		assertToken(scanner, source, "&&", scanner.operatorToken(), SWT.BOLD); //$NON-NLS-1$
+		assertToken(scanner, source, "||", scanner.operatorToken(), SWT.BOLD); //$NON-NLS-1$
+	}
+
+	@Test
+	void constructsScannersWithoutLoadingNativeSwtInStandaloneMaven() {
+		assertDoesNotThrow(SandboxHintCodeScanner::new);
+		assertDoesNotThrow(SandboxHintMetadataScanner::new);
+		assertEquals(new RGB(0, 0, 192), SandboxHintCodeScanner.FUNCTION_RGB);
+		assertEquals(new RGB(128, 0, 128), SandboxHintCodeScanner.OPERATOR_RGB);
+		assertEquals(new RGB(128, 0, 0), SandboxHintCodeScanner.PLACEHOLDER_RGB);
+	}
+
+	@Test
+	void completionCombinesRegistryLocalPredicatesAndDirectivesWithoutDuplicates() {
+		String source= """
+				<!predicate exactTest($method): isPublic($method) && paramCount($method, 0)>
+				foo($method) :: ex
+				=> bar($method)
+				;;
+				""";
+
+		List<CompletionEntry> guards= SandboxHintContentAssistProcessor.completionEntries(source, false);
+		assertEquals(guards.size(), guards.stream().map(CompletionEntry::name).distinct().count());
+		CompletionEntry local= guards.stream().filter(entry -> "exactTest".equals(entry.name())) //$NON-NLS-1$
+				.findFirst().orElseThrow();
+		assertTrue(local.description().contains("exactTest($method)")); //$NON-NLS-1$
+		assertTrue(guards.stream().anyMatch(entry -> "plannedRole".equals(entry.name()))); //$NON-NLS-1$
+
+		List<CompletionEntry> directives=
+				SandboxHintContentAssistProcessor.completionEntries("<!pre", true); //$NON-NLS-1$
+		CompletionEntry predicate= directives.stream()
+				.filter(entry -> "predicate".equals(entry.name())).findFirst().orElseThrow(); //$NON-NLS-1$
+		assertTrue(predicate.replacement().startsWith("predicate ")); //$NON-NLS-1$
+	}
+
+	private static void assertToken(SandboxHintCodeScanner scanner, String source,
+			String expectedText, IToken expectedToken, int style) {
+		scanner.setRange(new Document(source), 0, source.length());
+		while (true) {
+			IToken token= scanner.nextToken();
+			if (token == Token.EOF) {
+				break;
+			}
+			int offset= scanner.getTokenOffset();
+			int length= scanner.getTokenLength();
+			if (!expectedText.equals(source.substring(offset, offset + length))) {
+				continue;
+			}
+			assertSame(expectedToken, token);
+			assertTrue(token.getData() instanceof TextAttribute);
+			TextAttribute attribute= (TextAttribute) token.getData();
+			assertTrue((attribute.getStyle() & style) != 0);
+			return;
+		}
+		throw new AssertionError("No token for " + expectedText); //$NON-NLS-1$
+	}
+}

--- a/sandbox_common_test/src/org/sandbox/jdt/triggerpattern/editor/SandboxHintPredicateEditorContextTest.java
+++ b/sandbox_common_test/src/org/sandbox/jdt/triggerpattern/editor/SandboxHintPredicateEditorContextTest.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.editor;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.TextAttribute;
+import org.eclipse.jface.text.contentassist.ContentAssistant;
+import org.eclipse.jface.text.rules.IToken;
+import org.eclipse.jface.text.rules.Token;
+
+import org.eclipse.swt.SWT;
+
+class SandboxHintPredicateEditorContextTest {
+
+	@Test
+	void highlightsGuardLanguageInsidePredicateMetadata() {
+		String source= "<!predicate exactTest($method): isPublic($method) && !isStatic($method)>"; //$NON-NLS-1$
+		SandboxHintMetadataScanner scanner= new SandboxHintMetadataScanner();
+
+		assertToken(scanner, source, "exactTest", scanner.functionToken(), SWT.BOLD); //$NON-NLS-1$
+		assertToken(scanner, source, "isPublic", scanner.functionToken(), SWT.BOLD); //$NON-NLS-1$
+		assertToken(scanner, source, "$method", scanner.placeholderToken(), SWT.NORMAL); //$NON-NLS-1$
+		assertToken(scanner, source, "&&", scanner.operatorToken(), SWT.BOLD); //$NON-NLS-1$
+	}
+
+	@Test
+	void recognizesPredicateBodyAsGuardCompletionContext() {
+		String source= "<!predicate exactTest($method): isP"; //$NON-NLS-1$
+
+		assertTrue(SandboxHintContentAssistProcessor.isPredicateGuardContext(source, source.length()));
+		assertTrue(SandboxHintContentAssistProcessor.isDirectiveContext(source, source.length()));
+		assertFalse(SandboxHintContentAssistProcessor.isPredicateGuardContext("<!pre", 5)); //$NON-NLS-1$
+	}
+
+	@Test
+	void registersContentAssistForMetadataPartitions() {
+		ContentAssistant assistant= (ContentAssistant) new SandboxHintSourceViewerConfiguration()
+				.getContentAssistant(null);
+
+		assertNotNull(assistant.getContentAssistProcessor(SandboxHintPartitionScanner.METADATA));
+	}
+
+	private static void assertToken(SandboxHintMetadataScanner scanner, String source,
+			String expectedText, IToken expectedToken, int style) {
+		scanner.setRange(new Document(source), 0, source.length());
+		while (true) {
+			IToken token= scanner.nextToken();
+			if (token == Token.EOF) {
+				break;
+			}
+			int offset= scanner.getTokenOffset();
+			int length= scanner.getTokenLength();
+			if (!expectedText.equals(source.substring(offset, offset + length))) {
+				continue;
+			}
+			assertSame(expectedToken, token);
+			assertTrue(token.getData() instanceof TextAttribute);
+			TextAttribute attribute= (TextAttribute) token.getData();
+			if (style == SWT.NORMAL) {
+				assertTrue(attribute.getStyle() == SWT.NORMAL);
+			} else {
+				assertTrue((attribute.getStyle() & style) != 0);
+			}
+			return;
+		}
+		throw new AssertionError("No token for " + expectedText); //$NON-NLS-1$
+	}
+}

--- a/sandbox_common_test/src/org/sandbox/jdt/triggerpattern/editor/SandboxHintPredicatePartitionTest.java
+++ b/sandbox_common_test/src/org/sandbox/jdt/triggerpattern/editor/SandboxHintPredicatePartitionTest.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.editor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.rules.IToken;
+
+class SandboxHintPredicatePartitionTest {
+
+	@Test
+	void treatsCompleteMultilinePredicateDeclarationAsMetadataPartition() {
+		String source= """
+				<!predicate exactTest($method):
+				    isPublic($method)
+				    && !isStatic($method)>
+				foo($method) :: exactTest($method)
+				""";
+		SandboxHintPartitionScanner scanner= new SandboxHintPartitionScanner();
+		scanner.setRange(new Document(source), 0, source.length());
+
+		IToken predicate= scanner.nextToken();
+
+		assertEquals(SandboxHintPartitionScanner.METADATA, predicate.getData());
+		assertEquals(0, scanner.getTokenOffset());
+		assertEquals(source.indexOf('>') + 1, scanner.getTokenLength());
+	}
+}

--- a/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/PlanAwarePredicateHintTest.java
+++ b/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/PlanAwarePredicateHintTest.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.quickfix;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
+import org.eclipse.jdt.internal.corext.refactoring.util.RefactoringASTParser;
+import org.eclipse.jdt.junit.JUnitCore;
+
+import org.sandbox.jdt.triggerpattern.api.SemanticRewritePlan;
+import org.sandbox.jdt.triggerpattern.api.SemanticRewritePlan.NodeKey;
+import org.sandbox.jdt.triggerpattern.cleanup.PlanAwareHintFileFixCore;
+import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
+import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava17;
+
+class PlanAwarePredicateHintTest {
+
+	@RegisterExtension
+	AbstractEclipseJava context= new EclipseJava17();
+
+	@Test
+	void expandsPredicateAndCreatesAuthorizedRewriteOperation() throws CoreException {
+		IPackageFragmentRoot root= context.createClasspathForJUnit(JUnitCore.JUNIT5_CONTAINER_PATH);
+		IPackageFragment pack= root.createPackageFragment("sample", true, null); //$NON-NLS-1$
+		ICompilationUnit unit= pack.createCompilationUnit("Sample.java", //$NON-NLS-1$
+				"""
+				package sample;
+				public class Sample {
+					public void testOne() {
+					}
+				}
+				""", false, null);
+		CompilationUnit ast= parse(unit);
+		MethodDeclaration method= findMethod(ast, "testOne"); //$NON-NLS-1$
+		IMethodBinding binding= method.resolveBinding();
+		String key= binding.getMethodDeclaration().getKey();
+		SemanticRewritePlan plan= SemanticRewritePlan.builder("predicate-demo") //$NON-NLS-1$
+				.add(NodeKey.method(key), "TEST_METHOD").build(); //$NON-NLS-1$
+		String hint= """
+				<!id: predicate-demo>
+				<!requires-plan: predicate-demo>
+				<!predicate selected($method):
+				    enclosingPlannedRole($method, "TEST_METHOD") && isPublic($method)>
+				void $name() :: selected($name)
+				=> @org.junit.jupiter.api.Test void $name()
+				;;
+				""";
+		Set<CompilationUnitRewriteOperationWithSourceRange> operations= new LinkedHashSet<>();
+		Set<org.eclipse.jdt.core.dom.ASTNode> processed= new LinkedHashSet<>();
+
+		Set<NodeKey> covered= PlanAwareHintFileFixCore.findOperationsFromContent(ast, hint, plan,
+				unit.getJavaProject().getOptions(true), operations, processed);
+
+		assertEquals(Set.of(NodeKey.method(key)), covered);
+		assertEquals(1, operations.size());
+		assertTrue(processed.contains(method));
+	}
+
+	private CompilationUnit parse(ICompilationUnit unit) {
+		ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
+		parser.setProject(context.getJavaProject());
+		parser.setSource(unit);
+		parser.setResolveBindings(true);
+		parser.setBindingsRecovery(IASTSharedValues.SHARED_BINDING_RECOVERY);
+		parser.setStatementsRecovery(IASTSharedValues.SHARED_AST_STATEMENT_RECOVERY);
+		parser.setCompilerOptions(RefactoringASTParser.getCompilerOptions(context.getJavaProject()));
+		return (CompilationUnit) parser.createAST(null);
+	}
+
+	private static MethodDeclaration findMethod(CompilationUnit ast, String name) {
+		MethodDeclaration[] result= new MethodDeclaration[1];
+		ast.accept(new ASTVisitor() {
+			@Override
+			public boolean visit(MethodDeclaration node) {
+				if (name.equals(node.getName().getIdentifier())) {
+					result[0]= node;
+				}
+				return result[0] == null;
+			}
+		});
+		return java.util.Objects.requireNonNull(result[0]);
+	}
+}


### PR DESCRIPTION
## Problem

The former JDT-Core-specific harness drafts duplicated discovery, filtering, ordering and rewrite policy in large Java implementations. Continuing that approach would make every legacy harness a new special case. The existing editor also maintained separate and partly stale lists of directives and guard functions.

## Generic language foundation

This PR adds a project-neutral composition layer to TriggerPattern:

- `<!predicate name($parameter): guard-expression>` declares a local parameterized guard predicate;
- predicates may compose other predicates and are expanded through the existing parsed `GuardExpression` AST rather than global text replacement;
- expansion is limited to guard positions, so a same-named Java call in a source or replacement pattern is not rewritten;
- definitions preserve source-line information and literal text, including repeated whitespace inside strings;
- duplicate definitions, wrong arity, direct or indirect recursion, undeclared placeholder capture, unused parameters and names shadowing built-in guards fail closed;
- malformed lookalike directives such as `predicateFactory` remain ordinary forward-compatible metadata;
- `HintProgramParser` is a small composition layer in front of the stable compatibility-oriented `HintFileParser`;
- the plan-aware backend executes the expanded program through the existing `HintFileFixCore` rewrite backend;
- no JDT Core type or method name appears in the predicate model, parser, expansion engine or editor support.

The immutable `HintPredicateDefinition` is the only shared API model required across the core parser and editor bundles. Parsing state, expansion and vocabulary implementation remain internal.

## Duplication and language-vocabulary control

- built-in guard names are derived from the same `BuiltInGuardRegistration` map that makes them executable;
- directives and operators have one canonical editor vocabulary;
- only a few guard descriptions need explicit overrides; remaining descriptions are derived from the registered name;
- a contract test requires every documented directive to have representative parser syntax and verifies the resulting semantic model;
- adding or removing a built-in guard, directive or operator without updating its language contract fails a unit test.

## Editor integration

- the ordinary rule scanner highlights only registered guards and predicates actually declared in the current document, avoiding accidental coloring of arbitrary Java method calls;
- the metadata scanner styles multiline predicate declarations internally: directive names, local function calls, placeholders, strings and logical operators remain distinguishable;
- the complete multiline declaration remains one metadata partition;
- directive completion is offered after `<!`;
- guard and local-predicate completion is offered in ordinary `::` guards and after the colon of a predicate declaration;
- registry and local proposals are de-duplicated by name;
- scanner colors use JDT's shared color manager rather than allocating unmanaged SWT colors;
- reconciliation validates complete composed programs and uses the structured parser line number for markers.

## Verification

Core tests cover:

- multiline definitions and nested composition;
- structural argument substitution;
- preservation of repeated whitespace inside string literals;
- same-named source calls and comment text remaining untouched;
- directive keyword boundaries;
- duplicate names, wrong arity, direct/indirect cycles, hidden captures, unused parameters and built-in shadowing;
- registry-derived guard vocabulary and documented-directive/parser drift.

PDE/editor tests cover:

- registered guards, declared predicates and logical-operator highlighting;
- multiline metadata partitioning and detailed predicate-body styling;
- metadata content-assist registration and predicate-body context detection;
- de-duplicated guard, predicate and directive completion.

A plan-aware integration test proves that a composed predicate authorizes the exact semantic method target and reaches the existing AST rewrite backend.

## Scope

This is the first generic harness-contract DSL slice. Predicate programs are productive in the plan-aware backend and editor validation. The repository still contains historical direct `HintFileParser` entry points in ordinary cleanup, persistence and mining paths; migrating those mechanically without changing legacy behavior is deliberately a separate compatibility slice.

The next generic language slices add typed semantic-plan values, binding-graph predicates, structured declaration actions and reusable discovery/ordering/selection/lifecycle/matrix contract fragments. JDT Core will become a short recipe and demanding runtime-tree fixture, not part of the generic implementation.

The superseded project-specific drafts #1341 and #1343 were closed without merge.

## Final one-commit evidence

- reviewed development milestone: `c4523d4747dc897c754cb3c4c02f6321fc2e87ae`;
- final head: `b9db09efe526aec14e34fc5286ef05146f40dc64`;
- base: current `main` at `a9d4ee720fbf9eaab6a47b30d52e4a103e087c8f`;
- history: exactly one PR commit;
- scope: exactly the reviewed 20 language/editor/test files, with no typed-plan, graph-predicate or structured-action slice folded in;
- all inline review threads are resolved;
- fresh final-head gates:
  - Test Source Inventory — run `30594105240` — success;
  - Core Module Build — run `30594105236` — success;
  - Java CI with Maven — run `30594105234` — success;
  - Distribution Smoke Test — run `30594105267` — success;
  - CodeQL — run `30594105235` — success;
  - Codacy Security Scan — run `30594105243` — success.

This PR remains Draft and must not be merged without explicit user approval.

Refs #1334 and #1217.