### PR TITLE
Add typed semantic plan facts and relations

### DIFF
--- a/docs/generic-harness-contract-dsl.md
+++ b/docs/generic-harness-contract-dsl.md
@@ -4,9 +4,9 @@
 
 Legacy test frameworks often encode discovery, construction, ordering, selection,
 lifecycle and matrix execution implicitly in Java inheritance and suite builders.
-The migration engine must not contain project names such as JDT Core. Instead,
-project-specific recipes describe those contracts using generic semantic facts,
-composable predicates and structured rewrite actions.
+The migration engine must not contain project names such as JDT Core or JDT UI.
+Instead, project-specific recipes describe those contracts using generic semantic
+facts, composable predicates and structured rewrite actions.
 
 The existing binding-resolved planner and JDT runtime-tree recorder remain the
 safety boundaries. The DSL describes reusable policy; it does not replace scope
@@ -43,6 +43,57 @@ Predicate contracts are deliberately closed:
 
 These rules keep predicates locally understandable and safe to reuse or rename.
 
+## Typed semantic facts
+
+Roles answer only whether a node participates in a transformation. Harness
+migration also needs properties such as runner kind, lifecycle scope,
+constructor mode, selection policy, ordering and matrix coordinates.
+`SemanticRewritePlan` therefore carries immutable typed values:
+
+- exact strings for enum-like contract values;
+- booleans;
+- signed integers;
+- stable references to another plan node;
+- homogeneous immutable lists.
+
+Fact names have one value kind across a plan. Conflicting duplicate values or
+conflicting kinds fail while the plan is built rather than becoming a silent
+non-match later. The DSL reads those values with fail-closed guards:
+
+```text
+<!predicate selectedJupiterTest($method):
+    plannedValue($method, "test-kind", "JUPITER")
+    && plannedValue($method, "selected", true)>
+```
+
+`plannedNodeValue` compares a node-reference fact with another bound node,
+`plannedListContains` checks a typed list, and `enclosingPlannedValue` searches
+only the node and its semantic ancestors. Missing plans, facts, bindings or
+wrong value kinds return false.
+
+## Ordered semantic relations
+
+Directed relations model suite membership, providers, wrappers, lifecycle
+ownership, inheritance and matrix expansion without hard-coding any test
+framework. Relations carry typed attributes and remain in planner order.
+Duplicate relation occurrences are intentionally preserved because a runtime
+suite may contain the same test more than once.
+
+```text
+<!predicate firstSuiteOccurrence($suite, $test):
+    plannedRelation($suite, "CONTAINS", $test)
+    && plannedRelationValue($suite, "CONTAINS", $test, "index", 0)>
+```
+
+The shared guards also support incoming/outgoing existence and exact outgoing
+relation counts. Contract predicates can combine those primitives rather than
+requiring a new Java guard for every framework concept.
+
+Stable plan keys now cover ordinary, enum, annotation and record types, methods,
+fields and exact method/constructor call sites. Field keys are needed for JUnit
+4 `@Rule`/`@ClassRule` migration; exact constructor call sites are needed for
+named JUnit 3 test construction and custom suite builders.
+
 ## One language vocabulary
 
 `HintLanguageVocabulary` is the canonical source for:
@@ -78,46 +129,78 @@ one parser class.
 
 ## Next generic language slices
 
-Predicates reduce duplication but do not yet express the complete harness
-migration. The next extensions must stay generic and typed:
+Typed facts and relations provide the shared data model, but they do not yet
+express all required AST changes. The next extensions remain generic:
 
 ```text
 contract legacy-tests/v1 {
     discover methods where exactTest($method)
-    construct by namedConstructor(String methodName)
+    construct by planValue("construction")
     order by planValue("ordering")
     select by planValue("selection")
-    lifecycle perSuite("setUpSuite", "tearDownSuite")
-    matrix dimension("compliance", planValue("levels"))
+    lifecycle through relation("OWNS_LIFECYCLE")
+    matrix through relation("EXPANDS_TO")
 }
 ```
 
 Required engine concepts are:
 
-- typed semantic-plan values rather than untyped strings;
-- binding-based graph predicates such as source-subtype and external-reference
-  closure;
 - structured AST actions such as replacing a supertype, removing a validated
-  constructor, adding annotations and generating a nested adapter type;
-- reusable contract fragments for discovery, ordering, selection, suite state
-  and execution matrices;
+  constructor, replacing an annotation, qualifying an invocation and generating
+  a nested adapter type;
+- reusable contract fragments for discovery, ordering, selection, suite state,
+  providers, wrappers and execution matrices;
+- trace output containing rule ID, plan node, relation occurrence, binding key,
+  typed values and rejection/skip reason;
 - a generic runtime oracle requiring an identical non-empty successful test
   tree with configurable identity, nesting, order and multiplicity policies.
 
 Project-specific recipes then supply only type names, method patterns and the
 composition of these generic contracts.
 
+## Migration roadmap
+
+### JDT Core
+
+The first demanding fixture is the JDT Core JUnit 3 harness. The planner must
+capture named test construction, custom `suite()` builders, inherited test-depth
+selection, compliance-level multiplication, setup wrappers, ordering/filtering
+and performance callbacks as typed facts and ordered relations. Unsupported or
+incomplete concepts remain fail-closed. The migrated implementation is accepted
+only when the existing JDT launch infrastructure records an equivalent
+successful runtime tree under the declared identity, nesting, order and
+multiplicity policy.
+
+### JDT UI
+
+After the JDT Core contract is under control, the same engine is applied to JDT
+UI rather than creating a second migration framework. Its dominant input is
+JUnit 4, so the planner and recipes will classify and transform different
+concepts:
+
+- `@RunWith` runners and suites;
+- `@Rule` and `@ClassRule` fields and their extension mappings;
+- parameterized constructors, fields and provider methods;
+- categories, assumptions and custom runners;
+- inherited lifecycle methods and shared assertion helpers;
+- mixed JUnit 3, JUnit 4, Vintage and Jupiter execution during staged migration.
+
+The typed field, call-site, fact and relation model is intentionally shared by
+both projects. Only contract-specific planners, fact names and recipes differ.
+
 ## Acceptance criteria
 
 Every language extension must include:
 
 - parser and model tests for valid composition;
-- negative tests for ambiguity, hidden capture, recursion and stale contracts;
+- negative tests for ambiguity, hidden capture, recursion, stale contracts and
+  conflicting value kinds;
 - syntax-highlighting tests for every new lexical form;
 - content-assist tests for declarations and references;
 - a vocabulary-drift test where applicable;
 - plan-aware end-to-end execution proving that the expanded program reaches the
   existing rewrite backend;
+- relation tests preserving explicit order and duplicate multiplicity;
 - at least one runtime-tree regression when execution semantics are affected.
 
 A feature is not complete when only the parser accepts it. Editor support,

--- a/sandbox_common/src/org/sandbox/jdt/triggerpattern/cleanup/PlanAwareHintFileFixCore.java
+++ b/sandbox_common/src/org/sandbox/jdt/triggerpattern/cleanup/PlanAwareHintFileFixCore.java
@@ -73,7 +73,7 @@ public final class PlanAwareHintFileFixCore {
 			throws CoreException {
 		GuardRegistry.getInstance();
 		String requiredPlan= requiredPlan(hintFileContent);
-		if (plan == null || plan.rolesByNode().isEmpty()) {
+		if (plan == null || plan.isEmpty()) {
 			throw failure("Hint program requires semantic plan " + requiredPlan //$NON-NLS-1$
 					+ " but no non-empty authorization plan was supplied", null); //$NON-NLS-1$
 		}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/api/SemanticPlanRelation.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/api/SemanticPlanRelation.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.api;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.sandbox.jdt.triggerpattern.api.SemanticRewritePlan.NodeKey;
+
+/**
+ * One ordered directed relation between two stable semantic-plan nodes.
+ *
+ * <p>Relations are stored in plan order and may occur more than once. This is
+ * intentional: suite construction and runtime trees can contain duplicate test
+ * occurrences, while relation attributes can record order, matrix coordinates
+ * or other contract-specific data without adding project concepts to the core
+ * model.</p>
+ */
+public record SemanticPlanRelation(String kind, NodeKey source, NodeKey target,
+		Map<String, SemanticPlanValue> attributes) {
+
+	/** Creates a defensive immutable relation. */
+	public SemanticPlanRelation {
+		kind= requireName(kind, "Relation kind"); //$NON-NLS-1$
+		Objects.requireNonNull(source);
+		Objects.requireNonNull(target);
+		Map<String, SemanticPlanValue> copy= new LinkedHashMap<>();
+		if (attributes != null) {
+			attributes.forEach((name, value) -> copy.put(requireName(name, "Relation attribute"), //$NON-NLS-1$
+					Objects.requireNonNull(value)));
+		}
+		attributes= Map.copyOf(copy);
+	}
+
+	/** Creates a relation without attributes. */
+	public SemanticPlanRelation(String kind, NodeKey source, NodeKey target) {
+		this(kind, source, target, Map.of());
+	}
+
+	/** Returns one typed relation attribute. */
+	public Optional<SemanticPlanValue> attribute(String name) {
+		return Optional.ofNullable(attributes.get(name));
+	}
+
+	/** Returns whether an attribute equals the supplied typed value. */
+	public boolean hasAttribute(String name, SemanticPlanValue expected) {
+		return expected != null && expected.equals(attributes.get(name));
+	}
+
+	private static String requireName(String value, String label) {
+		if (value == null || value.isBlank()) {
+			throw new IllegalArgumentException(label + " must not be blank"); //$NON-NLS-1$
+		}
+		return value.trim();
+	}
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/api/SemanticPlanValue.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/api/SemanticPlanValue.java
@@ -1,0 +1,155 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.api;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+import org.sandbox.jdt.triggerpattern.api.SemanticRewritePlan.NodeKey;
+
+/**
+ * Closed typed value model for semantic-plan facts and relation attributes.
+ *
+ * <p>The model deliberately contains only immutable transport values. Project
+ * planners may define contract-specific fact names, while the shared hint
+ * engine can compare values without depending on JUnit, JDT Core or JDT UI
+ * concepts.</p>
+ */
+public sealed interface SemanticPlanValue permits SemanticPlanValue.StringValue,
+		SemanticPlanValue.BooleanValue, SemanticPlanValue.IntegerValue,
+		SemanticPlanValue.NodeValue, SemanticPlanValue.ListValue {
+
+	/** Stable value kinds used for contract validation and diagnostics. */
+	enum Kind {
+		STRING,
+		BOOLEAN,
+		INTEGER,
+		NODE,
+		LIST
+	}
+
+	/** Returns the stable kind of this value. */
+	Kind kind();
+
+	/** Creates an exact text value. */
+	static StringValue string(String value) {
+		return new StringValue(value);
+	}
+
+	/** Creates a boolean value. */
+	static BooleanValue bool(boolean value) {
+		return new BooleanValue(value);
+	}
+
+	/** Creates a signed integer value. */
+	static IntegerValue integer(long value) {
+		return new IntegerValue(value);
+	}
+
+	/** Creates a reference to another stable semantic-plan node. */
+	static NodeValue node(NodeKey value) {
+		return new NodeValue(value);
+	}
+
+	/** Creates a homogeneous immutable list value. */
+	static ListValue list(SemanticPlanValue... values) {
+		return new ListValue(values == null ? List.of() : Arrays.asList(values));
+	}
+
+	/**
+	 * Parses the literal forms accepted by typed plan guards.
+	 *
+	 * <p>Quoted values are strings, {@code true}/{@code false} are booleans and
+	 * signed decimal values are integers. Remaining unquoted values are exact
+	 * strings, which keeps enum-like contract values concise.</p>
+	 */
+	static SemanticPlanValue fromGuardLiteral(String literal) {
+		String value= literal == null ? "" : literal.trim(); //$NON-NLS-1$
+		if (value.length() >= 2 && value.startsWith("\"") && value.endsWith("\"")) { //$NON-NLS-1$ //$NON-NLS-2$
+			return string(value.substring(1, value.length() - 1));
+		}
+		if ("true".equalsIgnoreCase(value) || "false".equalsIgnoreCase(value)) { //$NON-NLS-1$ //$NON-NLS-2$
+			return bool(Boolean.parseBoolean(value));
+		}
+		try {
+			return integer(Long.parseLong(value));
+		} catch (NumberFormatException e) {
+			return string(value);
+		}
+	}
+
+	/** Exact text fact. */
+	record StringValue(String value) implements SemanticPlanValue {
+		public StringValue {
+			Objects.requireNonNull(value);
+		}
+
+		@Override
+		public Kind kind() {
+			return Kind.STRING;
+		}
+	}
+
+	/** Boolean fact. */
+	record BooleanValue(boolean value) implements SemanticPlanValue {
+		@Override
+		public Kind kind() {
+			return Kind.BOOLEAN;
+		}
+	}
+
+	/** Signed integer fact. */
+	record IntegerValue(long value) implements SemanticPlanValue {
+		@Override
+		public Kind kind() {
+			return Kind.INTEGER;
+		}
+	}
+
+	/** Reference to another stable semantic-plan node. */
+	record NodeValue(NodeKey value) implements SemanticPlanValue {
+		public NodeValue {
+			Objects.requireNonNull(value);
+		}
+
+		@Override
+		public Kind kind() {
+			return Kind.NODE;
+		}
+	}
+
+	/** Homogeneous immutable list fact. */
+	record ListValue(List<SemanticPlanValue> values) implements SemanticPlanValue {
+		public ListValue {
+			values= List.copyOf(values == null ? List.of() : values);
+			Kind elementKind= null;
+			for (SemanticPlanValue value : values) {
+				Objects.requireNonNull(value);
+				if (elementKind == null) {
+					elementKind= value.kind();
+				} else if (elementKind != value.kind()) {
+					throw new IllegalArgumentException("Semantic plan lists must be homogeneous"); //$NON-NLS-1$
+				}
+			}
+		}
+
+		@Override
+		public Kind kind() {
+			return Kind.LIST;
+		}
+
+		/** Returns the element kind, or {@code null} for an empty list. */
+		public Kind elementKind() {
+			return values.isEmpty() ? null : values.get(0).kind();
+		}
+	}
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/api/SemanticRewritePlan.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/api/SemanticRewritePlan.java
@@ -10,51 +10,80 @@
  *******************************************************************************/
 package org.sandbox.jdt.triggerpattern.api;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.AnnotationTypeDeclaration;
+import org.eclipse.jdt.core.dom.ClassInstanceCreation;
+import org.eclipse.jdt.core.dom.ConstructorInvocation;
+import org.eclipse.jdt.core.dom.EnumDeclaration;
 import org.eclipse.jdt.core.dom.IBinding;
 import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.IVariableBinding;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.RecordDeclaration;
 import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.SuperConstructorInvocation;
+import org.eclipse.jdt.core.dom.SuperMethodInvocation;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 
 /**
- * Immutable binding-stable authorization plan for plan-aware hint rules.
+ * Immutable binding-stable authorization and fact plan for plan-aware hints.
  *
  * <p>A named contract identifies the semantic planner that produced the plan.
- * Type and method targets are identified by declaration binding keys. Method
- * invocations additionally retain their source range so multiple calls to the
+ * Roles authorize broad rewrite categories. Typed values describe properties
+ * such as runner kind, lifecycle scope, matrix coordinates or ordering policy.
+ * Ordered directed relations describe graph structure such as suite membership,
+ * providers, wrappers and inheritance without introducing project-specific
+ * concepts into the shared engine.</p>
+ *
+ * <p>Type, method and field targets are identified by declaration binding keys.
+ * Call sites additionally retain their source range so multiple calls to the
  * same API remain distinct. Missing contracts or bindings never authorize a
  * plan-aware rewrite.</p>
  */
-public record SemanticRewritePlan(String contractId, Map<NodeKey, Set<String>> rolesByNode) {
+public record SemanticRewritePlan(String contractId, Map<NodeKey, Set<String>> rolesByNode,
+		Map<NodeKey, Map<String, SemanticPlanValue>> valuesByNode,
+		List<SemanticPlanRelation> relations) {
 
 	/** Creates a defensive immutable plan. */
 	public SemanticRewritePlan {
 		contractId= contractId == null || contractId.isBlank() ? null : contractId.trim();
-		Map<NodeKey, Set<String>> copy= new LinkedHashMap<>();
-		if (rolesByNode != null) {
-			rolesByNode.forEach((key, roles) -> copy.put(Objects.requireNonNull(key),
-					Set.copyOf(roles == null ? Set.of() : roles)));
-		}
-		rolesByNode= Map.copyOf(copy);
+		rolesByNode= immutableRoles(rolesByNode);
+		valuesByNode= immutableValues(valuesByNode);
+		relations= List.copyOf(relations == null ? List.of() : relations);
+		validateValueKinds(valuesByNode, relations);
+	}
+
+	/** Backward-compatible constructor for role-only contracted plans. */
+	public SemanticRewritePlan(String contractId, Map<NodeKey, Set<String>> rolesByNode) {
+		this(contractId, rolesByNode, Map.of(), List.of());
+	}
+
+	/** Creates a contracted plan with roles and typed values but no relations. */
+	public SemanticRewritePlan(String contractId, Map<NodeKey, Set<String>> rolesByNode,
+			Map<NodeKey, Map<String, SemanticPlanValue>> valuesByNode) {
+		this(contractId, rolesByNode, valuesByNode, List.of());
 	}
 
 	/** Backward-compatible constructor for uncontracted guard-only plans. */
 	public SemanticRewritePlan(Map<NodeKey, Set<String>> rolesByNode) {
-		this(null, rolesByNode);
+		this(null, rolesByNode, Map.of(), List.of());
 	}
 
 	/** Returns an empty, uncontracted plan. */
 	public static SemanticRewritePlan empty() {
-		return new SemanticRewritePlan(null, Map.of());
+		return new SemanticRewritePlan(null, Map.of(), Map.of(), List.of());
 	}
 
 	/** Creates a mutable builder without an execution contract. */
@@ -65,6 +94,11 @@ public record SemanticRewritePlan(String contractId, Map<NodeKey, Set<String>> r
 	/** Creates a mutable builder bound to a plan-aware hint contract. */
 	public static Builder builder(String contractId) {
 		return new Builder(contractId);
+	}
+
+	/** Returns whether this plan contains no roles, values or relations. */
+	public boolean isEmpty() {
+		return rolesByNode.isEmpty() && valuesByNode.isEmpty() && relations.isEmpty();
 	}
 
 	/** Returns whether this plan was produced for the exact named contract. */
@@ -91,10 +125,155 @@ public record SemanticRewritePlan(String contractId, Map<NodeKey, Set<String>> r
 		return false;
 	}
 
+	/** Returns one typed value for the exact stable node key. */
+	public Optional<SemanticPlanValue> value(NodeKey key, String name) {
+		if (key == null || name == null) {
+			return Optional.empty();
+		}
+		return Optional.ofNullable(valuesByNode.getOrDefault(key, Map.of()).get(name));
+	}
+
+	/** Returns one typed value for the exact AST target. */
+	public Optional<SemanticPlanValue> value(ASTNode node, String name) {
+		return value(NodeKey.from(node), name);
+	}
+
+	/** Returns the first typed value found on the node or an enclosing declaration. */
+	public Optional<SemanticPlanValue> enclosingValue(ASTNode node, String name) {
+		ASTNode current= node;
+		while (current != null) {
+			Optional<SemanticPlanValue> value= value(current, name);
+			if (value.isPresent()) {
+				return value;
+			}
+			current= current.getParent();
+		}
+		return Optional.empty();
+	}
+
+	/** Returns whether the exact AST target has the supplied typed value. */
+	public boolean hasValue(ASTNode node, String name, SemanticPlanValue expected) {
+		return expected != null && value(node, name).filter(expected::equals).isPresent();
+	}
+
+	/** Returns whether the node or an enclosing declaration has the supplied value. */
+	public boolean hasEnclosingValue(ASTNode node, String name, SemanticPlanValue expected) {
+		return expected != null && enclosingValue(node, name).filter(expected::equals).isPresent();
+	}
+
+	/** Returns all outgoing relations of the requested kind in declared order. */
+	public List<SemanticPlanRelation> outgoing(NodeKey source, String kind) {
+		if (source == null || kind == null) {
+			return List.of();
+		}
+		return relations.stream()
+				.filter(relation -> source.equals(relation.source()) && kind.equals(relation.kind()))
+				.toList();
+	}
+
+	/** Returns all outgoing relations for an AST target in declared order. */
+	public List<SemanticPlanRelation> outgoing(ASTNode source, String kind) {
+		return outgoing(NodeKey.from(source), kind);
+	}
+
+	/** Returns all incoming relations of the requested kind in declared order. */
+	public List<SemanticPlanRelation> incoming(NodeKey target, String kind) {
+		if (target == null || kind == null) {
+			return List.of();
+		}
+		return relations.stream()
+				.filter(relation -> target.equals(relation.target()) && kind.equals(relation.kind()))
+				.toList();
+	}
+
+	/** Returns all incoming relations for an AST target in declared order. */
+	public List<SemanticPlanRelation> incoming(ASTNode target, String kind) {
+		return incoming(NodeKey.from(target), kind);
+	}
+
+	/** Returns whether an exact directed relation exists. */
+	public boolean hasRelation(ASTNode source, String kind, ASTNode target) {
+		NodeKey sourceKey= NodeKey.from(source);
+		NodeKey targetKey= NodeKey.from(target);
+		return sourceKey != null && targetKey != null && outgoing(sourceKey, kind).stream()
+				.anyMatch(relation -> targetKey.equals(relation.target()));
+	}
+
+	/** Returns whether an exact relation has the supplied typed attribute. */
+	public boolean hasRelationValue(ASTNode source, String kind, ASTNode target, String name,
+			SemanticPlanValue expected) {
+		NodeKey sourceKey= NodeKey.from(source);
+		NodeKey targetKey= NodeKey.from(target);
+		return sourceKey != null && targetKey != null && expected != null
+				&& outgoing(sourceKey, kind).stream()
+						.filter(relation -> targetKey.equals(relation.target()))
+						.anyMatch(relation -> relation.hasAttribute(name, expected));
+	}
+
+	private static Map<NodeKey, Set<String>> immutableRoles(Map<NodeKey, Set<String>> source) {
+		Map<NodeKey, Set<String>> copy= new LinkedHashMap<>();
+		if (source != null) {
+			source.forEach((key, roles) -> copy.put(Objects.requireNonNull(key),
+					Set.copyOf(roles == null ? Set.of() : roles)));
+		}
+		return Map.copyOf(copy);
+	}
+
+	private static Map<NodeKey, Map<String, SemanticPlanValue>> immutableValues(
+			Map<NodeKey, Map<String, SemanticPlanValue>> source) {
+		Map<NodeKey, Map<String, SemanticPlanValue>> copy= new LinkedHashMap<>();
+		if (source != null) {
+			source.forEach((key, values) -> {
+				Map<String, SemanticPlanValue> nodeValues= new LinkedHashMap<>();
+				if (values != null) {
+					values.forEach((name, value) -> nodeValues.put(requireName(name, "Plan value"), //$NON-NLS-1$
+							Objects.requireNonNull(value)));
+				}
+				copy.put(Objects.requireNonNull(key), Map.copyOf(nodeValues));
+			});
+		}
+		return Map.copyOf(copy);
+	}
+
+	private static void validateValueKinds(Map<NodeKey, Map<String, SemanticPlanValue>> values,
+			List<SemanticPlanRelation> relations) {
+		Map<String, String> factKinds= new LinkedHashMap<>();
+		values.values().forEach(nodeValues -> nodeValues.forEach((name, value) ->
+				validateKind(factKinds, name, typeSignature(value), "plan value"))); //$NON-NLS-1$
+		Map<String, String> relationKinds= new LinkedHashMap<>();
+		for (SemanticPlanRelation relation : relations) {
+			relation.attributes().forEach((name, value) -> validateKind(relationKinds,
+					relation.kind() + "." + name, typeSignature(value), "relation attribute")); //$NON-NLS-1$ //$NON-NLS-2$
+		}
+	}
+
+	private static void validateKind(Map<String, String> kinds, String name, String kind, String label) {
+		String previous= kinds.putIfAbsent(name, kind);
+		if (previous != null && !previous.equals(kind)) {
+			throw new IllegalArgumentException("Conflicting types for " + label + " " + name //$NON-NLS-1$ //$NON-NLS-2$
+					+ ": " + previous + " and " + kind); //$NON-NLS-1$ //$NON-NLS-2$
+		}
+	}
+
+	private static String typeSignature(SemanticPlanValue value) {
+		if (value instanceof SemanticPlanValue.ListValue list) {
+			return list.elementKind() == null ? "LIST" : "LIST<" + list.elementKind() + ">"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		}
+		return value.kind().name();
+	}
+
+	private static String requireName(String value, String label) {
+		if (value == null || value.isBlank()) {
+			throw new IllegalArgumentException(label + " name must not be blank"); //$NON-NLS-1$
+		}
+		return value.trim();
+	}
+
 	/** Stable supported semantic node kinds. */
 	public enum NodeKind {
 		TYPE,
 		METHOD,
+		FIELD,
 		INVOCATION
 	}
 
@@ -113,6 +292,10 @@ public record SemanticRewritePlan(String contractId, Map<NodeKey, Set<String>> r
 			return bindingKey == null ? null : new NodeKey(NodeKind.METHOD, bindingKey, -1, -1);
 		}
 
+		public static NodeKey field(String bindingKey) {
+			return bindingKey == null ? null : new NodeKey(NodeKind.FIELD, bindingKey, -1, -1);
+		}
+
 		public static NodeKey invocation(String bindingKey, int sourceStart, int sourceLength) {
 			return bindingKey == null ? null
 					: new NodeKey(NodeKind.INVOCATION, bindingKey, sourceStart, sourceLength);
@@ -123,11 +306,39 @@ public record SemanticRewritePlan(String contractId, Map<NodeKey, Set<String>> r
 			if (node instanceof TypeDeclaration type) {
 				return type(typeKey(type.resolveBinding()));
 			}
+			if (node instanceof EnumDeclaration type) {
+				return type(typeKey(type.resolveBinding()));
+			}
+			if (node instanceof AnnotationTypeDeclaration type) {
+				return type(typeKey(type.resolveBinding()));
+			}
+			if (node instanceof RecordDeclaration type) {
+				return type(typeKey(type.resolveBinding()));
+			}
 			if (node instanceof MethodDeclaration method) {
 				return method(methodKey(method.resolveBinding()));
 			}
+			if (node instanceof VariableDeclarationFragment field) {
+				return field(fieldKey(field.resolveBinding()));
+			}
 			if (node instanceof MethodInvocation invocation) {
 				return invocation(methodKey(invocation.resolveMethodBinding()), invocation.getStartPosition(),
+						invocation.getLength());
+			}
+			if (node instanceof SuperMethodInvocation invocation) {
+				return invocation(methodKey(invocation.resolveMethodBinding()), invocation.getStartPosition(),
+						invocation.getLength());
+			}
+			if (node instanceof ClassInstanceCreation invocation) {
+				return invocation(methodKey(invocation.resolveConstructorBinding()), invocation.getStartPosition(),
+						invocation.getLength());
+			}
+			if (node instanceof ConstructorInvocation invocation) {
+				return invocation(methodKey(invocation.resolveConstructorBinding()), invocation.getStartPosition(),
+						invocation.getLength());
+			}
+			if (node instanceof SuperConstructorInvocation invocation) {
+				return invocation(methodKey(invocation.resolveConstructorBinding()), invocation.getStartPosition(),
 						invocation.getLength());
 			}
 			if (node instanceof SimpleName name) {
@@ -138,6 +349,9 @@ public record SemanticRewritePlan(String contractId, Map<NodeKey, Set<String>> r
 				if (binding instanceof ITypeBinding typeBinding) {
 					return type(typeKey(typeBinding));
 				}
+				if (binding instanceof IVariableBinding variableBinding) {
+					return field(fieldKey(variableBinding));
+				}
 			}
 			return null;
 		}
@@ -146,12 +360,20 @@ public record SemanticRewritePlan(String contractId, Map<NodeKey, Set<String>> r
 			if (binding == null) {
 				return null;
 			}
-			ITypeBinding declaration= binding.getErasure().getTypeDeclaration();
+			ITypeBinding erasure= binding.getErasure();
+			ITypeBinding declaration= (erasure == null ? binding : erasure).getTypeDeclaration();
 			return declaration == null ? null : declaration.getKey();
 		}
 
 		private static String methodKey(IMethodBinding binding) {
 			return binding == null ? null : binding.getMethodDeclaration().getKey();
+		}
+
+		private static String fieldKey(IVariableBinding binding) {
+			if (binding == null || !binding.isField()) {
+				return null;
+			}
+			return binding.getVariableDeclaration().getKey();
 		}
 	}
 
@@ -159,11 +381,14 @@ public record SemanticRewritePlan(String contractId, Map<NodeKey, Set<String>> r
 	public static final class Builder {
 		private final String contractId;
 		private final Map<NodeKey, Set<String>> roles= new LinkedHashMap<>();
+		private final Map<NodeKey, Map<String, SemanticPlanValue>> values= new LinkedHashMap<>();
+		private final List<SemanticPlanRelation> relations= new ArrayList<>();
 
 		private Builder(String contractId) {
 			this.contractId= contractId;
 		}
 
+		/** Adds one authorization role to a stable node. */
 		public Builder add(NodeKey key, String role) {
 			if (key != null && role != null && !role.isBlank()) {
 				roles.computeIfAbsent(key, ignored -> new LinkedHashSet<>()).add(role);
@@ -171,8 +396,57 @@ public record SemanticRewritePlan(String contractId, Map<NodeKey, Set<String>> r
 			return this;
 		}
 
+		/** Adds one typed fact and rejects conflicting duplicate definitions. */
+		public Builder put(NodeKey key, String name, SemanticPlanValue value) {
+			if (key == null) {
+				return this;
+			}
+			String factName= requireName(name, "Plan value"); //$NON-NLS-1$
+			SemanticPlanValue factValue= Objects.requireNonNull(value);
+			Map<String, SemanticPlanValue> nodeValues=
+					values.computeIfAbsent(key, ignored -> new LinkedHashMap<>());
+			SemanticPlanValue previous= nodeValues.putIfAbsent(factName, factValue);
+			if (previous != null && !previous.equals(factValue)) {
+				throw new IllegalArgumentException("Conflicting values for " + factName + " on " + key); //$NON-NLS-1$ //$NON-NLS-2$
+			}
+			return this;
+		}
+
+		public Builder putString(NodeKey key, String name, String value) {
+			return put(key, name, SemanticPlanValue.string(value));
+		}
+
+		public Builder putBoolean(NodeKey key, String name, boolean value) {
+			return put(key, name, SemanticPlanValue.bool(value));
+		}
+
+		public Builder putInteger(NodeKey key, String name, long value) {
+			return put(key, name, SemanticPlanValue.integer(value));
+		}
+
+		public Builder putNode(NodeKey key, String name, NodeKey value) {
+			return put(key, name, SemanticPlanValue.node(value));
+		}
+
+		public Builder putList(NodeKey key, String name, SemanticPlanValue... value) {
+			return put(key, name, SemanticPlanValue.list(value));
+		}
+
+		/** Adds one ordered relation occurrence. Duplicate occurrences are preserved. */
+		public Builder relate(NodeKey source, String kind, NodeKey target) {
+			return relate(source, kind, target, Map.of());
+		}
+
+		/** Adds one ordered relation occurrence with typed attributes. */
+		public Builder relate(NodeKey source, String kind, NodeKey target,
+				Map<String, SemanticPlanValue> attributes) {
+			relations.add(new SemanticPlanRelation(kind, Objects.requireNonNull(source),
+					Objects.requireNonNull(target), attributes));
+			return this;
+		}
+
 		public SemanticRewritePlan build() {
-			return new SemanticRewritePlan(contractId, roles);
+			return new SemanticRewritePlan(contractId, roles, values, relations);
 		}
 	}
 }

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/api/SemanticRewritePlan.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/api/SemanticRewritePlan.java
@@ -24,6 +24,7 @@ import org.eclipse.jdt.core.dom.AnnotationTypeDeclaration;
 import org.eclipse.jdt.core.dom.ClassInstanceCreation;
 import org.eclipse.jdt.core.dom.ConstructorInvocation;
 import org.eclipse.jdt.core.dom.EnumDeclaration;
+import org.eclipse.jdt.core.dom.FieldDeclaration;
 import org.eclipse.jdt.core.dom.IBinding;
 import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
@@ -256,9 +257,6 @@ public record SemanticRewritePlan(String contractId, Map<NodeKey, Set<String>> r
 	}
 
 	private static String typeSignature(SemanticPlanValue value) {
-		if (value instanceof SemanticPlanValue.ListValue list) {
-			return list.elementKind() == null ? "LIST" : "LIST<" + list.elementKind() + ">"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-		}
 		return value.kind().name();
 	}
 
@@ -317,6 +315,9 @@ public record SemanticRewritePlan(String contractId, Map<NodeKey, Set<String>> r
 			}
 			if (node instanceof MethodDeclaration method) {
 				return method(methodKey(method.resolveBinding()));
+			}
+			if (node instanceof FieldDeclaration field) {
+				return field.fragments().size() == 1 ? from((ASTNode) field.fragments().get(0)) : null;
 			}
 			if (node instanceof VariableDeclarationFragment field) {
 				return field(fieldKey(field.resolveBinding()));

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/api/SemanticRewritePlan.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/api/SemanticRewritePlan.java
@@ -53,17 +53,26 @@ import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
  * same API remain distinct. Missing contracts or bindings never authorize a
  * plan-aware rewrite.</p>
  */
-public record SemanticRewritePlan(String contractId, Map<NodeKey, Set<String>> rolesByNode,
-		Map<NodeKey, Map<String, SemanticPlanValue>> valuesByNode,
-		List<SemanticPlanRelation> relations) {
+public final class SemanticRewritePlan {
+
+	private final String contractId;
+	private final Map<NodeKey, Set<String>> rolesByNode;
+	private final Map<NodeKey, Map<String, SemanticPlanValue>> valuesByNode;
+	private final List<SemanticPlanRelation> relations;
+	private final Map<NodeKey, Map<String, List<SemanticPlanRelation>>> outgoingRelations;
+	private final Map<NodeKey, Map<String, List<SemanticPlanRelation>>> incomingRelations;
 
 	/** Creates a defensive immutable plan. */
-	public SemanticRewritePlan {
-		contractId= contractId == null || contractId.isBlank() ? null : contractId.trim();
-		rolesByNode= immutableRoles(rolesByNode);
-		valuesByNode= immutableValues(valuesByNode);
-		relations= List.copyOf(relations == null ? List.of() : relations);
-		validateValueKinds(valuesByNode, relations);
+	public SemanticRewritePlan(String contractId, Map<NodeKey, Set<String>> rolesByNode,
+			Map<NodeKey, Map<String, SemanticPlanValue>> valuesByNode,
+			List<SemanticPlanRelation> relations) {
+		this.contractId= contractId == null || contractId.isBlank() ? null : contractId.trim();
+		this.rolesByNode= immutableRoles(rolesByNode);
+		this.valuesByNode= immutableValues(valuesByNode);
+		this.relations= List.copyOf(relations == null ? List.of() : relations);
+		validateValueKinds(this.valuesByNode, this.relations);
+		this.outgoingRelations= indexRelations(this.relations, true);
+		this.incomingRelations= indexRelations(this.relations, false);
 	}
 
 	/** Backward-compatible constructor for role-only contracted plans. */
@@ -95,6 +104,23 @@ public record SemanticRewritePlan(String contractId, Map<NodeKey, Set<String>> r
 	/** Creates a mutable builder bound to a plan-aware hint contract. */
 	public static Builder builder(String contractId) {
 		return new Builder(contractId);
+	}
+
+	public String contractId() {
+		return contractId;
+	}
+
+	public Map<NodeKey, Set<String>> rolesByNode() {
+		return rolesByNode;
+	}
+
+	public Map<NodeKey, Map<String, SemanticPlanValue>> valuesByNode() {
+		return valuesByNode;
+	}
+
+	/** Returns all relation occurrences in planner order, including duplicates. */
+	public List<SemanticPlanRelation> relations() {
+		return relations;
 	}
 
 	/** Returns whether this plan contains no roles, values or relations. */
@@ -167,9 +193,7 @@ public record SemanticRewritePlan(String contractId, Map<NodeKey, Set<String>> r
 		if (source == null || kind == null) {
 			return List.of();
 		}
-		return relations.stream()
-				.filter(relation -> source.equals(relation.source()) && kind.equals(relation.kind()))
-				.toList();
+		return outgoingRelations.getOrDefault(source, Map.of()).getOrDefault(kind, List.of());
 	}
 
 	/** Returns all outgoing relations for an AST target in declared order. */
@@ -182,9 +206,7 @@ public record SemanticRewritePlan(String contractId, Map<NodeKey, Set<String>> r
 		if (target == null || kind == null) {
 			return List.of();
 		}
-		return relations.stream()
-				.filter(relation -> target.equals(relation.target()) && kind.equals(relation.kind()))
-				.toList();
+		return incomingRelations.getOrDefault(target, Map.of()).getOrDefault(kind, List.of());
 	}
 
 	/** Returns all incoming relations for an AST target in declared order. */
@@ -236,6 +258,24 @@ public record SemanticRewritePlan(String contractId, Map<NodeKey, Set<String>> r
 		return Map.copyOf(copy);
 	}
 
+	private static Map<NodeKey, Map<String, List<SemanticPlanRelation>>> indexRelations(
+			List<SemanticPlanRelation> relations, boolean outgoing) {
+		Map<NodeKey, Map<String, List<SemanticPlanRelation>>> mutable= new LinkedHashMap<>();
+		for (SemanticPlanRelation relation : relations) {
+			NodeKey node= outgoing ? relation.source() : relation.target();
+			mutable.computeIfAbsent(node, ignored -> new LinkedHashMap<>())
+					.computeIfAbsent(relation.kind(), ignored -> new ArrayList<>()).add(relation);
+		}
+		Map<NodeKey, Map<String, List<SemanticPlanRelation>>> result= new LinkedHashMap<>();
+		mutable.forEach((node, byKind) -> {
+			Map<String, List<SemanticPlanRelation>> immutableByKind= new LinkedHashMap<>();
+			byKind.forEach((kind, indexedRelations) ->
+					immutableByKind.put(kind, List.copyOf(indexedRelations)));
+			result.put(node, Map.copyOf(immutableByKind));
+		});
+		return Map.copyOf(result);
+	}
+
 	private static void validateValueKinds(Map<NodeKey, Map<String, SemanticPlanValue>> values,
 			List<SemanticPlanRelation> relations) {
 		Map<String, String> factKinds= new LinkedHashMap<>();
@@ -265,6 +305,31 @@ public record SemanticRewritePlan(String contractId, Map<NodeKey, Set<String>> r
 			throw new IllegalArgumentException(label + " name must not be blank"); //$NON-NLS-1$
 		}
 		return value.trim();
+	}
+
+	@Override
+	public boolean equals(Object other) {
+		if (this == other) {
+			return true;
+		}
+		if (!(other instanceof SemanticRewritePlan plan)) {
+			return false;
+		}
+		return Objects.equals(contractId, plan.contractId)
+				&& rolesByNode.equals(plan.rolesByNode)
+				&& valuesByNode.equals(plan.valuesByNode)
+				&& relations.equals(plan.relations);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(contractId, rolesByNode, valuesByNode, relations);
+	}
+
+	@Override
+	public String toString() {
+		return "SemanticRewritePlan[contractId=" + contractId + ", rolesByNode=" + rolesByNode //$NON-NLS-1$ //$NON-NLS-2$
+				+ ", valuesByNode=" + valuesByNode + ", relations=" + relations + "]"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 	}
 
 	/** Stable supported semantic node kinds. */

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/BuiltInGuardRegistration.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/BuiltInGuardRegistration.java
@@ -53,107 +53,47 @@ public final class BuiltInGuardRegistration {
 	}
 
 	private static boolean evaluatePlannedRole(GuardContext context, Object... args) {
-		ASTNode node;
-		String role;
-		if (args.length == 1) {
-			node= context.getMatchedNode();
-			role= stripQuotes(argument(args, 0));
-		} else if (args.length >= 2) {
-			node= context.getBinding(argument(args, 0));
-			role= stripQuotes(argument(args, 1));
-		} else {
-			return false;
-		}
-		return node != null && context.getSemanticPlan().hasRole(node, role);
+		PlanNodeArguments parsed= planNodeArguments(context, args, 1);
+		return parsed != null && parsed.node() != null && context.getSemanticPlan().hasRole(parsed.node(),
+				stripQuotes(argument(args, parsed.offset())));
 	}
 
 	private static boolean evaluateEnclosingPlannedRole(GuardContext context, Object... args) {
-		ASTNode node;
-		String role;
-		if (args.length == 1) {
-			node= context.getMatchedNode();
-			role= stripQuotes(argument(args, 0));
-		} else if (args.length >= 2) {
-			node= context.getBinding(argument(args, 0));
-			role= stripQuotes(argument(args, 1));
-		} else {
-			return false;
-		}
-		return node != null && context.getSemanticPlan().hasEnclosingRole(node, role);
+		PlanNodeArguments parsed= planNodeArguments(context, args, 1);
+		return parsed != null && parsed.node() != null && context.getSemanticPlan().hasEnclosingRole(parsed.node(),
+				stripQuotes(argument(args, parsed.offset())));
 	}
 
 	private static boolean evaluatePlannedValue(GuardContext context, Object... args) {
-		ASTNode node;
-		String name;
-		SemanticPlanValue expected;
-		if (args.length == 2) {
-			node= context.getMatchedNode();
-			name= stripQuotes(argument(args, 0));
-			expected= literal(args, 1);
-		} else if (args.length >= 3) {
-			node= context.getBinding(argument(args, 0));
-			name= stripQuotes(argument(args, 1));
-			expected= literal(args, 2);
-		} else {
-			return false;
-		}
-		return node != null && context.getSemanticPlan().hasValue(node, name, expected);
+		PlanNodeArguments parsed= planNodeArguments(context, args, 2);
+		return parsed != null && parsed.node() != null && context.getSemanticPlan().hasValue(parsed.node(),
+				stripQuotes(argument(args, parsed.offset())), literal(args, parsed.offset() + 1));
 	}
 
 	private static boolean evaluateEnclosingPlannedValue(GuardContext context, Object... args) {
-		ASTNode node;
-		String name;
-		SemanticPlanValue expected;
-		if (args.length == 2) {
-			node= context.getMatchedNode();
-			name= stripQuotes(argument(args, 0));
-			expected= literal(args, 1);
-		} else if (args.length >= 3) {
-			node= context.getBinding(argument(args, 0));
-			name= stripQuotes(argument(args, 1));
-			expected= literal(args, 2);
-		} else {
-			return false;
-		}
-		return node != null && context.getSemanticPlan().hasEnclosingValue(node, name, expected);
+		PlanNodeArguments parsed= planNodeArguments(context, args, 2);
+		return parsed != null && parsed.node() != null && context.getSemanticPlan().hasEnclosingValue(parsed.node(),
+				stripQuotes(argument(args, parsed.offset())), literal(args, parsed.offset() + 1));
 	}
 
 	private static boolean evaluatePlannedNodeValue(GuardContext context, Object... args) {
-		ASTNode node;
-		String name;
-		ASTNode expectedNode;
-		if (args.length == 2) {
-			node= context.getMatchedNode();
-			name= stripQuotes(argument(args, 0));
-			expectedNode= context.getBinding(argument(args, 1));
-		} else if (args.length >= 3) {
-			node= context.getBinding(argument(args, 0));
-			name= stripQuotes(argument(args, 1));
-			expectedNode= context.getBinding(argument(args, 2));
-		} else {
+		PlanNodeArguments parsed= planNodeArguments(context, args, 2);
+		if (parsed == null || parsed.node() == null) {
 			return false;
 		}
-		NodeKey expectedKey= NodeKey.from(expectedNode);
-		return node != null && expectedKey != null
-				&& context.getSemanticPlan().hasValue(node, name, SemanticPlanValue.node(expectedKey));
+		NodeKey expectedKey= NodeKey.from(context.getBinding(argument(args, parsed.offset() + 1)));
+		return expectedKey != null && context.getSemanticPlan().hasValue(parsed.node(),
+				stripQuotes(argument(args, parsed.offset())), SemanticPlanValue.node(expectedKey));
 	}
 
 	private static boolean evaluatePlannedListContains(GuardContext context, Object... args) {
-		ASTNode node;
-		String name;
-		SemanticPlanValue expected;
-		if (args.length == 2) {
-			node= context.getMatchedNode();
-			name= stripQuotes(argument(args, 0));
-			expected= literal(args, 1);
-		} else if (args.length >= 3) {
-			node= context.getBinding(argument(args, 0));
-			name= stripQuotes(argument(args, 1));
-			expected= literal(args, 2);
-		} else {
+		PlanNodeArguments parsed= planNodeArguments(context, args, 2);
+		if (parsed == null || parsed.node() == null) {
 			return false;
 		}
-		return node != null && context.getSemanticPlan().value(node, name)
+		String name= stripQuotes(argument(args, parsed.offset()));
+		SemanticPlanValue expected= literal(args, parsed.offset() + 1);
+		return context.getSemanticPlan().value(parsed.node(), name)
 				.filter(ListValue.class::isInstance)
 				.map(ListValue.class::cast)
 				.map(value -> value.values().contains(expected))
@@ -161,100 +101,67 @@ public final class BuiltInGuardRegistration {
 	}
 
 	private static boolean evaluatePlannedRelation(GuardContext context, Object... args) {
-		ASTNode source;
-		String kind;
-		ASTNode target;
-		if (args.length == 2) {
-			source= context.getMatchedNode();
-			kind= stripQuotes(argument(args, 0));
-			target= context.getBinding(argument(args, 1));
-		} else if (args.length >= 3) {
-			source= context.getBinding(argument(args, 0));
-			kind= stripQuotes(argument(args, 1));
-			target= context.getBinding(argument(args, 2));
-		} else {
+		PlanNodeArguments parsed= planNodeArguments(context, args, 2);
+		if (parsed == null || parsed.node() == null) {
 			return false;
 		}
-		return source != null && target != null
-				&& context.getSemanticPlan().hasRelation(source, kind, target);
+		ASTNode target= context.getBinding(argument(args, parsed.offset() + 1));
+		return target != null && context.getSemanticPlan().hasRelation(parsed.node(),
+				stripQuotes(argument(args, parsed.offset())), target);
 	}
 
 	private static boolean evaluatePlannedRelationValue(GuardContext context, Object... args) {
-		ASTNode source;
-		String kind;
-		ASTNode target;
-		String name;
-		SemanticPlanValue expected;
-		if (args.length == 4) {
-			source= context.getMatchedNode();
-			kind= stripQuotes(argument(args, 0));
-			target= context.getBinding(argument(args, 1));
-			name= stripQuotes(argument(args, 2));
-			expected= literal(args, 3);
-		} else if (args.length >= 5) {
-			source= context.getBinding(argument(args, 0));
-			kind= stripQuotes(argument(args, 1));
-			target= context.getBinding(argument(args, 2));
-			name= stripQuotes(argument(args, 3));
-			expected= literal(args, 4);
-		} else {
+		PlanNodeArguments parsed= planNodeArguments(context, args, 4);
+		if (parsed == null || parsed.node() == null) {
 			return false;
 		}
-		return source != null && target != null
-				&& context.getSemanticPlan().hasRelationValue(source, kind, target, name, expected);
+		ASTNode target= context.getBinding(argument(args, parsed.offset() + 1));
+		return target != null && context.getSemanticPlan().hasRelationValue(parsed.node(),
+				stripQuotes(argument(args, parsed.offset())), target,
+				stripQuotes(argument(args, parsed.offset() + 2)), literal(args, parsed.offset() + 3));
 	}
 
 	private static boolean evaluatePlannedOutgoingRelation(GuardContext context, Object... args) {
-		ASTNode source;
-		String kind;
-		if (args.length == 1) {
-			source= context.getMatchedNode();
-			kind= stripQuotes(argument(args, 0));
-		} else if (args.length >= 2) {
-			source= context.getBinding(argument(args, 0));
-			kind= stripQuotes(argument(args, 1));
-		} else {
-			return false;
-		}
-		return source != null && !context.getSemanticPlan().outgoing(source, kind).isEmpty();
+		PlanNodeArguments parsed= planNodeArguments(context, args, 1);
+		return parsed != null && parsed.node() != null && !context.getSemanticPlan()
+				.outgoing(parsed.node(), stripQuotes(argument(args, parsed.offset()))).isEmpty();
 	}
 
 	private static boolean evaluatePlannedIncomingRelation(GuardContext context, Object... args) {
-		ASTNode target;
-		String kind;
-		if (args.length == 1) {
-			target= context.getMatchedNode();
-			kind= stripQuotes(argument(args, 0));
-		} else if (args.length >= 2) {
-			target= context.getBinding(argument(args, 0));
-			kind= stripQuotes(argument(args, 1));
-		} else {
-			return false;
-		}
-		return target != null && !context.getSemanticPlan().incoming(target, kind).isEmpty();
+		PlanNodeArguments parsed= planNodeArguments(context, args, 1);
+		return parsed != null && parsed.node() != null && !context.getSemanticPlan()
+				.incoming(parsed.node(), stripQuotes(argument(args, parsed.offset()))).isEmpty();
 	}
 
 	private static boolean evaluatePlannedRelationCount(GuardContext context, Object... args) {
-		ASTNode source;
-		String kind;
-		String countValue;
-		if (args.length == 2) {
-			source= context.getMatchedNode();
-			kind= stripQuotes(argument(args, 0));
-			countValue= argument(args, 1);
-		} else if (args.length >= 3) {
-			source= context.getBinding(argument(args, 0));
-			kind= stripQuotes(argument(args, 1));
-			countValue= argument(args, 2);
-		} else {
+		PlanNodeArguments parsed= planNodeArguments(context, args, 2);
+		if (parsed == null || parsed.node() == null) {
 			return false;
 		}
 		try {
-			return source != null
-					&& context.getSemanticPlan().outgoing(source, kind).size() == Integer.parseInt(countValue);
+			return context.getSemanticPlan()
+					.outgoing(parsed.node(), stripQuotes(argument(args, parsed.offset()))).size()
+					== Integer.parseInt(argument(args, parsed.offset() + 1));
 		} catch (NumberFormatException e) {
 			return false;
 		}
+	}
+
+	/**
+	 * Resolves the optional leading bound-node argument shared by all plan guards.
+	 * Extra or missing arguments are rejected rather than ignored.
+	 */
+	private static PlanNodeArguments planNodeArguments(GuardContext context, Object[] args, int implicitArity) {
+		if (args == null) {
+			return null;
+		}
+		if (args.length == implicitArity) {
+			return new PlanNodeArguments(context.getMatchedNode(), 0);
+		}
+		if (args.length == implicitArity + 1) {
+			return new PlanNodeArguments(context.getBinding(argument(args, 0)), 1);
+		}
+		return null;
 	}
 
 	private static boolean evaluateInstanceOf(GuardContext context, Object... args) {
@@ -344,5 +251,8 @@ public final class BuiltInGuardRegistration {
 			return stripped.substring(1, stripped.length() - 1);
 		}
 		return stripped;
+	}
+
+	private record PlanNodeArguments(ASTNode node, int offset) {
 	}
 }

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/BuiltInGuardRegistration.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/BuiltInGuardRegistration.java
@@ -24,6 +24,9 @@ import org.eclipse.jdt.core.dom.Type;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.sandbox.jdt.triggerpattern.api.GuardContext;
 import org.sandbox.jdt.triggerpattern.api.GuardFunction;
+import org.sandbox.jdt.triggerpattern.api.SemanticPlanValue;
+import org.sandbox.jdt.triggerpattern.api.SemanticPlanValue.ListValue;
+import org.sandbox.jdt.triggerpattern.api.SemanticRewritePlan.NodeKey;
 
 /** Canonical registration entry point for built-in guard functions. */
 public final class BuiltInGuardRegistration {
@@ -38,6 +41,15 @@ public final class BuiltInGuardRegistration {
 		guards.put("genericTypeIs", BuiltInGuardRegistration::evaluateGenericTypeIs); //$NON-NLS-1$
 		guards.put("plannedRole", BuiltInGuardRegistration::evaluatePlannedRole); //$NON-NLS-1$
 		guards.put("enclosingPlannedRole", BuiltInGuardRegistration::evaluateEnclosingPlannedRole); //$NON-NLS-1$
+		guards.put("plannedValue", BuiltInGuardRegistration::evaluatePlannedValue); //$NON-NLS-1$
+		guards.put("enclosingPlannedValue", BuiltInGuardRegistration::evaluateEnclosingPlannedValue); //$NON-NLS-1$
+		guards.put("plannedNodeValue", BuiltInGuardRegistration::evaluatePlannedNodeValue); //$NON-NLS-1$
+		guards.put("plannedListContains", BuiltInGuardRegistration::evaluatePlannedListContains); //$NON-NLS-1$
+		guards.put("plannedRelation", BuiltInGuardRegistration::evaluatePlannedRelation); //$NON-NLS-1$
+		guards.put("plannedRelationValue", BuiltInGuardRegistration::evaluatePlannedRelationValue); //$NON-NLS-1$
+		guards.put("plannedOutgoingRelation", BuiltInGuardRegistration::evaluatePlannedOutgoingRelation); //$NON-NLS-1$
+		guards.put("plannedIncomingRelation", BuiltInGuardRegistration::evaluatePlannedIncomingRelation); //$NON-NLS-1$
+		guards.put("plannedRelationCount", BuiltInGuardRegistration::evaluatePlannedRelationCount); //$NON-NLS-1$
 	}
 
 	private static boolean evaluatePlannedRole(GuardContext context, Object... args) {
@@ -68,6 +80,181 @@ public final class BuiltInGuardRegistration {
 			return false;
 		}
 		return node != null && context.getSemanticPlan().hasEnclosingRole(node, role);
+	}
+
+	private static boolean evaluatePlannedValue(GuardContext context, Object... args) {
+		ASTNode node;
+		String name;
+		SemanticPlanValue expected;
+		if (args.length == 2) {
+			node= context.getMatchedNode();
+			name= stripQuotes(argument(args, 0));
+			expected= literal(args, 1);
+		} else if (args.length >= 3) {
+			node= context.getBinding(argument(args, 0));
+			name= stripQuotes(argument(args, 1));
+			expected= literal(args, 2);
+		} else {
+			return false;
+		}
+		return node != null && context.getSemanticPlan().hasValue(node, name, expected);
+	}
+
+	private static boolean evaluateEnclosingPlannedValue(GuardContext context, Object... args) {
+		ASTNode node;
+		String name;
+		SemanticPlanValue expected;
+		if (args.length == 2) {
+			node= context.getMatchedNode();
+			name= stripQuotes(argument(args, 0));
+			expected= literal(args, 1);
+		} else if (args.length >= 3) {
+			node= context.getBinding(argument(args, 0));
+			name= stripQuotes(argument(args, 1));
+			expected= literal(args, 2);
+		} else {
+			return false;
+		}
+		return node != null && context.getSemanticPlan().hasEnclosingValue(node, name, expected);
+	}
+
+	private static boolean evaluatePlannedNodeValue(GuardContext context, Object... args) {
+		ASTNode node;
+		String name;
+		ASTNode expectedNode;
+		if (args.length == 2) {
+			node= context.getMatchedNode();
+			name= stripQuotes(argument(args, 0));
+			expectedNode= context.getBinding(argument(args, 1));
+		} else if (args.length >= 3) {
+			node= context.getBinding(argument(args, 0));
+			name= stripQuotes(argument(args, 1));
+			expectedNode= context.getBinding(argument(args, 2));
+		} else {
+			return false;
+		}
+		NodeKey expectedKey= NodeKey.from(expectedNode);
+		return node != null && expectedKey != null
+				&& context.getSemanticPlan().hasValue(node, name, SemanticPlanValue.node(expectedKey));
+	}
+
+	private static boolean evaluatePlannedListContains(GuardContext context, Object... args) {
+		ASTNode node;
+		String name;
+		SemanticPlanValue expected;
+		if (args.length == 2) {
+			node= context.getMatchedNode();
+			name= stripQuotes(argument(args, 0));
+			expected= literal(args, 1);
+		} else if (args.length >= 3) {
+			node= context.getBinding(argument(args, 0));
+			name= stripQuotes(argument(args, 1));
+			expected= literal(args, 2);
+		} else {
+			return false;
+		}
+		return node != null && context.getSemanticPlan().value(node, name)
+				.filter(ListValue.class::isInstance)
+				.map(ListValue.class::cast)
+				.map(value -> value.values().contains(expected))
+				.orElse(false);
+	}
+
+	private static boolean evaluatePlannedRelation(GuardContext context, Object... args) {
+		ASTNode source;
+		String kind;
+		ASTNode target;
+		if (args.length == 2) {
+			source= context.getMatchedNode();
+			kind= stripQuotes(argument(args, 0));
+			target= context.getBinding(argument(args, 1));
+		} else if (args.length >= 3) {
+			source= context.getBinding(argument(args, 0));
+			kind= stripQuotes(argument(args, 1));
+			target= context.getBinding(argument(args, 2));
+		} else {
+			return false;
+		}
+		return source != null && target != null
+				&& context.getSemanticPlan().hasRelation(source, kind, target);
+	}
+
+	private static boolean evaluatePlannedRelationValue(GuardContext context, Object... args) {
+		ASTNode source;
+		String kind;
+		ASTNode target;
+		String name;
+		SemanticPlanValue expected;
+		if (args.length == 4) {
+			source= context.getMatchedNode();
+			kind= stripQuotes(argument(args, 0));
+			target= context.getBinding(argument(args, 1));
+			name= stripQuotes(argument(args, 2));
+			expected= literal(args, 3);
+		} else if (args.length >= 5) {
+			source= context.getBinding(argument(args, 0));
+			kind= stripQuotes(argument(args, 1));
+			target= context.getBinding(argument(args, 2));
+			name= stripQuotes(argument(args, 3));
+			expected= literal(args, 4);
+		} else {
+			return false;
+		}
+		return source != null && target != null
+				&& context.getSemanticPlan().hasRelationValue(source, kind, target, name, expected);
+	}
+
+	private static boolean evaluatePlannedOutgoingRelation(GuardContext context, Object... args) {
+		ASTNode source;
+		String kind;
+		if (args.length == 1) {
+			source= context.getMatchedNode();
+			kind= stripQuotes(argument(args, 0));
+		} else if (args.length >= 2) {
+			source= context.getBinding(argument(args, 0));
+			kind= stripQuotes(argument(args, 1));
+		} else {
+			return false;
+		}
+		return source != null && !context.getSemanticPlan().outgoing(source, kind).isEmpty();
+	}
+
+	private static boolean evaluatePlannedIncomingRelation(GuardContext context, Object... args) {
+		ASTNode target;
+		String kind;
+		if (args.length == 1) {
+			target= context.getMatchedNode();
+			kind= stripQuotes(argument(args, 0));
+		} else if (args.length >= 2) {
+			target= context.getBinding(argument(args, 0));
+			kind= stripQuotes(argument(args, 1));
+		} else {
+			return false;
+		}
+		return target != null && !context.getSemanticPlan().incoming(target, kind).isEmpty();
+	}
+
+	private static boolean evaluatePlannedRelationCount(GuardContext context, Object... args) {
+		ASTNode source;
+		String kind;
+		String countValue;
+		if (args.length == 2) {
+			source= context.getMatchedNode();
+			kind= stripQuotes(argument(args, 0));
+			countValue= argument(args, 1);
+		} else if (args.length >= 3) {
+			source= context.getBinding(argument(args, 0));
+			kind= stripQuotes(argument(args, 1));
+			countValue= argument(args, 2);
+		} else {
+			return false;
+		}
+		try {
+			return source != null
+					&& context.getSemanticPlan().outgoing(source, kind).size() == Integer.parseInt(countValue);
+		} catch (NumberFormatException e) {
+			return false;
+		}
 	}
 
 	private static boolean evaluateInstanceOf(GuardContext context, Object... args) {
@@ -111,6 +298,10 @@ public final class BuiltInGuardRegistration {
 		ITypeBinding[] arguments= binding.getTypeArguments();
 		return index >= 0 && index < arguments.length
 				&& matchesTypeName(arguments[index], stripQuotes(argument(args, 2)));
+	}
+
+	private static SemanticPlanValue literal(Object[] args, int index) {
+		return SemanticPlanValue.fromGuardLiteral(argument(args, index));
 	}
 
 	private static String argument(Object[] args, int index) {

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/HintLanguageVocabulary.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/HintLanguageVocabulary.java
@@ -46,6 +46,15 @@ public final class HintLanguageVocabulary {
 	private static final Map<String, String> DESCRIPTION_OVERRIDES= Map.ofEntries(
 			Map.entry("plannedRole", "Matched or bound node has the supplied semantic-plan role"), //$NON-NLS-1$ //$NON-NLS-2$
 			Map.entry("enclosingPlannedRole", "An enclosing node has the supplied semantic-plan role"), //$NON-NLS-1$ //$NON-NLS-2$
+			Map.entry("plannedValue", "Matched or bound node has an equal typed semantic-plan value"), //$NON-NLS-1$ //$NON-NLS-2$
+			Map.entry("enclosingPlannedValue", "A node or enclosing declaration has an equal typed plan value"), //$NON-NLS-1$ //$NON-NLS-2$
+			Map.entry("plannedNodeValue", "A typed semantic-plan value references the supplied bound node"), //$NON-NLS-1$ //$NON-NLS-2$
+			Map.entry("plannedListContains", "A typed semantic-plan list contains the supplied value"), //$NON-NLS-1$ //$NON-NLS-2$
+			Map.entry("plannedRelation", "An exact directed semantic-plan relation connects two nodes"), //$NON-NLS-1$ //$NON-NLS-2$
+			Map.entry("plannedRelationValue", "A semantic-plan relation has an equal typed attribute"), //$NON-NLS-1$ //$NON-NLS-2$
+			Map.entry("plannedOutgoingRelation", "A node has an outgoing semantic-plan relation of a kind"), //$NON-NLS-1$ //$NON-NLS-2$
+			Map.entry("plannedIncomingRelation", "A node has an incoming semantic-plan relation of a kind"), //$NON-NLS-1$ //$NON-NLS-2$
+			Map.entry("plannedRelationCount", "A node has the exact number of outgoing planned relations"), //$NON-NLS-1$ //$NON-NLS-2$
 			Map.entry("referencedIn", "A variable is referenced in another bound node"), //$NON-NLS-1$ //$NON-NLS-2$
 			Map.entry("hasNoSideEffect", "Expression is side-effect free"), //$NON-NLS-1$ //$NON-NLS-2$
 			Map.entry("sourceVersionBetween", "Source version is within the supplied range"), //$NON-NLS-1$ //$NON-NLS-2$

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/SemanticRewritePlanFactGuardTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/SemanticRewritePlanFactGuardTest.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+
+import org.sandbox.jdt.triggerpattern.api.GuardContext;
+import org.sandbox.jdt.triggerpattern.api.GuardFunction;
+import org.sandbox.jdt.triggerpattern.api.Match;
+import org.sandbox.jdt.triggerpattern.api.SemanticPlanValue;
+import org.sandbox.jdt.triggerpattern.api.SemanticRewritePlan;
+import org.sandbox.jdt.triggerpattern.api.SemanticRewritePlan.NodeKey;
+import org.sandbox.jdt.triggerpattern.internal.BuiltInGuardRegistration;
+
+/** Fail-closed evaluation tests for typed facts and plan relations. */
+public class SemanticRewritePlanFactGuardTest {
+
+	@Test
+	public void typedFactAndRelationGuardsUseStableBindings() {
+		TypeDeclaration type= parseType();
+		MethodDeclaration first= type.getMethods()[0];
+		MethodDeclaration second= type.getMethods()[1];
+		NodeKey typeKey= NodeKey.from(type);
+		NodeKey firstKey= NodeKey.from(first);
+		NodeKey secondKey= NodeKey.from(second);
+		SemanticRewritePlan plan= SemanticRewritePlan.builder("harness/v1") //$NON-NLS-1$
+				.putString(typeKey, "runner", "CUSTOM") //$NON-NLS-1$ //$NON-NLS-2$
+				.putBoolean(firstKey, "selected", true) //$NON-NLS-1$
+				.putList(typeKey, "levels", SemanticPlanValue.integer(17), SemanticPlanValue.integer(21)) //$NON-NLS-1$
+				.putNode(firstKey, "owner", typeKey) //$NON-NLS-1$
+				.relate(typeKey, "CONTAINS", firstKey, Map.of("index", SemanticPlanValue.integer(0))) //$NON-NLS-1$ //$NON-NLS-2$
+				.relate(typeKey, "CONTAINS", firstKey, Map.of("index", SemanticPlanValue.integer(1))) //$NON-NLS-1$ //$NON-NLS-2$
+				.relate(typeKey, "CONTAINS", secondKey, Map.of("index", SemanticPlanValue.integer(2))) //$NON-NLS-1$ //$NON-NLS-2$
+				.build();
+		Map<String, Object> bindings= Map.of(
+				"$type", type.getName(), //$NON-NLS-1$
+				"$first", first.getName(), //$NON-NLS-1$
+				"$second", second.getName()); //$NON-NLS-1$
+		Match match= new Match(type, bindings, type.getStartPosition(), type.getLength());
+		GuardContext context= GuardContext.fromMatch(match, (CompilationUnit) type.getRoot(), Map.of(), plan);
+		Map<String, GuardFunction> guards= guards();
+
+		assertTrue(guards.get("plannedValue").evaluate(context, "$type", "runner", "CUSTOM")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+		assertTrue(guards.get("plannedValue").evaluate(context, "$first", "selected", "true")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+		assertTrue(guards.get("plannedListContains").evaluate(context, "$type", "levels", "21")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+		assertTrue(guards.get("plannedNodeValue").evaluate(context, "$first", "owner", "$type")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+		assertTrue(guards.get("plannedRelation").evaluate(context, "$type", "CONTAINS", "$first")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+		assertTrue(guards.get("plannedRelationValue").evaluate(context, "$type", "CONTAINS", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+				"$first", "index", "1")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		assertTrue(guards.get("plannedOutgoingRelation").evaluate(context, "$type", "CONTAINS")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		assertTrue(guards.get("plannedIncomingRelation").evaluate(context, "$first", "CONTAINS")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		assertTrue(guards.get("plannedRelationCount").evaluate(context, "$type", "CONTAINS", "3")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+
+		assertFalse(guards.get("plannedValue").evaluate(context, "$type", "runner", "OTHER")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+		assertFalse(guards.get("plannedRelation").evaluate(context, "$first", "CONTAINS", "$type")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+		assertFalse(guards.get("plannedRelationCount").evaluate(context, "$type", "CONTAINS", "2")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+	}
+
+	@Test
+	public void typedGuardsRejectMissingPlansAndBindings() {
+		TypeDeclaration type= parseType();
+		Match match= new Match(type, Map.of(), type.getStartPosition(), type.getLength());
+		GuardContext context= GuardContext.fromMatch(match, (CompilationUnit) type.getRoot());
+		Map<String, GuardFunction> guards= guards();
+
+		assertFalse(guards.get("plannedValue").evaluate(context, "runner", "CUSTOM")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		assertFalse(guards.get("plannedRelation").evaluate(context, "CONTAINS", "$missing")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		assertFalse(guards.get("plannedNodeValue").evaluate(context, "owner", "$missing")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+	}
+
+	private static Map<String, GuardFunction> guards() {
+		Map<String, GuardFunction> guards= new HashMap<>();
+		BuiltInGuardRegistration.registerAll(guards);
+		return guards;
+	}
+
+	private static TypeDeclaration parseType() {
+		ASTParser parser= ASTParser.newParser(AST.getJLSLatest());
+		parser.setKind(ASTParser.K_COMPILATION_UNIT);
+		parser.setSource("package test; public class Sample { public void first() {} public void second() {} }" //$NON-NLS-1$
+				.toCharArray());
+		parser.setUnitName("Sample.java"); //$NON-NLS-1$
+		parser.setResolveBindings(true);
+		parser.setBindingsRecovery(true);
+		parser.setEnvironment(new String[0], new String[0], null, true);
+		Map<String, String> options= JavaCore.getOptions();
+		JavaCore.setComplianceOptions(JavaCore.VERSION_21, options);
+		parser.setCompilerOptions(options);
+		CompilationUnit root= (CompilationUnit) parser.createAST(null);
+		return (TypeDeclaration) root.types().get(0);
+	}
+}

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/SemanticRewritePlanFactGuardTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/SemanticRewritePlanFactGuardTest.java
@@ -75,6 +75,8 @@ public class SemanticRewritePlanFactGuardTest {
 		assertFalse(guards.get("plannedValue").evaluate(context, "$type", "runner", "OTHER")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		assertFalse(guards.get("plannedRelation").evaluate(context, "$first", "CONTAINS", "$type")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		assertFalse(guards.get("plannedRelationCount").evaluate(context, "$type", "CONTAINS", "2")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+		assertFalse(guards.get("plannedValue").evaluate(context, "$type", "runner", "CUSTOM", "extra")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+		assertFalse(guards.get("plannedRelation").evaluate(context, "$type", "CONTAINS", "$first", "extra")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
 	}
 
 	@Test

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/SemanticRewritePlanFactsTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/SemanticRewritePlanFactsTest.java
@@ -81,6 +81,12 @@ public class SemanticRewritePlanFactsTest {
 		assertThrows(IllegalArgumentException.class, () -> SemanticRewritePlan.builder()
 				.putString(type, "mode", "FIRST") //$NON-NLS-1$ //$NON-NLS-2$
 				.putString(type, "mode", "SECOND")); //$NON-NLS-1$ //$NON-NLS-2$
+
+		SemanticRewritePlan lists= SemanticRewritePlan.builder("lists") //$NON-NLS-1$
+				.putList(type, "levels") //$NON-NLS-1$
+				.putList(method, "levels", SemanticPlanValue.integer(21)) //$NON-NLS-1$
+				.build();
+		assertEquals(SemanticPlanValue.list(), lists.value(type, "levels").orElseThrow()); //$NON-NLS-1$
 	}
 
 	@Test
@@ -108,6 +114,7 @@ public class SemanticRewritePlanFactsTest {
 		});
 
 		NodeKey typeKey= NodeKey.from(type);
+		NodeKey fieldDeclarationKey= NodeKey.from(type.getFields()[0]);
 		NodeKey fieldKey= NodeKey.from(field);
 		NodeKey invocationKey= NodeKey.from(creation[0]);
 		assertNotNull(typeKey);
@@ -115,6 +122,7 @@ public class SemanticRewritePlanFactsTest {
 		assertNotNull(invocationKey);
 		assertEquals(NodeKind.TYPE, typeKey.kind());
 		assertEquals(NodeKind.FIELD, fieldKey.kind());
+		assertEquals(fieldKey, fieldDeclarationKey);
 		assertEquals(NodeKind.INVOCATION, invocationKey.kind());
 		assertTrue(invocationKey.sourceStart() >= 0);
 		assertTrue(invocationKey.sourceLength() > 0);

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/SemanticRewritePlanFactsTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/SemanticRewritePlanFactsTest.java
@@ -1,0 +1,140 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.ClassInstanceCreation;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+
+import org.sandbox.jdt.triggerpattern.api.SemanticPlanRelation;
+import org.sandbox.jdt.triggerpattern.api.SemanticPlanValue;
+import org.sandbox.jdt.triggerpattern.api.SemanticRewritePlan;
+import org.sandbox.jdt.triggerpattern.api.SemanticRewritePlan.NodeKey;
+import org.sandbox.jdt.triggerpattern.api.SemanticRewritePlan.NodeKind;
+
+/** Contract tests for typed plan facts, graph relations and stable node keys. */
+public class SemanticRewritePlanFactsTest {
+
+	@Test
+	public void typedFactsAndRelationsPreserveOrderAndMultiplicity() {
+		NodeKey suite= NodeKey.type("Ltest/Suite;"); //$NON-NLS-1$
+		NodeKey first= NodeKey.method("Ltest/Suite;.first()V"); //$NON-NLS-1$
+		NodeKey second= NodeKey.method("Ltest/Suite;.second()V"); //$NON-NLS-1$
+		SemanticRewritePlan plan= SemanticRewritePlan.builder("legacy-tests/v1") //$NON-NLS-1$
+				.putString(suite, "runner", "CUSTOM") //$NON-NLS-1$ //$NON-NLS-2$
+				.putBoolean(suite, "ordered", true) //$NON-NLS-1$
+				.putInteger(suite, "multiplicity", 3) //$NON-NLS-1$
+				.putList(suite, "levels", SemanticPlanValue.integer(17), SemanticPlanValue.integer(21)) //$NON-NLS-1$
+				.putNode(first, "owner", suite) //$NON-NLS-1$
+				.relate(suite, "CONTAINS", first, Map.of("index", SemanticPlanValue.integer(0))) //$NON-NLS-1$ //$NON-NLS-2$
+				.relate(suite, "CONTAINS", first, Map.of("index", SemanticPlanValue.integer(1))) //$NON-NLS-1$ //$NON-NLS-2$
+				.relate(suite, "CONTAINS", second, Map.of("index", SemanticPlanValue.integer(2))) //$NON-NLS-1$ //$NON-NLS-2$
+				.build();
+
+		assertFalse(plan.isEmpty());
+		assertEquals(SemanticPlanValue.string("CUSTOM"), plan.value(suite, "runner").orElseThrow()); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals(SemanticPlanValue.bool(true), plan.value(suite, "ordered").orElseThrow()); //$NON-NLS-1$
+		assertEquals(SemanticPlanValue.integer(3), plan.value(suite, "multiplicity").orElseThrow()); //$NON-NLS-1$
+		assertEquals(SemanticPlanValue.node(suite), plan.value(first, "owner").orElseThrow()); //$NON-NLS-1$
+		assertEquals(3, plan.outgoing(suite, "CONTAINS").size()); //$NON-NLS-1$
+		assertEquals(2, plan.incoming(first, "CONTAINS").size()); //$NON-NLS-1$
+		assertEquals(SemanticPlanValue.integer(0), relationIndex(plan.outgoing(suite, "CONTAINS").get(0))); //$NON-NLS-1$
+		assertEquals(SemanticPlanValue.integer(1), relationIndex(plan.outgoing(suite, "CONTAINS").get(1))); //$NON-NLS-1$
+		assertEquals(SemanticPlanValue.integer(2), relationIndex(plan.outgoing(suite, "CONTAINS").get(2))); //$NON-NLS-1$
+	}
+
+	@Test
+	public void conflictingFactTypesAndHeterogeneousListsFailClosed() {
+		NodeKey type= NodeKey.type("Ltest/Sample;"); //$NON-NLS-1$
+		NodeKey method= NodeKey.method("Ltest/Sample;.test()V"); //$NON-NLS-1$
+
+		assertThrows(IllegalArgumentException.class, () -> SemanticRewritePlan.builder("contract") //$NON-NLS-1$
+				.putString(type, "mode", "CUSTOM") //$NON-NLS-1$ //$NON-NLS-2$
+				.putInteger(method, "mode", 1) //$NON-NLS-1$
+				.build());
+		assertThrows(IllegalArgumentException.class, () -> SemanticPlanValue.list(
+				SemanticPlanValue.string("17"), SemanticPlanValue.integer(21))); //$NON-NLS-1$
+		assertThrows(IllegalArgumentException.class, () -> SemanticRewritePlan.builder()
+				.putString(type, "mode", "FIRST") //$NON-NLS-1$ //$NON-NLS-2$
+				.putString(type, "mode", "SECOND")); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	@Test
+	public void stableKeysCoverFieldsAndConstructorCallSites() {
+		CompilationUnit root= parse("""
+				package test;
+				public class Sample {
+					public Object rule;
+					public Sample() {
+					}
+					public void create() {
+						new Sample();
+					}
+				}
+				""");
+		TypeDeclaration type= (TypeDeclaration) root.types().get(0);
+		VariableDeclarationFragment field= (VariableDeclarationFragment) type.getFields()[0].fragments().get(0);
+		ClassInstanceCreation[] creation= new ClassInstanceCreation[1];
+		root.accept(new ASTVisitor() {
+			@Override
+			public boolean visit(ClassInstanceCreation node) {
+				creation[0]= node;
+				return false;
+			}
+		});
+
+		NodeKey typeKey= NodeKey.from(type);
+		NodeKey fieldKey= NodeKey.from(field);
+		NodeKey invocationKey= NodeKey.from(creation[0]);
+		assertNotNull(typeKey);
+		assertNotNull(fieldKey);
+		assertNotNull(invocationKey);
+		assertEquals(NodeKind.TYPE, typeKey.kind());
+		assertEquals(NodeKind.FIELD, fieldKey.kind());
+		assertEquals(NodeKind.INVOCATION, invocationKey.kind());
+		assertTrue(invocationKey.sourceStart() >= 0);
+		assertTrue(invocationKey.sourceLength() > 0);
+	}
+
+	private static SemanticPlanValue relationIndex(SemanticPlanRelation relation) {
+		return relation.attribute("index").orElseThrow(); //$NON-NLS-1$
+	}
+
+	private static CompilationUnit parse(String source) {
+		ASTParser parser= ASTParser.newParser(AST.getJLSLatest());
+		parser.setKind(ASTParser.K_COMPILATION_UNIT);
+		parser.setSource(source.toCharArray());
+		parser.setUnitName("Sample.java"); //$NON-NLS-1$
+		parser.setResolveBindings(true);
+		parser.setBindingsRecovery(true);
+		parser.setEnvironment(new String[0], new String[0], null, true);
+		Map<String, String> options= JavaCore.getOptions();
+		JavaCore.setComplianceOptions(JavaCore.VERSION_21, options);
+		parser.setCompilerOptions(options);
+		return (CompilationUnit) parser.createAST(null);
+	}
+}

--- a/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/PlanAwarePredicateHintTest.java
+++ b/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/PlanAwarePredicateHintTest.java
@@ -72,6 +72,41 @@ class PlanAwarePredicateHintTest {
 				=> @org.junit.jupiter.api.Test void $name()
 				;;
 				""";
+		assertAuthorized(method, ast, unit, plan, hint, key);
+	}
+
+	@Test
+	void typedFactWithoutRoleCreatesAuthorizedRewriteOperation() throws CoreException {
+		IPackageFragmentRoot root= context.createClasspathForJUnit(JUnitCore.JUNIT5_CONTAINER_PATH);
+		IPackageFragment pack= root.createPackageFragment("samplefact", true, null); //$NON-NLS-1$
+		ICompilationUnit unit= pack.createCompilationUnit("FactSample.java", //$NON-NLS-1$
+				"""
+				package samplefact;
+				public class FactSample {
+					public void selectedTest() {
+					}
+				}
+				""", false, null);
+		CompilationUnit ast= parse(unit);
+		MethodDeclaration method= findMethod(ast, "selectedTest"); //$NON-NLS-1$
+		IMethodBinding binding= method.resolveBinding();
+		String key= binding.getMethodDeclaration().getKey();
+		SemanticRewritePlan plan= SemanticRewritePlan.builder("typed-fact-demo") //$NON-NLS-1$
+				.putString(NodeKey.method(key), "test-kind", "JUPITER").build(); //$NON-NLS-1$ //$NON-NLS-2$
+		String hint= """
+				<!id: typed-fact-demo>
+				<!requires-plan: typed-fact-demo>
+				<!predicate selected($method):
+				    plannedValue($method, "test-kind", "JUPITER") && isPublic($method)>
+				void $name() :: selected($name)
+				=> @org.junit.jupiter.api.Test void $name()
+				;;
+				""";
+		assertAuthorized(method, ast, unit, plan, hint, key);
+	}
+
+	private static void assertAuthorized(MethodDeclaration method, CompilationUnit ast, ICompilationUnit unit,
+			SemanticRewritePlan plan, String hint, String key) throws CoreException {
 		Set<CompilationUnitRewriteOperationWithSourceRange> operations= new LinkedHashSet<>();
 		Set<org.eclipse.jdt.core.dom.ASTNode> processed= new LinkedHashSet<>();
 


### PR DESCRIPTION
## Purpose

Roles alone cannot describe demanding harness migrations. JDT Core needs named construction, ordered suite membership, duplicate occurrences, compliance matrices and wrapper/lifecycle ownership. A later JDT UI migration needs runner, provider and `@Rule`/`@ClassRule` field information. This PR adds one generic project-neutral plan model for both.

## Typed fact model

- adds the closed immutable `SemanticPlanValue` model for string, boolean, integer, stable node-reference and homogeneous list values;
- extends `SemanticRewritePlan` with binding-keyed typed values while preserving the existing role-only constructors and accessor API;
- rejects conflicting duplicate values and fact/relation-attribute kind drift when a plan is built;
- keeps fact-only plans productive in the existing plan-aware rewrite backend.

## Ordered relation graph

- adds directed `SemanticPlanRelation` occurrences with typed attributes;
- preserves planner order and duplicate occurrences intentionally, so suite order and runtime multiplicity are representable;
- builds immutable forward and reverse indexes by node and relation kind, avoiding repeated full-list scans in large suite or compliance-matrix plans;
- provides exact incoming/outgoing/relation/value/count queries without adding JUnit or project concepts to the shared API.

## Stable semantic targets

`NodeKey` now covers:

- ordinary, enum, annotation and record types;
- methods and constructors;
- single-fragment field declarations and field fragments, required for JUnit 4 rule migration;
- exact ordinary/super method calls and constructor call sites, required for named JUnit 3 construction and custom suite builders.

Ambiguous multi-fragment field declarations remain fail-closed rather than authorizing the wrong field.

## Guard DSL

Adds fail-closed guards:

- `plannedValue` / `enclosingPlannedValue`;
- `plannedNodeValue` / `plannedListContains`;
- `plannedRelation` / `plannedRelationValue`;
- `plannedOutgoingRelation` / `plannedIncomingRelation`;
- `plannedRelationCount`.

All plan guards use one strict optional-node argument decoder. Missing or extra arguments, missing bindings and missing facts return false instead of being silently ignored. The guards are derived into the existing canonical editor vocabulary and can be composed through the predicate declarations merged in #1344.

## Verification

- pure core tests cover value typing, conflict rejection, ordered duplicate relations, relation indexes, field keys and constructor call-site keys;
- guard tests cover exact binding-based fact and relation queries plus missing-plan, missing-binding and wrong-arity rejection;
- a PDE integration test proves that a fact-only plan passes the existing contract gate and reaches `HintFileFixCore` through a composed predicate;
- architecture documentation records the shared JDT Core then JDT UI migration roadmap.

## Deliberate boundary

This PR provides the generic semantic data layer. It does not yet add structured declaration actions or claim support for the JDT Core custom harness. The next slice replaces the ad-hoc structural-operation growth path with registered, schema-validated AST actions and applies them to a demanding harness fixture.

Refs #1334 and #1217.