### PR TITLE
Add a generic execution-tree migration oracle

### DIFF
--- a/docs/generic-harness-contract-dsl.md
+++ b/docs/generic-harness-contract-dsl.md
@@ -94,6 +94,33 @@ fields and exact method/constructor call sites. Field keys are needed for JUnit
 4 `@Rule`/`@ClassRule` migration; exact constructor call sites are needed for
 named JUnit 3 test construction and custom suite builders.
 
+## Generic execution-tree oracle
+
+`ExecutionTreeSnapshot` is the framework-neutral before/after contract. Adapters
+convert a completed JDT JUnit model, another launcher or a dedicated harness
+fixture into immutable containers and tests with stable semantic identities,
+results, attributes and ordered children. No live framework model object is
+retained after capture.
+
+`ExecutionTreeComparator` requires a named policy rather than silently
+normalizing differences. Available policy shapes include:
+
+- strict structure, container identity, order, results and attributes;
+- identical shape while allowing framework container names to change;
+- ordered leaves while ignoring wrappers;
+- an unordered leaf multiset.
+
+Every policy preserves duplicate occurrences exactly. There is deliberately no
+set-only mode that could hide a lost or duplicated test. Successful execution is
+required by default, and result or attribute comparison can be relaxed only by
+an explicit policy copy. The existing coordinated JUnit 3 hierarchy regression
+now uses this generic model through a small JDT adapter.
+
+For demanding migrations, the planner assigns stable identities to legacy and
+replacement containers. That lets the strict policy compare semantic suite
+structure even when the physical implementation changes from JUnit 3 suite
+objects to Jupiter dynamic containers.
+
 ## One language vocabulary
 
 `HintLanguageVocabulary` is the canonical source for:
@@ -129,8 +156,9 @@ one parser class.
 
 ## Next generic language slices
 
-Typed facts and relations provide the shared data model, but they do not yet
-express all required AST changes. The next extensions remain generic:
+Typed facts, relations and execution-tree verification provide the shared data
+and safety model, but they do not yet express all required AST changes. The next
+extensions remain generic:
 
 ```text
 contract legacy-tests/v1 {
@@ -145,15 +173,15 @@ contract legacy-tests/v1 {
 
 Required engine concepts are:
 
-- structured AST actions such as replacing a supertype, removing a validated
-  constructor, replacing an annotation, qualifying an invocation and generating
-  a nested adapter type;
+- a separate registrable structured-action channel rather than encoding AST
+  operations as syntactically invalid Java replacement text;
+- actions such as replacing a supertype, removing a validated constructor,
+  replacing an annotation, qualifying an invocation and generating a nested
+  adapter type;
 - reusable contract fragments for discovery, ordering, selection, suite state,
   providers, wrappers and execution matrices;
 - trace output containing rule ID, plan node, relation occurrence, binding key,
-  typed values and rejection/skip reason;
-- a generic runtime oracle requiring an identical non-empty successful test
-  tree with configurable identity, nesting, order and multiplicity policies.
+  typed values and rejection/skip reason.
 
 Project-specific recipes then supply only type names, method patterns and the
 composition of these generic contracts.
@@ -201,7 +229,7 @@ Every language extension must include:
 - plan-aware end-to-end execution proving that the expanded program reaches the
   existing rewrite backend;
 - relation tests preserving explicit order and duplicate multiplicity;
-- at least one runtime-tree regression when execution semantics are affected.
+- execution-tree regressions whenever discovery or runtime semantics change.
 
 A feature is not complete when only the parser accepts it. Editor support,
 diagnostics, execution and tests are part of the language contract.

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/api/ExecutionTreeComparator.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/api/ExecutionTreeComparator.java
@@ -1,0 +1,210 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.api;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+
+import org.sandbox.jdt.triggerpattern.api.ExecutionTreeSnapshot.Node;
+import org.sandbox.jdt.triggerpattern.api.ExecutionTreeSnapshot.NodeKind;
+
+/** Compares framework-neutral execution trees under an explicit safety policy. */
+public final class ExecutionTreeComparator {
+
+	/**
+	 * Explicit comparison dimensions.
+	 *
+	 * <p>Multiplicity is always exact: canonical entries retain every occurrence.
+	 * A migration may relax wrapper identity, nesting or order only by selecting a
+	 * corresponding policy. There is deliberately no set-only mode that could hide
+	 * duplicate or lost tests.</p>
+	 */
+	public record Policy(boolean compareNesting, boolean compareContainerIdentity,
+			boolean compareOrder, boolean compareResults, boolean compareAttributes,
+			boolean compareDisplayNames, boolean requireSuccessful) {
+
+		/** Strict comparison of structure, semantic identities, order, results and attributes. */
+		public static Policy strict() {
+			return new Policy(true, true, true, true, true, false, true);
+		}
+
+		/** Compares tree shape and leaves while allowing framework container names to change. */
+		public static Policy sameShape() {
+			return new Policy(true, false, true, true, true, false, true);
+		}
+
+		/** Compares ordered leaf identities and multiplicity while ignoring all wrappers. */
+		public static Policy leavesInOrder() {
+			return new Policy(false, false, true, true, true, false, true);
+		}
+
+		/** Compares the unordered leaf multiset while preserving exact multiplicity. */
+		public static Policy leafMultiset() {
+			return new Policy(false, false, false, true, true, false, true);
+		}
+
+		/** Returns a copy with result comparison changed. */
+		public Policy withResults(boolean enabled) {
+			return new Policy(compareNesting, compareContainerIdentity, compareOrder, enabled,
+					compareAttributes, compareDisplayNames, requireSuccessful);
+		}
+
+		/** Returns a copy with adapter attributes changed. */
+		public Policy withAttributes(boolean enabled) {
+			return new Policy(compareNesting, compareContainerIdentity, compareOrder, compareResults,
+					enabled, compareDisplayNames, requireSuccessful);
+		}
+
+		/** Returns a copy with display-name comparison changed. */
+		public Policy withDisplayNames(boolean enabled) {
+			return new Policy(compareNesting, compareContainerIdentity, compareOrder, compareResults,
+					compareAttributes, enabled, requireSuccessful);
+		}
+
+		/** Returns a copy with the successful-execution requirement changed. */
+		public Policy requiringSuccessful(boolean enabled) {
+			return new Policy(compareNesting, compareContainerIdentity, compareOrder, compareResults,
+					compareAttributes, compareDisplayNames, enabled);
+		}
+	}
+
+	/** Complete deterministic comparison result and diagnostic canonical forms. */
+	public record Comparison(boolean equivalent, List<String> beforeEntries,
+			List<String> afterEntries, String difference) {
+		public Comparison {
+			beforeEntries= List.copyOf(beforeEntries);
+			afterEntries= List.copyOf(afterEntries);
+			difference= difference == null ? "" : difference; //$NON-NLS-1$
+		}
+	}
+
+	private ExecutionTreeComparator() {
+	}
+
+	/** Compares two snapshots under the supplied explicit policy. */
+	public static Comparison compare(ExecutionTreeSnapshot before, ExecutionTreeSnapshot after,
+			Policy policy) {
+		Objects.requireNonNull(before);
+		Objects.requireNonNull(after);
+		Objects.requireNonNull(policy);
+		List<String> beforeEntries= canonicalEntries(before, policy);
+		List<String> afterEntries= canonicalEntries(after, policy);
+		if (policy.requireSuccessful() && (!before.successful() || !after.successful())) {
+			return new Comparison(false, beforeEntries, afterEntries,
+					"Execution must be successful before and after migration: before=" //$NON-NLS-1$
+							+ before.successful() + ", after=" + after.successful()); //$NON-NLS-1$
+		}
+		if (beforeEntries.equals(afterEntries)) {
+			return new Comparison(true, beforeEntries, afterEntries, ""); //$NON-NLS-1$
+		}
+		return new Comparison(false, beforeEntries, afterEntries,
+				firstDifference(beforeEntries, afterEntries));
+	}
+
+	private static List<String> canonicalEntries(ExecutionTreeSnapshot snapshot, Policy policy) {
+		List<String> entries= new ArrayList<>();
+		if (policy.compareNesting()) {
+			for (Node root : snapshot.roots()) {
+				entries.add(canonicalNode(root, policy));
+			}
+		} else {
+			for (Node root : snapshot.roots()) {
+				appendLeaves(root, policy, entries);
+			}
+		}
+		if (!policy.compareOrder()) {
+			entries.sort(Comparator.naturalOrder());
+		}
+		return List.copyOf(entries);
+	}
+
+	private static String canonicalNode(Node node, Policy policy) {
+		List<String> children= node.children().stream()
+				.map(child -> canonicalNode(child, policy))
+				.collect(java.util.stream.Collectors.toCollection(ArrayList::new));
+		if (!policy.compareOrder()) {
+			children.sort(Comparator.naturalOrder());
+		}
+		StringBuilder result= new StringBuilder();
+		result.append(node.kind()).append('{');
+		if (node.kind() != NodeKind.CONTAINER || policy.compareContainerIdentity()) {
+			appendValue(result, node.identity());
+		}
+		if (policy.compareDisplayNames()) {
+			appendValue(result, node.displayName());
+		}
+		if (policy.compareResults()) {
+			appendValue(result, node.result());
+		}
+		if (policy.compareAttributes()) {
+			appendAttributes(result, node.attributes());
+		}
+		result.append('}').append('[');
+		for (String child : children) {
+			appendValue(result, child);
+		}
+		return result.append(']').toString();
+	}
+
+	private static void appendLeaves(Node node, Policy policy, List<String> entries) {
+		if (node.kind() == NodeKind.TEST || node.children().isEmpty()) {
+			entries.add(canonicalLeaf(node, policy));
+			return;
+		}
+		for (Node child : node.children()) {
+			appendLeaves(child, policy, entries);
+		}
+	}
+
+	private static String canonicalLeaf(Node node, Policy policy) {
+		StringBuilder result= new StringBuilder(node.kind().name()).append('{');
+		appendValue(result, node.identity());
+		if (policy.compareDisplayNames()) {
+			appendValue(result, node.displayName());
+		}
+		if (policy.compareResults()) {
+			appendValue(result, node.result());
+		}
+		if (policy.compareAttributes()) {
+			appendAttributes(result, node.attributes());
+		}
+		return result.append('}').toString();
+	}
+
+	private static void appendAttributes(StringBuilder target, Map<String, String> attributes) {
+		Map<String, String> sorted= new TreeMap<>(attributes);
+		for (Map.Entry<String, String> entry : sorted.entrySet()) {
+			appendValue(target, entry.getKey());
+			appendValue(target, entry.getValue());
+		}
+	}
+
+	private static void appendValue(StringBuilder target, String value) {
+		String text= value == null ? "" : value; //$NON-NLS-1$
+		target.append(text.length()).append(':').append(text).append(';');
+	}
+
+	private static String firstDifference(List<String> before, List<String> after) {
+		int common= Math.min(before.size(), after.size());
+		for (int index= 0; index < common; index++) {
+			if (!before.get(index).equals(after.get(index))) {
+				return "Execution tree differs at canonical entry " + index //$NON-NLS-1$
+						+ ": before=" + before.get(index) + ", after=" + after.get(index); //$NON-NLS-1$ //$NON-NLS-2$
+			}
+		}
+		return "Execution tree occurrence count differs: before=" + before.size() //$NON-NLS-1$
+				+ ", after=" + after.size(); //$NON-NLS-1$
+	}
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/api/ExecutionTreeSnapshot.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/api/ExecutionTreeSnapshot.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.api;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Immutable framework-neutral snapshot of one completed execution tree.
+ *
+ * <p>The model deliberately contains no JUnit or Eclipse launch types. Adapters
+ * assign stable semantic identities to containers and tests while retaining
+ * optional display names and attributes for diagnostics. Child order and
+ * duplicate occurrences are preserved, so ordering and multiplicity remain
+ * observable migration contracts.</p>
+ */
+public record ExecutionTreeSnapshot(List<Node> roots, boolean successful) {
+
+	/** Creates a defensive immutable snapshot. */
+	public ExecutionTreeSnapshot {
+		roots= immutableNodes(roots);
+	}
+
+	/** Returns whether no execution element was captured. */
+	public boolean isEmpty() {
+		return roots.isEmpty();
+	}
+
+	/** Stable execution element kinds. */
+	public enum NodeKind {
+		CONTAINER,
+		TEST,
+		OTHER
+	}
+
+	/**
+	 * One immutable execution element.
+	 *
+	 * @param kind semantic element kind
+	 * @param identity stable comparison identity supplied by the adapter
+	 * @param displayName optional framework display name, normalized to an empty string
+	 * @param result optional result token, normalized to an empty string
+	 * @param attributes immutable adapter-defined diagnostic attributes
+	 * @param children ordered child occurrences
+	 */
+	public record Node(NodeKind kind, String identity, String displayName, String result,
+			Map<String, String> attributes, List<Node> children) {
+
+		/** Creates a defensive immutable node. */
+		public Node {
+			kind= Objects.requireNonNull(kind);
+			identity= requireText(identity, "Execution node identity"); //$NON-NLS-1$
+			displayName= displayName == null ? "" : displayName; //$NON-NLS-1$
+			result= result == null ? "" : result; //$NON-NLS-1$
+			attributes= immutableAttributes(attributes);
+			children= immutableNodes(children);
+			if (kind == NodeKind.TEST && !children.isEmpty()) {
+				throw new IllegalArgumentException("Execution test nodes cannot contain children"); //$NON-NLS-1$
+			}
+		}
+
+		/** Creates a container node without attributes. */
+		public static Node container(String identity, String displayName, String result, List<Node> children) {
+			return new Node(NodeKind.CONTAINER, identity, displayName, result, Map.of(), children);
+		}
+
+		/** Creates a test node without attributes. */
+		public static Node test(String identity, String displayName, String result) {
+			return new Node(NodeKind.TEST, identity, displayName, result, Map.of(), List.of());
+		}
+
+		/** Creates an adapter-specific node. */
+		public static Node other(String identity, String displayName, String result,
+				Map<String, String> attributes, List<Node> children) {
+			return new Node(NodeKind.OTHER, identity, displayName, result, attributes, children);
+		}
+	}
+
+	private static List<Node> immutableNodes(List<Node> nodes) {
+		if (nodes == null || nodes.isEmpty()) {
+			return List.of();
+		}
+		return nodes.stream().map(Objects::requireNonNull).toList();
+	}
+
+	private static Map<String, String> immutableAttributes(Map<String, String> attributes) {
+		if (attributes == null || attributes.isEmpty()) {
+			return Map.of();
+		}
+		Map<String, String> copy= new LinkedHashMap<>();
+		attributes.forEach((key, value) -> copy.put(requireText(key, "Execution attribute name"), //$NON-NLS-1$
+				Objects.requireNonNull(value)));
+		return Map.copyOf(copy);
+	}
+
+	private static String requireText(String value, String label) {
+		if (value == null || value.isBlank()) {
+			throw new IllegalArgumentException(label + " must not be blank"); //$NON-NLS-1$
+		}
+		return value;
+	}
+}

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/ExecutionTreeComparatorTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/test/ExecutionTreeComparatorTest.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.sandbox.jdt.triggerpattern.api.ExecutionTreeComparator;
+import org.sandbox.jdt.triggerpattern.api.ExecutionTreeComparator.Comparison;
+import org.sandbox.jdt.triggerpattern.api.ExecutionTreeComparator.Policy;
+import org.sandbox.jdt.triggerpattern.api.ExecutionTreeSnapshot;
+import org.sandbox.jdt.triggerpattern.api.ExecutionTreeSnapshot.Node;
+import org.sandbox.jdt.triggerpattern.api.ExecutionTreeSnapshot.NodeKind;
+
+/** Contract tests for execution-tree equivalence policies. */
+public class ExecutionTreeComparatorTest {
+
+	@Test
+	public void strictComparisonPreservesStructureOrderAndDuplicateOccurrences() {
+		ExecutionTreeSnapshot before= snapshot(container("suite", //$NON-NLS-1$
+				test("Sample#first"), test("Sample#first"), test("Sample#second"))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		ExecutionTreeSnapshot same= snapshot(container("suite", //$NON-NLS-1$
+				test("Sample#first"), test("Sample#first"), test("Sample#second"))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		ExecutionTreeSnapshot reordered= snapshot(container("suite", //$NON-NLS-1$
+				test("Sample#second"), test("Sample#first"), test("Sample#first"))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
+		assertTrue(compare(before, same, Policy.strict()).equivalent());
+		assertFalse(compare(before, reordered, Policy.strict()).equivalent());
+		assertTrue(compare(before, reordered, Policy.leafMultiset()).equivalent());
+	}
+
+	@Test
+	public void wrapperRelaxationIsExplicitAndDoesNotHideLeafChanges() {
+		ExecutionTreeSnapshot legacy= snapshot(container("legacy-suite", //$NON-NLS-1$
+				container("compliance-21", test("Sample#test")))); //$NON-NLS-1$ //$NON-NLS-2$
+		ExecutionTreeSnapshot migrated= snapshot(container("jupiter-engine", //$NON-NLS-1$
+				container("dynamic-container", test("Sample#test")))); //$NON-NLS-1$ //$NON-NLS-2$
+		ExecutionTreeSnapshot changed= snapshot(container("jupiter-engine", //$NON-NLS-1$
+				container("dynamic-container", test("Sample#other")))); //$NON-NLS-1$ //$NON-NLS-2$
+
+		assertFalse(compare(legacy, migrated, Policy.strict()).equivalent());
+		assertTrue(compare(legacy, migrated, Policy.sameShape()).equivalent());
+		assertTrue(compare(legacy, migrated, Policy.leavesInOrder()).equivalent());
+		assertFalse(compare(legacy, changed, Policy.leavesInOrder()).equivalent());
+	}
+
+	@Test
+	public void unorderedLeafComparisonStillRequiresExactMultiplicity() {
+		ExecutionTreeSnapshot before= snapshot(container("suite", //$NON-NLS-1$
+				test("Sample#first"), test("Sample#first"), test("Sample#second"))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		ExecutionTreeSnapshot after= snapshot(container("suite", //$NON-NLS-1$
+				test("Sample#first"), test("Sample#second"), test("Sample#second"))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
+		Comparison comparison= compare(before, after, Policy.leafMultiset());
+		assertFalse(comparison.equivalent());
+		assertFalse(comparison.difference().isBlank());
+	}
+
+	@Test
+	public void resultAttributesAndSuccessfulExecutionArePolicyControlled() {
+		Node beforeTest= new Node(NodeKind.TEST, "Sample#test", "test", "OK", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+				Map.of("matrix", "21"), List.of()); //$NON-NLS-1$ //$NON-NLS-2$
+		Node failedTest= new Node(NodeKind.TEST, "Sample#test", "test", "FAILURE", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+				Map.of("matrix", "21"), List.of()); //$NON-NLS-1$ //$NON-NLS-2$
+		Node changedAttribute= new Node(NodeKind.TEST, "Sample#test", "test", "OK", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+				Map.of("matrix", "17"), List.of()); //$NON-NLS-1$ //$NON-NLS-2$
+
+		assertFalse(compare(snapshot(beforeTest), snapshot(failedTest), Policy.strict()).equivalent());
+		assertTrue(compare(snapshot(beforeTest), snapshot(failedTest),
+				Policy.strict().withResults(false)).equivalent());
+		assertFalse(compare(snapshot(beforeTest), snapshot(changedAttribute), Policy.strict()).equivalent());
+		assertTrue(compare(snapshot(beforeTest), snapshot(changedAttribute),
+				Policy.strict().withAttributes(false)).equivalent());
+
+		ExecutionTreeSnapshot unsuccessful= new ExecutionTreeSnapshot(List.of(beforeTest), false);
+		assertFalse(compare(snapshot(beforeTest), unsuccessful, Policy.strict()).equivalent());
+		assertTrue(compare(snapshot(beforeTest), unsuccessful,
+				Policy.strict().requiringSuccessful(false)).equivalent());
+	}
+
+	@Test
+	public void testNodesCannotContainChildren() {
+		assertThrows(IllegalArgumentException.class, () -> new Node(NodeKind.TEST, "Sample#test", //$NON-NLS-1$
+				"test", "OK", Map.of(), List.of(test("nested")))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+	}
+
+	private static Comparison compare(ExecutionTreeSnapshot before, ExecutionTreeSnapshot after,
+			Policy policy) {
+		return ExecutionTreeComparator.compare(before, after, policy);
+	}
+
+	private static ExecutionTreeSnapshot snapshot(Node... roots) {
+		return new ExecutionTreeSnapshot(List.of(roots), true);
+	}
+
+	private static Node container(String identity, Node... children) {
+		return Node.container(identity, identity, "OK", List.of(children)); //$NON-NLS-1$
+	}
+
+	private static Node test(String identity) {
+		return Node.test(identity, identity, "OK"); //$NON-NLS-1$
+	}
+}

--- a/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/JUnit3CoordinatedHierarchyMigrationTest.java
+++ b/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/JUnit3CoordinatedHierarchyMigrationTest.java
@@ -29,10 +29,12 @@ import org.eclipse.jdt.junit.JUnitCore;
 
 import org.sandbox.jdt.internal.corext.fix.multifile.JUnitTestTypeInventory;
 import org.sandbox.jdt.internal.corext.fix2.MYCleanUpConstants;
+import org.sandbox.jdt.triggerpattern.api.ExecutionTreeComparator;
+import org.sandbox.jdt.triggerpattern.api.ExecutionTreeComparator.Comparison;
+import org.sandbox.jdt.triggerpattern.api.ExecutionTreeComparator.Policy;
+import org.sandbox.jdt.triggerpattern.api.ExecutionTreeSnapshot;
 import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
 import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava17;
-
-import org.eclipse.jdt.ui.tests.quickfix.Java8.JUnitRuntimeTestTree.Snapshot;
 
 /** End-to-end rewrite contract for ordinary closed JUnit 3 hierarchies. */
 public class JUnit3CoordinatedHierarchyMigrationTest {
@@ -83,8 +85,8 @@ public class JUnit3CoordinatedHierarchyMigrationTest {
 		IType launchTarget= concrete.findPrimaryType();
 		assertNotNull(launchTarget);
 		JUnitTestTypeInventory before= JUnitTestTypeInventory.capture(context.getJavaProject(), null);
-		Snapshot runtimeBefore= JUnitRuntimeTestTree.capture(launchTarget);
-		assertTrue(runtimeBefore.successful(), () -> "JUnit 3 baseline failed: " + runtimeBefore.entries()); //$NON-NLS-1$
+		ExecutionTreeSnapshot runtimeBefore= JUnitRuntimeTestTree.capture(launchTarget);
+		assertTrue(runtimeBefore.successful(), () -> "JUnit 3 baseline failed: " + runtimeBefore.roots()); //$NON-NLS-1$
 		enableMigration();
 		context.assertRefactoringResultAsExpectedNormalizingWhitespace(
 				new ICompilationUnit[] { base, concrete }, new String[] {
@@ -166,8 +168,8 @@ public class JUnit3CoordinatedHierarchyMigrationTest {
 		IType launchTarget= concrete.findPrimaryType();
 		assertNotNull(launchTarget);
 		JUnitTestTypeInventory before= JUnitTestTypeInventory.capture(context.getJavaProject(), null);
-		Snapshot runtimeBefore= JUnitRuntimeTestTree.capture(launchTarget);
-		assertTrue(runtimeBefore.successful(), () -> "JUnit 3 baseline failed: " + runtimeBefore.entries()); //$NON-NLS-1$
+		ExecutionTreeSnapshot runtimeBefore= JUnitRuntimeTestTree.capture(launchTarget);
+		assertTrue(runtimeBefore.successful(), () -> "JUnit 3 baseline failed: " + runtimeBefore.roots()); //$NON-NLS-1$
 		enableMigration();
 		context.assertRefactoringResultAsExpectedNormalizingWhitespace(
 				new ICompilationUnit[] { base, middle, concrete }, new String[] {
@@ -228,10 +230,10 @@ public class JUnit3CoordinatedHierarchyMigrationTest {
 				"The configured JDT JUnit finder must expose the same test types after migration."); //$NON-NLS-1$
 	}
 
-	private void assertRuntimeTreeUnchanged(Snapshot before, IType launchTarget) throws CoreException {
-		Snapshot after= JUnitRuntimeTestTree.capture(launchTarget);
-		assertTrue(after.successful(), () -> "Migrated Jupiter run failed: " + after.entries()); //$NON-NLS-1$
-		assertEquals(before.entries(), after.entries(),
-				"The same JDT JUnit launch must preserve suite nesting, test identity, order and multiplicity."); //$NON-NLS-1$
+	private void assertRuntimeTreeUnchanged(ExecutionTreeSnapshot before, IType launchTarget)
+			throws CoreException {
+		ExecutionTreeSnapshot after= JUnitRuntimeTestTree.capture(launchTarget);
+		Comparison comparison= ExecutionTreeComparator.compare(before, after, Policy.strict());
+		assertTrue(comparison.equivalent(), comparison::difference);
 	}
 }

--- a/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/JUnitRuntimeTestTree.java
+++ b/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/JUnitRuntimeTestTree.java
@@ -70,6 +70,7 @@ final class JUnitRuntimeTestTree {
 				} finally {
 					completed.countDown();
 				}
+			}
 		};
 
 		ILaunchConfigurationWorkingCopy configuration= null;

--- a/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/JUnitRuntimeTestTree.java
+++ b/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/JUnitRuntimeTestTree.java
@@ -12,6 +12,7 @@ package org.eclipse.jdt.ui.tests.quickfix.Java8;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -40,6 +41,10 @@ import org.eclipse.jdt.junit.model.ITestElementContainer;
 import org.eclipse.jdt.junit.model.ITestRunSession;
 import org.eclipse.jdt.junit.model.ITestSuiteElement;
 
+import org.sandbox.jdt.triggerpattern.api.ExecutionTreeSnapshot;
+import org.sandbox.jdt.triggerpattern.api.ExecutionTreeSnapshot.Node;
+import org.sandbox.jdt.triggerpattern.api.ExecutionTreeSnapshot.NodeKind;
+
 /** Captures one completed JDT JUnit runtime tree without retaining model elements. */
 final class JUnitRuntimeTestTree {
 
@@ -47,19 +52,13 @@ final class JUnitRuntimeTestTree {
 	private static final String JUNIT5_TEST_KIND_ID= "org.eclipse.jdt.junit.loader.junit5"; //$NON-NLS-1$
 	private static final long SESSION_TIMEOUT_SECONDS= 90;
 
-	record Snapshot(List<String> entries, boolean successful) {
-		Snapshot {
-			entries= List.copyOf(entries);
-		}
-	}
-
 	private JUnitRuntimeTestTree() {
 	}
 
-	static Snapshot capture(IJavaElement launchTarget) throws CoreException {
+	static ExecutionTreeSnapshot capture(IJavaElement launchTarget) throws CoreException {
 		ResourcesPlugin.getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, null);
 		CountDownLatch completed= new CountDownLatch(1);
-		AtomicReference<Snapshot> captured= new AtomicReference<>();
+		AtomicReference<ExecutionTreeSnapshot> captured= new AtomicReference<>();
 		AtomicReference<Throwable> callbackFailure= new AtomicReference<>();
 		TestRunListener listener= new TestRunListener() {
 			@Override
@@ -71,7 +70,6 @@ final class JUnitRuntimeTestTree {
 				} finally {
 					completed.countDown();
 				}
-			}
 		};
 
 		ILaunchConfigurationWorkingCopy configuration= null;
@@ -87,11 +85,11 @@ final class JUnitRuntimeTestTree {
 			if (callbackFailure.get() != null) {
 				throw failure("Cannot snapshot the completed JDT JUnit runtime test tree", callbackFailure.get()); //$NON-NLS-1$
 			}
-			Snapshot result= captured.get();
+			ExecutionTreeSnapshot result= captured.get();
 			if (result == null) {
 				throw failure("The JDT JUnit launch completed without a runtime test tree", null); //$NON-NLS-1$
 			}
-			if (result.entries().isEmpty()) {
+			if (result.isEmpty()) {
 				throw failure("The JDT JUnit runtime test tree contains no test elements", null); //$NON-NLS-1$
 			}
 			return result;
@@ -104,32 +102,50 @@ final class JUnitRuntimeTestTree {
 		}
 	}
 
-	private static Snapshot snapshot(ITestRunSession session) {
-		List<String> entries= new ArrayList<>();
-		appendChildren(session, "", entries); //$NON-NLS-1$
-		return new Snapshot(entries, session.getTestResult(true) == Result.OK);
+	private static ExecutionTreeSnapshot snapshot(ITestRunSession session) {
+		return new ExecutionTreeSnapshot(snapshotChildren(session),
+				session.getTestResult(true) == Result.OK);
 	}
 
-	private static void appendChildren(ITestElementContainer container, String parentPath, List<String> entries) {
-		int occurrence= 0;
+	private static List<Node> snapshotChildren(ITestElementContainer container) {
+		List<Node> children= new ArrayList<>();
 		for (ITestElement child : container.getChildren()) {
-			String identity= identity(child);
-			String path= parentPath + "/" + occurrence++ + ":" + identity; //$NON-NLS-1$ //$NON-NLS-2$
-			entries.add(path + "=" + child.getTestResult(true)); //$NON-NLS-1$
-			if (child instanceof ITestElementContainer childContainer) {
-				appendChildren(childContainer, path, entries);
-			}
+			children.add(snapshotNode(child));
 		}
+		return List.copyOf(children);
+	}
+
+	private static Node snapshotNode(ITestElement element) {
+		String identity= identity(element);
+		String result= String.valueOf(element.getTestResult(true));
+		if (element instanceof ITestCaseElement testCase) {
+			return new Node(NodeKind.TEST, identity, identity, result,
+					Map.of("testClass", text(testCase.getTestClassName()), //$NON-NLS-1$
+							"testMethod", text(testCase.getTestMethodName())), List.of()); //$NON-NLS-1$
+		}
+		if (element instanceof ITestSuiteElement suite) {
+			return new Node(NodeKind.CONTAINER, identity, identity, result,
+					Map.of("suiteType", text(suite.getSuiteTypeName())), snapshotChildren(suite)); //$NON-NLS-1$
+		}
+		List<Node> children= element instanceof ITestElementContainer container
+				? snapshotChildren(container) : List.of();
+		return new Node(NodeKind.OTHER, identity, identity, result,
+				Map.of("modelType", element.getClass().getName()), children); //$NON-NLS-1$
 	}
 
 	private static String identity(ITestElement element) {
 		if (element instanceof ITestCaseElement testCase) {
-			return "test:" + testCase.getTestClassName() + "#" + testCase.getTestMethodName(); //$NON-NLS-1$ //$NON-NLS-2$
+			return "test:" + text(testCase.getTestClassName()) + "#" //$NON-NLS-1$ //$NON-NLS-2$
+					+ text(testCase.getTestMethodName());
 		}
 		if (element instanceof ITestSuiteElement suite) {
-			return "suite:" + suite.getSuiteTypeName(); //$NON-NLS-1$
+			return "suite:" + text(suite.getSuiteTypeName()); //$NON-NLS-1$
 		}
 		return element.getClass().getName();
+	}
+
+	private static String text(String value) {
+		return value == null ? "<unknown>" : value; //$NON-NLS-1$
 	}
 
 	private static void cleanUp(ILaunch launch, ILaunchConfigurationWorkingCopy configuration) {


### PR DESCRIPTION
## Purpose

Migration safety must not be encoded as ad-hoc strings inside one JUnit 3 test. JDT Core custom harnesses and the later JDT UI JUnit 4 migration both need a framework-neutral before/after execution contract that preserves identity, nesting, order, multiplicity and results.

## Generic model

- adds immutable `ExecutionTreeSnapshot` containers and test nodes;
- preserves ordered children and duplicate occurrences;
- carries stable semantic identity, optional display name, result and deterministic attributes;
- rejects test nodes with children and blank identities;
- contains no JUnit, Eclipse launch or project-specific type.

## Explicit comparison policy

`ExecutionTreeComparator` supports explicit policies for:

- strict structure, container identity, order, results and attributes;
- identical shape with different framework container names;
- ordered leaves while ignoring wrappers;
- unordered leaf multisets.

Multiplicity is always exact. There is intentionally no set-only mode that could hide lost or duplicated tests. Successful execution is required by default; result, attribute and display-name comparison can only be relaxed explicitly.

## JDT adapter

- refactors the existing completed JDT JUnit runtime-tree recorder to snapshot the generic model without retaining JDT model elements;
- records suite/test identities, result tokens and stable diagnostic attributes;
- changes the coordinated JUnit 3 hierarchy regression to use the strict generic comparator.

## Verification

Core tests cover:

- strict order and duplicate preservation;
- explicit wrapper relaxation;
- unordered comparison with exact multiplicity;
- result, attribute and success policies;
- invalid test-tree shapes.

## Clean base

The branch was reconstructed on the squash-merged #1345 `main` and contains exactly the six reviewed oracle/documentation/adapter files. No typed-plan implementation is duplicated in this PR.

The next slice is #1347, a separate registrable structured AST-action channel; actions are not hidden inside invalid Java replacement text.

Refs #1334 and #1217.