### PR TITLE
Add explicit header-only type declaration patterns

### DIFF
--- a/sandbox_common/src/org/sandbox/jdt/triggerpattern/editor/SandboxHintContentAssistProcessor.java
+++ b/sandbox_common/src/org/sandbox/jdt/triggerpattern/editor/SandboxHintContentAssistProcessor.java
@@ -27,11 +27,12 @@ import org.eclipse.jface.text.contentassist.IContextInformation;
 import org.eclipse.jface.text.contentassist.IContextInformationValidator;
 
 import org.sandbox.jdt.triggerpattern.api.HintPredicateDefinition;
+import org.sandbox.jdt.triggerpattern.api.PatternKind;
 import org.sandbox.jdt.triggerpattern.internal.GuardRegistry;
 import org.sandbox.jdt.triggerpattern.internal.HintLanguageVocabulary;
 import org.sandbox.jdt.triggerpattern.internal.HintPredicatePreprocessor;
 
-/** Content assist for directives, guards, predicates and structured actions. */
+/** Content assist for directives, guards, predicates, actions and explicit kinds. */
 public class SandboxHintContentAssistProcessor implements IContentAssistProcessor {
 
 	/** Pure proposal description used by UI code and PDE unit tests. */
@@ -47,16 +48,19 @@ public class SandboxHintContentAssistProcessor implements IContentAssistProcesso
 		String source= document.get();
 		boolean predicateGuardContext= isPredicateGuardContext(source, replacementOffset);
 		boolean directiveContext= !predicateGuardContext && isDirectiveContext(source, replacementOffset);
-		boolean actionContext= !directiveContext && !predicateGuardContext
+		boolean patternKindContext= !directiveContext && !predicateGuardContext
+				&& isPatternKindContext(source, replacementOffset);
+		boolean actionContext= !directiveContext && !predicateGuardContext && !patternKindContext
 				&& isStructuredActionContext(source, replacementOffset);
-		if (!directiveContext && !predicateGuardContext && !actionContext
+		if (!directiveContext && !predicateGuardContext && !patternKindContext && !actionContext
 				&& !isGuardContext(source, replacementOffset)) {
 			return new ICompletionProposal[0];
 		}
 
 		String lowerPrefix= prefix.toLowerCase(Locale.ROOT);
 		List<ICompletionProposal> proposals= new ArrayList<>();
-		for (CompletionEntry entry : completionEntries(source, directiveContext, actionContext)) {
+		for (CompletionEntry entry : completionEntries(source, directiveContext, actionContext,
+				patternKindContext)) {
 			if (!entry.name().toLowerCase(Locale.ROOT).startsWith(lowerPrefix)) {
 				continue;
 			}
@@ -68,11 +72,16 @@ public class SandboxHintContentAssistProcessor implements IContentAssistProcesso
 	}
 
 	static List<CompletionEntry> completionEntries(String source, boolean directiveContext) {
-		return completionEntries(source, directiveContext, false);
+		return completionEntries(source, directiveContext, false, false);
 	}
 
 	static List<CompletionEntry> completionEntries(String source, boolean directiveContext,
 			boolean actionContext) {
+		return completionEntries(source, directiveContext, actionContext, false);
+	}
+
+	static List<CompletionEntry> completionEntries(String source, boolean directiveContext,
+			boolean actionContext, boolean patternKindContext) {
 		if (directiveContext) {
 			return HintLanguageVocabulary.directives().stream().map(directive -> {
 				String syntax= directive.syntax();
@@ -81,6 +90,12 @@ public class SandboxHintContentAssistProcessor implements IContentAssistProcesso
 				return new CompletionEntry(directive.name(), replacement, replacement.length(),
 						directive.description() + " — " + directive.syntax()); //$NON-NLS-1$
 			}).toList();
+		}
+		if (patternKindContext) {
+			return java.util.Arrays.stream(PatternKind.values())
+					.map(kind -> new CompletionEntry(kind.name(), kind.name(), kind.name().length(),
+							"Explicit source pattern kind " + kind.name())) //$NON-NLS-1$
+					.toList();
 		}
 		if (actionContext) {
 			return HintLanguageVocabulary.actions().stream().map(action -> {
@@ -174,6 +189,18 @@ public class SandboxHintContentAssistProcessor implements IContentAssistProcesso
 		}
 		int colon= source.indexOf(':', parametersEnd + 1);
 		return colon >= 0 && colon < safeOffset;
+	}
+
+	static boolean isPatternKindContext(String source, int offset) {
+		int safeOffset= Math.max(0, Math.min(offset, source.length()));
+		int lineStart= source.lastIndexOf('\n', Math.max(0, safeOffset - 1)) + 1;
+		String prefix= source.substring(lineStart, safeOffset).stripLeading();
+		if (!prefix.startsWith("@kind:")) { //$NON-NLS-1$
+			return false;
+		}
+		String valuePrefix= prefix.substring(6).trim();
+		return valuePrefix.isEmpty() || valuePrefix.chars()
+				.allMatch(character -> Character.isJavaIdentifierPart(character));
 	}
 
 	static boolean isStructuredActionContext(String source, int offset) {

--- a/sandbox_common/src/org/sandbox/jdt/triggerpattern/mining/analysis/RuleInferenceEngine.java
+++ b/sandbox_common/src/org/sandbox/jdt/triggerpattern/mining/analysis/RuleInferenceEngine.java
@@ -27,6 +27,7 @@ import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTParser;
 import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.sandbox.jdt.triggerpattern.api.HintFile;
 import org.sandbox.jdt.triggerpattern.api.ImportDirective;
 import org.sandbox.jdt.triggerpattern.api.Pattern;
@@ -74,7 +75,6 @@ public class RuleInferenceEngine {
 			return Optional.empty();
 		}
 
-		// Extract the relevant AST node for the kind
 		ASTNode beforeNode = extractNode(cuBefore, kind);
 		ASTNode afterNode = extractNode(cuAfter, kind);
 
@@ -83,7 +83,6 @@ public class RuleInferenceEngine {
 		}
 
 		AstDiff diff = diffAnalyzer.computeDiff(beforeNode, afterNode);
-
 		ImportDirective importDirective = importAnalyzer.analyzeImportChanges(cuBefore, cuAfter);
 
 		InferredRule rule = generalizer.generalize(diff, codeBefore, codeAfter, kind, importDirective);
@@ -244,8 +243,6 @@ public class RuleInferenceEngine {
 		return hintFile;
 	}
 
-	// ---- helpers ----
-
 	private static CompilationUnit parseCompilationUnit(String source) {
 		ASTParser parser = ASTParser.newParser(AST.getJLSLatest());
 		parser.setSource(source.toCharArray());
@@ -274,6 +271,7 @@ public class RuleInferenceEngine {
 		case METHOD_DECLARATION -> "class _Infer { " + snippet + " }"; //$NON-NLS-1$ //$NON-NLS-2$
 		case BLOCK -> "class _Infer { void _m() " + snippet + " }"; //$NON-NLS-1$ //$NON-NLS-2$
 		case STATEMENT_SEQUENCE -> "class _Infer { void _m() { " + snippet + " } }"; //$NON-NLS-1$ //$NON-NLS-2$
+		case TYPE_DECLARATION -> snippet;
 		};
 	}
 
@@ -282,8 +280,16 @@ public class RuleInferenceEngine {
 		if (cu.types().isEmpty()) {
 			return null;
 		}
-		org.eclipse.jdt.core.dom.TypeDeclaration type =
-				(org.eclipse.jdt.core.dom.TypeDeclaration) cu.types().get(0);
+		Object firstType = cu.types().get(0);
+		if (!(firstType instanceof ASTNode topLevelType)) {
+			return null;
+		}
+		if (kind == PatternKind.TYPE_DECLARATION) {
+			return topLevelType;
+		}
+		if (!(topLevelType instanceof TypeDeclaration type)) {
+			return null;
+		}
 
 		return switch (kind) {
 		case EXPRESSION, CONSTRUCTOR -> {
@@ -362,6 +368,7 @@ public class RuleInferenceEngine {
 			}
 			yield type.getMethods()[0].getBody();
 		}
+		case TYPE_DECLARATION -> topLevelType;
 		};
 	}
 }

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/api/PatternIndex.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/api/PatternIndex.java
@@ -40,7 +40,23 @@ import org.sandbox.jdt.triggerpattern.internal.PlaceholderAstMatcher;
 import org.sandbox.jdt.triggerpattern.internal.TypeDeclarationHeaderMatcher;
 import org.sandbox.jdt.triggerpattern.internal.TypeDeclarationPatternParser;
 
-/** Indexes transformation rules by pattern kind for one-pass AST matching. */
+/**
+ * Indexes transformation rules by their {@link PatternKind} for efficient
+ * batch matching against a compilation unit.
+ *
+ * <p>Instead of traversing the AST once per rule (O(N*M) where N is the number
+ * of AST nodes and M is the number of rules), a {@code PatternIndex} groups
+ * rules by their pattern kind and traverses the AST only once. Each visited
+ * node is checked against only the rules of the matching kind.</p>
+ *
+ * <h2>Usage</h2>
+ * <pre>
+ * PatternIndex index = new PatternIndex(hintFile.getRules());
+ * Map&lt;TransformationRule, List&lt;Match&gt;&gt; results = index.findAllMatches(cu);
+ * </pre>
+ *
+ * @since 1.3.3
+ */
 public final class PatternIndex {
 
 	private final Map<PatternKind, List<IndexEntry>> rulesByKind;
@@ -48,60 +64,112 @@ public final class PatternIndex {
 	private final TypeDeclarationPatternParser typeParser;
 	private boolean caseInsensitive;
 
+	/**
+	 * Creates a new pattern index from a list of transformation rules.
+	 *
+	 * <p>Pre-parses all source patterns and groups them by kind for efficient
+	 * batch matching. Explicit type declarations use a dedicated header parser
+	 * so ordinary expression and statement parsing remains unchanged.</p>
+	 *
+	 * @param rules the rules to index
+	 */
 	public PatternIndex(List<TransformationRule> rules) {
-		this.parser= new PatternParser();
-		this.typeParser= new TypeDeclarationPatternParser();
-		this.rulesByKind= buildIndex(rules);
+		this.parser = new PatternParser();
+		this.typeParser = new TypeDeclarationPatternParser();
+		this.rulesByKind = buildIndex(rules);
 	}
 
+	/**
+	 * Sets whether string literal matching should be case-insensitive.
+	 *
+	 * @param caseInsensitive {@code true} to enable case-insensitive matching
+	 * @since 1.3.8
+	 */
 	public void setCaseInsensitive(boolean caseInsensitive) {
-		this.caseInsensitive= caseInsensitive;
+		this.caseInsensitive = caseInsensitive;
 	}
 
 	private Map<PatternKind, List<IndexEntry>> buildIndex(List<TransformationRule> rules) {
-		Map<PatternKind, List<IndexEntry>> index= new EnumMap<>(PatternKind.class);
+		Map<PatternKind, List<IndexEntry>> index = new EnumMap<>(PatternKind.class);
+
 		for (TransformationRule rule : rules) {
-			Pattern sourcePattern= rule.sourcePattern();
-			ASTNode patternNode= sourcePattern.getKind() == PatternKind.TYPE_DECLARATION
-					? typeParser.parse(sourcePattern.getValue()) : parser.parse(sourcePattern);
+			Pattern sourcePattern = rule.sourcePattern();
+			ASTNode patternNode = sourcePattern.getKind() == PatternKind.TYPE_DECLARATION
+					? typeParser.parse(sourcePattern.getValue())
+					: parser.parse(sourcePattern);
 			if (patternNode == null) {
 				continue;
 			}
-			PatternKind kind= sourcePattern.getKind();
+
+			PatternKind kind = sourcePattern.getKind();
 			index.computeIfAbsent(kind, ignored -> new ArrayList<>())
 					.add(new IndexEntry(rule, sourcePattern, patternNode));
 		}
+
 		return index;
 	}
 
+	/**
+	 * Returns the number of indexed rules.
+	 *
+	 * @return the total number of rules in the index
+	 */
 	public int size() {
 		return rulesByKind.values().stream().mapToInt(List::size).sum();
 	}
 
+	/**
+	 * Returns the number of distinct pattern kinds in the index.
+	 *
+	 * @return the number of distinct pattern kinds
+	 */
 	public int kindCount() {
 		return rulesByKind.size();
 	}
 
+	/**
+	 * Returns the rules for a specific pattern kind.
+	 *
+	 * @param kind the pattern kind
+	 * @return unmodifiable list of transformation rules for the given kind
+	 */
 	public List<TransformationRule> getRulesForKind(PatternKind kind) {
-		List<IndexEntry> entries= rulesByKind.getOrDefault(kind, Collections.emptyList());
+		List<IndexEntry> entries = rulesByKind.getOrDefault(kind, Collections.emptyList());
 		return entries.stream().map(IndexEntry::rule).toList();
 	}
 
+	/**
+	 * Finds all matches for all indexed rules in a single AST traversal.
+	 *
+	 * <p>This is significantly more efficient than calling
+	 * {@link TriggerPatternEngine#findMatches(CompilationUnit, Pattern)} once per
+	 * rule, because the AST is traversed only once.</p>
+	 *
+	 * @param cu the compilation unit to search
+	 * @return map from each rule that had matches to its list of matches
+	 */
 	public Map<TransformationRule, List<Match>> findAllMatches(CompilationUnit cu) {
 		if (cu == null || rulesByKind.isEmpty()) {
 			return Collections.emptyMap();
 		}
-		Map<TransformationRule, List<Match>> results= new java.util.LinkedHashMap<>();
+
+		Map<TransformationRule, List<Match>> results = new java.util.LinkedHashMap<>();
+
 		cu.accept(new ASTVisitor() {
 			@Override
 			public void preVisit(ASTNode node) {
 				checkNodeAgainstIndex(node, results);
 			}
 		});
+
 		return results;
 	}
 
+	/**
+	 * Checks a single AST node against all applicable indexed patterns.
+	 */
 	private void checkNodeAgainstIndex(ASTNode node, Map<TransformationRule, List<Match>> results) {
+		// Determine which pattern kinds could match this node type
 		if (node instanceof Expression) {
 			matchAgainstKind(node, PatternKind.EXPRESSION, results);
 		}
@@ -138,56 +206,68 @@ public final class PatternIndex {
 		}
 	}
 
+	/**
+	 * Attempts to match a node against all rules of the given pattern kind.
+	 */
 	private void matchAgainstKind(ASTNode node, PatternKind kind,
 			Map<TransformationRule, List<Match>> results) {
-		List<IndexEntry> entries= rulesByKind.get(kind);
+		List<IndexEntry> entries = rulesByKind.get(kind);
 		if (entries == null || entries.isEmpty()) {
 			return;
 		}
+
 		for (IndexEntry entry : entries) {
-			PlaceholderAstMatcher matcher= kind == PatternKind.TYPE_DECLARATION
-					? new TypeDeclarationHeaderMatcher() : new FqnAwarePlaceholderAstMatcher();
+			PlaceholderAstMatcher matcher = kind == PatternKind.TYPE_DECLARATION
+					? new TypeDeclarationHeaderMatcher()
+					: new FqnAwarePlaceholderAstMatcher();
 			matcher.setCaseInsensitive(caseInsensitive);
 			if (entry.patternNode().subtreeMatch(matcher, node)) {
-				Match match= new Match(node, matcher.getBindings(),
+				Match match = new Match(node, matcher.getBindings(),
 						node.getStartPosition(), node.getLength());
 				results.computeIfAbsent(entry.rule(), ignored -> new ArrayList<>()).add(match);
 			}
 		}
 	}
 
+	/**
+	 * Attempts statement sequence matching for all STATEMENT_SEQUENCE rules.
+	 */
 	private void matchStatementSequences(Block block,
 			Map<TransformationRule, List<Match>> results) {
-		List<IndexEntry> entries= rulesByKind.get(PatternKind.STATEMENT_SEQUENCE);
+		List<IndexEntry> entries = rulesByKind.get(PatternKind.STATEMENT_SEQUENCE);
 		if (entries == null || entries.isEmpty()) {
 			return;
 		}
+
 		@SuppressWarnings("unchecked")
-		List<Statement> statements= block.statements();
+		List<Statement> statements = block.statements();
+
 		for (IndexEntry entry : entries) {
-			ASTNode patternNode= entry.patternNode();
+			ASTNode patternNode = entry.patternNode();
 			if (!(patternNode instanceof Block patternBlock)) {
 				continue;
 			}
 			@SuppressWarnings("unchecked")
-			List<Statement> patternStatements= patternBlock.statements();
-			int patternSize= patternStatements.size();
+			List<Statement> patternStatements = patternBlock.statements();
+			int patternSize = patternStatements.size();
 			if (patternSize == 0 || patternSize > statements.size()) {
 				continue;
 			}
-			for (int start= 0; start <= statements.size() - patternSize; start++) {
-				Block syntheticBlock= block.getAST().newBlock();
-				for (int index= 0; index < patternSize; index++) {
+
+			for (int start = 0; start <= statements.size() - patternSize; start++) {
+				Block syntheticBlock = block.getAST().newBlock();
+				for (int index = 0; index < patternSize; index++) {
 					syntheticBlock.statements().add(ASTNode.copySubtree(block.getAST(),
 							statements.get(start + index)));
 				}
-				PlaceholderAstMatcher matcher= new FqnAwarePlaceholderAstMatcher();
+
+				PlaceholderAstMatcher matcher = new FqnAwarePlaceholderAstMatcher();
 				matcher.setCaseInsensitive(caseInsensitive);
 				if (patternBlock.subtreeMatch(matcher, syntheticBlock)) {
-					int offset= statements.get(start).getStartPosition();
-					Statement last= statements.get(start + patternSize - 1);
-					int length= last.getStartPosition() + last.getLength() - offset;
-					Match match= new Match(block, matcher.getBindings(), offset, length);
+					int offset = statements.get(start).getStartPosition();
+					Statement last = statements.get(start + patternSize - 1);
+					int length = last.getStartPosition() + last.getLength() - offset;
+					Match match = new Match(block, matcher.getBindings(), offset, length);
 					results.computeIfAbsent(entry.rule(), ignored -> new ArrayList<>()).add(match);
 				}
 			}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/api/PatternIndex.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/api/PatternIndex.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
 import org.eclipse.jdt.core.dom.Annotation;
 import org.eclipse.jdt.core.dom.Block;
 import org.eclipse.jdt.core.dom.ClassInstanceCreation;
@@ -32,135 +33,75 @@ import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.core.dom.Statement;
 import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
+
 import org.sandbox.jdt.triggerpattern.internal.FqnAwarePlaceholderAstMatcher;
 import org.sandbox.jdt.triggerpattern.internal.PatternParser;
 import org.sandbox.jdt.triggerpattern.internal.PlaceholderAstMatcher;
+import org.sandbox.jdt.triggerpattern.internal.TypeDeclarationHeaderMatcher;
+import org.sandbox.jdt.triggerpattern.internal.TypeDeclarationPatternParser;
 
-/**
- * Indexes transformation rules by their {@link PatternKind} for efficient
- * batch matching against a compilation unit.
- *
- * <p>Instead of traversing the AST once per rule (O(N*M) where N is the number
- * of AST nodes and M is the number of rules), a {@code PatternIndex} groups
- * rules by their pattern kind and traverses the AST only once. Each visited
- * node is checked against only the rules of the matching kind.</p>
- *
- * <h2>Usage</h2>
- * <pre>
- * PatternIndex index = new PatternIndex(hintFile.getRules());
- * Map&lt;TransformationRule, List&lt;Match&gt;&gt; results = index.findAllMatches(cu);
- * </pre>
- *
- * @since 1.3.3
- */
+/** Indexes transformation rules by pattern kind for one-pass AST matching. */
 public final class PatternIndex {
 
 	private final Map<PatternKind, List<IndexEntry>> rulesByKind;
 	private final PatternParser parser;
+	private final TypeDeclarationPatternParser typeParser;
 	private boolean caseInsensitive;
 
-	/**
-	 * Creates a new pattern index from a list of transformation rules.
-	 *
-	 * <p>Pre-parses all source patterns and groups them by kind for efficient
-	 * batch matching.</p>
-	 *
-	 * @param rules the rules to index
-	 */
 	public PatternIndex(List<TransformationRule> rules) {
-		this.parser = new PatternParser();
-		this.rulesByKind = buildIndex(rules);
+		this.parser= new PatternParser();
+		this.typeParser= new TypeDeclarationPatternParser();
+		this.rulesByKind= buildIndex(rules);
 	}
 
-	/**
-	 * Sets whether string literal matching should be case-insensitive.
-	 *
-	 * @param caseInsensitive {@code true} to enable case-insensitive matching
-	 * @since 1.3.8
-	 */
 	public void setCaseInsensitive(boolean caseInsensitive) {
-		this.caseInsensitive = caseInsensitive;
+		this.caseInsensitive= caseInsensitive;
 	}
 
 	private Map<PatternKind, List<IndexEntry>> buildIndex(List<TransformationRule> rules) {
-		Map<PatternKind, List<IndexEntry>> index = new EnumMap<>(PatternKind.class);
-
+		Map<PatternKind, List<IndexEntry>> index= new EnumMap<>(PatternKind.class);
 		for (TransformationRule rule : rules) {
-			Pattern sourcePattern = rule.sourcePattern();
-			ASTNode patternNode = parser.parse(sourcePattern);
+			Pattern sourcePattern= rule.sourcePattern();
+			ASTNode patternNode= sourcePattern.getKind() == PatternKind.TYPE_DECLARATION
+					? typeParser.parse(sourcePattern.getValue()) : parser.parse(sourcePattern);
 			if (patternNode == null) {
 				continue;
 			}
-
-			PatternKind kind = sourcePattern.getKind();
-			index.computeIfAbsent(kind, k -> new ArrayList<>())
+			PatternKind kind= sourcePattern.getKind();
+			index.computeIfAbsent(kind, ignored -> new ArrayList<>())
 					.add(new IndexEntry(rule, sourcePattern, patternNode));
 		}
-
 		return index;
 	}
 
-	/**
-	 * Returns the number of indexed rules.
-	 *
-	 * @return the total number of rules in the index
-	 */
 	public int size() {
 		return rulesByKind.values().stream().mapToInt(List::size).sum();
 	}
 
-	/**
-	 * Returns the number of distinct pattern kinds in the index.
-	 *
-	 * @return the number of distinct pattern kinds
-	 */
 	public int kindCount() {
 		return rulesByKind.size();
 	}
 
-	/**
-	 * Returns the rules for a specific pattern kind.
-	 *
-	 * @param kind the pattern kind
-	 * @return unmodifiable list of transformation rules for the given kind
-	 */
 	public List<TransformationRule> getRulesForKind(PatternKind kind) {
-		List<IndexEntry> entries = rulesByKind.getOrDefault(kind, Collections.emptyList());
+		List<IndexEntry> entries= rulesByKind.getOrDefault(kind, Collections.emptyList());
 		return entries.stream().map(IndexEntry::rule).toList();
 	}
 
-	/**
-	 * Finds all matches for all indexed rules in a single AST traversal.
-	 *
-	 * <p>This is significantly more efficient than calling
-	 * {@link TriggerPatternEngine#findMatches(CompilationUnit, Pattern)} once per
-	 * rule, because the AST is traversed only once.</p>
-	 *
-	 * @param cu the compilation unit to search
-	 * @return map from each rule that had matches to its list of matches
-	 */
 	public Map<TransformationRule, List<Match>> findAllMatches(CompilationUnit cu) {
 		if (cu == null || rulesByKind.isEmpty()) {
 			return Collections.emptyMap();
 		}
-
-		Map<TransformationRule, List<Match>> results = new java.util.LinkedHashMap<>();
-
+		Map<TransformationRule, List<Match>> results= new java.util.LinkedHashMap<>();
 		cu.accept(new ASTVisitor() {
 			@Override
 			public void preVisit(ASTNode node) {
 				checkNodeAgainstIndex(node, results);
 			}
 		});
-
 		return results;
 	}
 
-	/**
-	 * Checks a single AST node against all applicable indexed patterns.
-	 */
 	private void checkNodeAgainstIndex(ASTNode node, Map<TransformationRule, List<Match>> results) {
-		// Determine which pattern kinds could match this node type
 		if (node instanceof Expression) {
 			matchAgainstKind(node, PatternKind.EXPRESSION, results);
 		}
@@ -185,6 +126,9 @@ public final class PatternIndex {
 		if (node instanceof MethodDeclaration) {
 			matchAgainstKind(node, PatternKind.METHOD_DECLARATION, results);
 		}
+		if (node instanceof AbstractTypeDeclaration) {
+			matchAgainstKind(node, PatternKind.TYPE_DECLARATION, results);
+		}
 		if (node instanceof VariableDeclarationStatement) {
 			matchAgainstKind(node, PatternKind.DECLARATION, results);
 		}
@@ -194,66 +138,57 @@ public final class PatternIndex {
 		}
 	}
 
-	/**
-	 * Attempts to match a node against all rules of the given pattern kind.
-	 */
 	private void matchAgainstKind(ASTNode node, PatternKind kind,
 			Map<TransformationRule, List<Match>> results) {
-		List<IndexEntry> entries = rulesByKind.get(kind);
+		List<IndexEntry> entries= rulesByKind.get(kind);
 		if (entries == null || entries.isEmpty()) {
 			return;
 		}
-
 		for (IndexEntry entry : entries) {
-			PlaceholderAstMatcher matcher = new FqnAwarePlaceholderAstMatcher();
+			PlaceholderAstMatcher matcher= kind == PatternKind.TYPE_DECLARATION
+					? new TypeDeclarationHeaderMatcher() : new FqnAwarePlaceholderAstMatcher();
 			matcher.setCaseInsensitive(caseInsensitive);
 			if (entry.patternNode().subtreeMatch(matcher, node)) {
-				Match match = new Match(node, matcher.getBindings(),
+				Match match= new Match(node, matcher.getBindings(),
 						node.getStartPosition(), node.getLength());
-				results.computeIfAbsent(entry.rule(), r -> new ArrayList<>()).add(match);
+				results.computeIfAbsent(entry.rule(), ignored -> new ArrayList<>()).add(match);
 			}
 		}
 	}
 
-	/**
-	 * Attempts statement sequence matching for all STATEMENT_SEQUENCE rules.
-	 */
 	private void matchStatementSequences(Block block,
 			Map<TransformationRule, List<Match>> results) {
-		List<IndexEntry> entries = rulesByKind.get(PatternKind.STATEMENT_SEQUENCE);
+		List<IndexEntry> entries= rulesByKind.get(PatternKind.STATEMENT_SEQUENCE);
 		if (entries == null || entries.isEmpty()) {
 			return;
 		}
-
 		@SuppressWarnings("unchecked")
-		List<Statement> statements = block.statements();
-
+		List<Statement> statements= block.statements();
 		for (IndexEntry entry : entries) {
-			ASTNode patternNode = entry.patternNode();
+			ASTNode patternNode= entry.patternNode();
 			if (!(patternNode instanceof Block patternBlock)) {
 				continue;
 			}
 			@SuppressWarnings("unchecked")
-			List<Statement> patternStatements = patternBlock.statements();
-			int patternSize = patternStatements.size();
+			List<Statement> patternStatements= patternBlock.statements();
+			int patternSize= patternStatements.size();
 			if (patternSize == 0 || patternSize > statements.size()) {
 				continue;
 			}
-
-			for (int start = 0; start <= statements.size() - patternSize; start++) {
-				Block syntheticBlock = block.getAST().newBlock();
-				for (int i = 0; i < patternSize; i++) {
-					syntheticBlock.statements().add(ASTNode.copySubtree(block.getAST(), statements.get(start + i)));
+			for (int start= 0; start <= statements.size() - patternSize; start++) {
+				Block syntheticBlock= block.getAST().newBlock();
+				for (int index= 0; index < patternSize; index++) {
+					syntheticBlock.statements().add(ASTNode.copySubtree(block.getAST(),
+							statements.get(start + index)));
 				}
-
-				PlaceholderAstMatcher matcher = new FqnAwarePlaceholderAstMatcher();
+				PlaceholderAstMatcher matcher= new FqnAwarePlaceholderAstMatcher();
 				matcher.setCaseInsensitive(caseInsensitive);
 				if (patternBlock.subtreeMatch(matcher, syntheticBlock)) {
-					int offset = statements.get(start).getStartPosition();
-					Statement last = statements.get(start + patternSize - 1);
-					int length = last.getStartPosition() + last.getLength() - offset;
-					Match match = new Match(block, matcher.getBindings(), offset, length);
-					results.computeIfAbsent(entry.rule(), r -> new ArrayList<>()).add(match);
+					int offset= statements.get(start).getStartPosition();
+					Statement last= statements.get(start + patternSize - 1);
+					int length= last.getStartPosition() + last.getLength() - offset;
+					Match match= new Match(block, matcher.getBindings(), offset, length);
+					results.computeIfAbsent(entry.rule(), ignored -> new ArrayList<>()).add(match);
 				}
 			}
 		}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/api/PatternKind.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/api/PatternKind.java
@@ -13,36 +13,101 @@
  *******************************************************************************/
 package org.sandbox.jdt.triggerpattern.api;
 
-/** Defines the kinds of AST patterns that can be matched. */
+/**
+ * Defines the kinds of AST patterns that can be matched.
+ *
+ * @since 1.2.2
+ */
 public enum PatternKind {
-	/** Java expression. */
-	EXPRESSION,
-	/** Java statement. */
-	STATEMENT,
-	/** Java annotation. */
-	ANNOTATION,
-	/** Java method invocation. */
-	METHOD_CALL,
-	/** Import declaration. */
-	IMPORT,
-	/** Field declaration. */
-	FIELD,
-	/** Class-instance creation expression. */
-	CONSTRUCTOR,
-	/** Method or constructor declaration. */
-	METHOD_DECLARATION,
 	/**
-	 * Class, interface, enum, record or annotation-type declaration.
+	 * Pattern represents a Java expression (e.g., {@code $x + 1}, {@code obj.method()})
+	 */
+	EXPRESSION,
+
+	/**
+	 * Pattern represents a Java statement (e.g., {@code if ($cond) $then;}, {@code return $x;})
+	 */
+	STATEMENT,
+
+	/**
+	 * Pattern represents a Java annotation (e.g., {@code @Before}, {@code @Test(expected=$ex)})
+	 * @since 1.2.3
+	 */
+	ANNOTATION,
+
+	/**
+	 * Pattern represents a Java method invocation (e.g., {@code Assert.assertEquals($a, $b)})
+	 * @since 1.2.3
+	 */
+	METHOD_CALL,
+
+	/**
+	 * Pattern represents an import declaration (e.g., {@code import org.junit.Assert})
+	 * @since 1.2.3
+	 */
+	IMPORT,
+
+	/**
+	 * Pattern represents a field declaration (e.g., {@code @Rule public TemporaryFolder $name})
+	 * @since 1.2.3
+	 */
+	FIELD,
+
+	/**
+	 * Pattern represents a constructor invocation (e.g., {@code new String($bytes, $enc)})
+	 * @since 1.2.5
+	 */
+	CONSTRUCTOR,
+
+	/**
+	 * Pattern represents a method declaration (e.g., {@code void dispose()}, {@code void $name($params$)})
+	 * @since 1.2.6
+	 */
+	METHOD_DECLARATION,
+
+	/**
+	 * Pattern represents a class, interface, enum, record or annotation-type declaration.
 	 *
-	 * <p>Type patterns are header patterns: an empty pattern body does not require
-	 * the source type to have an empty body. Name, kind and every explicitly
-	 * declared modifier, type parameter or supertype remain constraints.</p>
+	 * <p>Type-declaration patterns describe a header only. An empty pattern body does
+	 * not require the candidate declaration to have an empty body. The declaration
+	 * kind, name and every explicitly declared modifier, type parameter, record
+	 * component or supertype remain constraints.</p>
+	 *
+	 * @since 1.3.3
 	 */
 	TYPE_DECLARATION,
-	/** Complete block. */
+
+	/**
+	 * Pattern represents a block of statements (e.g., {@code { $before$; return $x; }}).
+	 * Used for matching statement sequences with variadic placeholders.
+	 * @since 1.3.2
+	 */
 	BLOCK,
-	/** Consecutive statement sequence. */
+
+	/**
+	 * Pattern represents a sequence of consecutive statements to match within a block
+	 * using a sliding-window approach. Unlike {@link #BLOCK}, which matches the entire
+	 * block, this matches N consecutive statements anywhere within a block.
+	 *
+	 * <p>Example: A two-statement pattern {@code "$T[] $copy = new $T[$len]; System.arraycopy($src, 0, $copy, 0, $len);"}
+	 * would match those two consecutive statements inside any method body.</p>
+	 *
+	 * @since 1.3.2
+	 */
 	STATEMENT_SEQUENCE,
-	/** Local variable declaration statement. */
+
+	/**
+	 * Pattern represents a local variable declaration statement (e.g.,
+	 * {@code $Type $var = $init;}). Used for matching variable declarations
+	 * and applying type-level transformations such as widening to the most
+	 * general type.
+	 *
+	 * <p>Example: A declaration pattern {@code $Type $var = $init;} with
+	 * a {@code canWidenType($var)} guard and a {@code $widestType($var)}
+	 * replacement would widen the declared type to the most general
+	 * supertype/interface that still supports all usages.</p>
+	 *
+	 * @since 1.3.12
+	 */
 	DECLARATION
 }

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/api/PatternKind.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/api/PatternKind.java
@@ -13,89 +13,36 @@
  *******************************************************************************/
 package org.sandbox.jdt.triggerpattern.api;
 
-/**
- * Defines the kinds of AST patterns that can be matched.
- * 
- * @since 1.2.2
- */
+/** Defines the kinds of AST patterns that can be matched. */
 public enum PatternKind {
-	/**
-	 * Pattern represents a Java expression (e.g., {@code $x + 1}, {@code obj.method()})
-	 */
+	/** Java expression. */
 	EXPRESSION,
-	
-	/**
-	 * Pattern represents a Java statement (e.g., {@code if ($cond) $then;}, {@code return $x;})
-	 */
+	/** Java statement. */
 	STATEMENT,
-	
-	/**
-	 * Pattern represents a Java annotation (e.g., {@code @Before}, {@code @Test(expected=$ex)})
-	 * @since 1.2.3
-	 */
+	/** Java annotation. */
 	ANNOTATION,
-	
-	/**
-	 * Pattern represents a Java method invocation (e.g., {@code Assert.assertEquals($a, $b)})
-	 * @since 1.2.3
-	 */
+	/** Java method invocation. */
 	METHOD_CALL,
-	
-	/**
-	 * Pattern represents an import declaration (e.g., {@code import org.junit.Assert})
-	 * @since 1.2.3
-	 */
+	/** Import declaration. */
 	IMPORT,
-	
-	/**
-	 * Pattern represents a field declaration (e.g., {@code @Rule public TemporaryFolder $name})
-	 * @since 1.2.3
-	 */
+	/** Field declaration. */
 	FIELD,
-	
-	/**
-	 * Pattern represents a constructor invocation (e.g., {@code new String($bytes, $enc)})
-	 * @since 1.2.5
-	 */
+	/** Class-instance creation expression. */
 	CONSTRUCTOR,
-	
-	/**
-	 * Pattern represents a method declaration (e.g., {@code void dispose()}, {@code void $name($params$)})
-	 * @since 1.2.6
-	 */
+	/** Method or constructor declaration. */
 	METHOD_DECLARATION,
-	
 	/**
-	 * Pattern represents a block of statements (e.g., {@code { $before$; return $x; }}).
-	 * Used for matching statement sequences with variadic placeholders.
-	 * @since 1.3.2
+	 * Class, interface, enum, record or annotation-type declaration.
+	 *
+	 * <p>Type patterns are header patterns: an empty pattern body does not require
+	 * the source type to have an empty body. Name, kind and every explicitly
+	 * declared modifier, type parameter or supertype remain constraints.</p>
 	 */
+	TYPE_DECLARATION,
+	/** Complete block. */
 	BLOCK,
-	
-	/**
-	 * Pattern represents a sequence of consecutive statements to match within a block
-	 * using a sliding-window approach. Unlike {@link #BLOCK}, which matches the entire
-	 * block, this matches N consecutive statements anywhere within a block.
-	 * 
-	 * <p>Example: A two-statement pattern {@code "$T[] $copy = new $T[$len]; System.arraycopy($src, 0, $copy, 0, $len);"}
-	 * would match those two consecutive statements inside any method body.</p>
-	 * 
-	 * @since 1.3.2
-	 */
+	/** Consecutive statement sequence. */
 	STATEMENT_SEQUENCE,
-
-	/**
-	 * Pattern represents a local variable declaration statement (e.g.,
-	 * {@code $Type $var = $init;}). Used for matching variable declarations
-	 * and applying type-level transformations such as widening to the most
-	 * general type.
-	 *
-	 * <p>Example: A declaration pattern {@code $Type $var = $init;} with
-	 * a {@code canWidenType($var)} guard and a {@code $widestType($var)}
-	 * replacement would widen the declared type to the most general
-	 * supertype/interface that still supports all usages.</p>
-	 *
-	 * @since 1.3.12
-	 */
+	/** Local variable declaration statement. */
 	DECLARATION
 }

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/HintProgramParser.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/HintProgramParser.java
@@ -112,8 +112,10 @@ public final class HintProgramParser {
 		validatePredicateNames(predicates.predicates());
 		HintRuleKindPreprocessor.Result kinds=
 				HintRuleKindPreprocessor.preprocess(predicates.expandedSource());
+		String normalizedTypeSources= HintTypeDeclarationSourcePreprocessor.preprocess(
+				kinds.parserSource(), kinds.kindsByRuleId());
 		HintStructuredActionPreprocessor.Result actions=
-				HintStructuredActionPreprocessor.preprocess(kinds.parserSource(), catalog);
+				HintStructuredActionPreprocessor.preprocess(normalizedTypeSources, catalog);
 		return new PreparedProgram(predicates.predicates(), actions.parserSource(),
 				actions.actionsBySentinel(), kinds.kindsByRuleId());
 	}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/HintProgramParser.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/HintProgramParser.java
@@ -12,11 +12,15 @@ package org.sandbox.jdt.triggerpattern.internal;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.sandbox.jdt.triggerpattern.api.HintFile;
 import org.sandbox.jdt.triggerpattern.api.HintPredicateDefinition;
+import org.sandbox.jdt.triggerpattern.api.Pattern;
+import org.sandbox.jdt.triggerpattern.api.PatternKind;
 import org.sandbox.jdt.triggerpattern.api.RewriteActionCatalog;
 import org.sandbox.jdt.triggerpattern.api.RewriteAlternative;
 import org.sandbox.jdt.triggerpattern.api.StructuredRewriteAction;
@@ -29,23 +33,29 @@ import org.sandbox.jdt.triggerpattern.internal.HintFileParser.HintParseException
  */
 public final class HintProgramParser {
 
-	/**
-	 * Immutable local declarations, parser-compatible source and structured action
-	 * attachments. A fresh compatibility model is reconstructed on demand.
-	 */
+	/** Immutable declarations and parser-compatible expanded source. */
 	public record ParsedProgram(List<HintPredicateDefinition> predicates, String expandedSource,
-			Map<String, List<StructuredRewriteAction>> actionsBySentinel) {
+			Map<String, List<StructuredRewriteAction>> actionsBySentinel,
+			Map<String, PatternKind> kindsByRuleId) {
 		public ParsedProgram {
 			predicates= List.copyOf(predicates);
-			Map<String, List<StructuredRewriteAction>> copy= new LinkedHashMap<>();
-			actionsBySentinel.forEach((sentinel, actions) -> copy.put(sentinel, List.copyOf(actions)));
-			actionsBySentinel= Map.copyOf(copy);
+			Map<String, List<StructuredRewriteAction>> actionCopy= new LinkedHashMap<>();
+			actionsBySentinel.forEach((sentinel, actions) ->
+					actionCopy.put(sentinel, List.copyOf(actions)));
+			actionsBySentinel= Map.copyOf(actionCopy);
+			kindsByRuleId= Map.copyOf(kindsByRuleId);
 		}
 
-		/** Returns a fresh validated rule model with structured actions restored. */
+		/** Backward-compatible constructor for programs without explicit rule kinds. */
+		public ParsedProgram(List<HintPredicateDefinition> predicates, String expandedSource,
+				Map<String, List<StructuredRewriteAction>> actionsBySentinel) {
+			this(predicates, expandedSource, actionsBySentinel, Map.of());
+		}
+
+		/** Returns a fresh validated rule model with high-level features restored. */
 		public HintFile hintFile() {
 			try {
-				return parseWithActions(expandedSource, actionsBySentinel);
+				return parseComposed(expandedSource, actionsBySentinel, kindsByRuleId);
 			} catch (HintParseException exception) {
 				throw new IllegalStateException("Validated expanded hint source can no longer be parsed", exception); //$NON-NLS-1$
 			}
@@ -53,10 +63,12 @@ public final class HintProgramParser {
 	}
 
 	private record PreparedProgram(List<HintPredicateDefinition> predicates, String expandedSource,
-			Map<String, List<StructuredRewriteAction>> actionsBySentinel) {
+			Map<String, List<StructuredRewriteAction>> actionsBySentinel,
+			Map<String, PatternKind> kindsByRuleId) {
 		PreparedProgram {
 			predicates= List.copyOf(predicates);
 			actionsBySentinel= Map.copyOf(actionsBySentinel);
+			kindsByRuleId= Map.copyOf(kindsByRuleId);
 		}
 	}
 
@@ -67,7 +79,6 @@ public final class HintProgramParser {
 		this(new HintFileParser(), RewriteActionCatalog.standard());
 	}
 
-	/** Creates a parser with an explicitly composed action catalog. */
 	public HintProgramParser(RewriteActionCatalog actionCatalog) {
 		this(new HintFileParser(), actionCatalog);
 	}
@@ -83,57 +94,89 @@ public final class HintProgramParser {
 
 	public ParsedProgram parse(String source) throws HintParseException {
 		PreparedProgram prepared= prepare(source, actionCatalog);
-		parseWithActions(ruleParser, prepared.expandedSource(), prepared.actionsBySentinel());
+		parseComposed(ruleParser, prepared.expandedSource(), prepared.actionsBySentinel(),
+				prepared.kindsByRuleId());
 		return new ParsedProgram(prepared.predicates(), prepared.expandedSource(),
-				prepared.actionsBySentinel());
+				prepared.actionsBySentinel(), prepared.kindsByRuleId());
 	}
 
-	/** Convenience for consumers that only need the existing rule model. */
 	public HintFile parseHintFile(String source) throws HintParseException {
 		PreparedProgram prepared= prepare(source, actionCatalog);
-		return parseWithActions(ruleParser, prepared.expandedSource(), prepared.actionsBySentinel());
+		return parseComposed(ruleParser, prepared.expandedSource(), prepared.actionsBySentinel(),
+				prepared.kindsByRuleId());
 	}
 
 	private static PreparedProgram prepare(String source, RewriteActionCatalog catalog)
 			throws HintParseException {
 		HintPredicatePreprocessor.Result predicates= HintPredicatePreprocessor.preprocess(source);
 		validatePredicateNames(predicates.predicates());
+		HintRuleKindPreprocessor.Result kinds=
+				HintRuleKindPreprocessor.preprocess(predicates.expandedSource());
 		HintStructuredActionPreprocessor.Result actions=
-				HintStructuredActionPreprocessor.preprocess(predicates.expandedSource(), catalog);
+				HintStructuredActionPreprocessor.preprocess(kinds.parserSource(), catalog);
 		return new PreparedProgram(predicates.predicates(), actions.parserSource(),
-				actions.actionsBySentinel());
+				actions.actionsBySentinel(), kinds.kindsByRuleId());
 	}
 
-	private static HintFile parseWithActions(String source,
-			Map<String, List<StructuredRewriteAction>> actionsBySentinel)
-			throws HintParseException {
-		return parseWithActions(new HintFileParser(), source, actionsBySentinel);
+	private static HintFile parseComposed(String source,
+			Map<String, List<StructuredRewriteAction>> actionsBySentinel,
+			Map<String, PatternKind> kindsByRuleId) throws HintParseException {
+		return parseComposed(new HintFileParser(), source, actionsBySentinel, kindsByRuleId);
 	}
 
-	private static HintFile parseWithActions(HintFileParser parser, String source,
-			Map<String, List<StructuredRewriteAction>> actionsBySentinel)
-			throws HintParseException {
+	private static HintFile parseComposed(HintFileParser parser, String source,
+			Map<String, List<StructuredRewriteAction>> actionsBySentinel,
+			Map<String, PatternKind> kindsByRuleId) throws HintParseException {
 		HintFile parsed= parser.parse(source);
-		if (actionsBySentinel.isEmpty()) {
+		if (actionsBySentinel.isEmpty() && kindsByRuleId.isEmpty()) {
 			return parsed;
 		}
 		HintFile result= copyMetadata(parsed);
+		Set<String> appliedKinds= new LinkedHashSet<>();
 		for (TransformationRule rule : parsed.getRules()) {
-			List<RewriteAlternative> alternatives= new ArrayList<>();
-			for (RewriteAlternative alternative : rule.alternatives()) {
-				List<StructuredRewriteAction> actions=
-						actionsBySentinel.get(alternative.replacementPattern());
-				if (actions == null) {
-					alternatives.add(alternative);
-				} else {
-					alternatives.add(RewriteAlternative.structured(actions, alternative.condition()));
-				}
+			List<RewriteAlternative> alternatives= restoreActions(rule, actionsBySentinel);
+			Pattern sourcePattern= rule.sourcePattern();
+			PatternKind explicitKind= rule.getRuleId() == null ? null : kindsByRuleId.get(rule.getRuleId());
+			if (explicitKind != null) {
+				appliedKinds.add(rule.getRuleId());
+				sourcePattern= withKind(sourcePattern, explicitKind, rule.getRuleId());
 			}
 			result.addRule(new TransformationRule(rule.getRuleId(), rule.getDescription(),
-					rule.sourcePattern(), rule.sourceGuard(), alternatives,
+					sourcePattern, rule.sourceGuard(), alternatives,
 					rule.getImportDirective(), rule.getSeverity()));
 		}
+		if (!appliedKinds.equals(kindsByRuleId.keySet())) {
+			Set<String> missing= new LinkedHashSet<>(kindsByRuleId.keySet());
+			missing.removeAll(appliedKinds);
+			throw new HintParseException("Explicit pattern kinds reference missing rule ids " + missing, 0); //$NON-NLS-1$
+		}
 		return result;
+	}
+
+	private static List<RewriteAlternative> restoreActions(TransformationRule rule,
+			Map<String, List<StructuredRewriteAction>> actionsBySentinel) {
+		List<RewriteAlternative> alternatives= new ArrayList<>();
+		for (RewriteAlternative alternative : rule.alternatives()) {
+			List<StructuredRewriteAction> actions=
+					actionsBySentinel.get(alternative.replacementPattern());
+			if (actions == null) {
+				alternatives.add(alternative);
+			} else {
+				alternatives.add(RewriteAlternative.structured(actions, alternative.condition()));
+			}
+		}
+		return alternatives;
+	}
+
+	private static Pattern withKind(Pattern source, PatternKind kind, String ruleId)
+			throws HintParseException {
+		if (kind == PatternKind.TYPE_DECLARATION
+				&& new TypeDeclarationPatternParser().parse(source.getValue()) == null) {
+			throw new HintParseException("Rule " + ruleId //$NON-NLS-1$
+					+ " must contain one syntactically valid type header with an empty body", 0); //$NON-NLS-1$
+		}
+		return new Pattern(source.getValue(), kind, source.getId(), source.getDisplayName(),
+				source.getQualifiedType(), source.getOverridesType(), source.getConstraints());
 	}
 
 	private static HintFile copyMetadata(HintFile source) {

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/HintRuleKindPreprocessor.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/HintRuleKindPreprocessor.java
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.internal;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.sandbox.jdt.triggerpattern.api.PatternKind;
+import org.sandbox.jdt.triggerpattern.internal.HintFileParser.HintParseException;
+
+/** Removes explicit {@code @kind:} metadata before compatibility parsing. */
+final class HintRuleKindPreprocessor {
+
+	record Result(String parserSource, Map<String, PatternKind> kindsByRuleId) {
+		Result {
+			kindsByRuleId= Map.copyOf(kindsByRuleId);
+		}
+	}
+
+	private HintRuleKindPreprocessor() {
+	}
+
+	static Result preprocess(String source) throws HintParseException {
+		String normalized= source == null ? "" : source.replace("\r\n", "\n").replace('\r', '\n'); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		String[] lines= normalized.split("\n", -1); //$NON-NLS-1$
+		StringBuilder output= new StringBuilder(normalized.length());
+		Map<String, PatternKind> kinds= new LinkedHashMap<>();
+		String ruleId= null;
+		PatternKind ruleKind= null;
+		int kindLine= -1;
+		boolean inBlockComment= false;
+		boolean inEmbeddedJava= false;
+
+		for (int index= 0; index < lines.length; index++) {
+			String line= lines[index];
+			String trimmed= line.stripLeading();
+			boolean metadataVisible= true;
+			if (inEmbeddedJava) {
+				metadataVisible= false;
+				if (trimmed.contains("?>")) { //$NON-NLS-1$
+					inEmbeddedJava= false;
+				}
+			} else if (inBlockComment) {
+				metadataVisible= false;
+				if (trimmed.contains("*/")) { //$NON-NLS-1$
+					inBlockComment= false;
+				}
+			} else if (trimmed.startsWith("<?")) { //$NON-NLS-1$
+				metadataVisible= false;
+				inEmbeddedJava= !trimmed.contains("?>"); //$NON-NLS-1$
+			} else if (trimmed.startsWith("/*")) { //$NON-NLS-1$
+				metadataVisible= false;
+				inBlockComment= !trimmed.contains("*/"); //$NON-NLS-1$
+			} else if (trimmed.startsWith("//")) { //$NON-NLS-1$
+				metadataVisible= false;
+			}
+
+			boolean stripLine= false;
+			if (metadataVisible && trimmed.startsWith("@id:")) { //$NON-NLS-1$
+				String parsedId= trimmed.substring(4).trim();
+				if (parsedId.isBlank()) {
+					throw new HintParseException("Per-rule id must not be blank", index + 1); //$NON-NLS-1$
+				}
+				if (ruleId != null && !ruleId.equals(parsedId)) {
+					throw new HintParseException("Rule contains multiple @id values", index + 1); //$NON-NLS-1$
+				}
+				ruleId= parsedId;
+			} else if (metadataVisible && trimmed.startsWith("@kind:")) { //$NON-NLS-1$
+				if (ruleKind != null) {
+					throw new HintParseException("Rule contains multiple @kind values", index + 1); //$NON-NLS-1$
+				}
+				String value= trimmed.substring(6).trim();
+				try {
+					ruleKind= PatternKind.valueOf(value);
+				} catch (IllegalArgumentException exception) {
+					throw new HintParseException("Unknown pattern kind " + value, index + 1); //$NON-NLS-1$
+				}
+				kindLine= index + 1;
+				stripLine= true;
+			}
+
+			if (metadataVisible && ";;".equals(trimmed)) { //$NON-NLS-1$
+				if (ruleKind != null) {
+					if (ruleId == null) {
+						throw new HintParseException("@kind requires an explicit @id in the same rule", //$NON-NLS-1$
+								kindLine);
+					}
+					PatternKind previous= kinds.putIfAbsent(ruleId, ruleKind);
+					if (previous != null && previous != ruleKind) {
+						throw new HintParseException("Conflicting @kind values for rule " + ruleId, kindLine); //$NON-NLS-1$
+					}
+				}
+				ruleId= null;
+				ruleKind= null;
+				kindLine= -1;
+			}
+
+			if (!stripLine) {
+				output.append(line);
+			}
+			if (index + 1 < lines.length) {
+				output.append('\n');
+			}
+		}
+		if (ruleKind != null) {
+			throw new HintParseException("Rule with @kind is missing ';;' terminator", kindLine); //$NON-NLS-1$
+		}
+		return new Result(output.toString(), kinds);
+	}
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/HintTypeDeclarationSourcePreprocessor.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/HintTypeDeclarationSourcePreprocessor.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.internal;
+
+import java.util.Map;
+
+import org.sandbox.jdt.triggerpattern.api.PatternKind;
+import org.sandbox.jdt.triggerpattern.internal.HintFileParser.HintParseException;
+
+/**
+ * Normalizes multiline explicit type headers for the line-oriented compatibility
+ * parser. The original line count is retained so later diagnostics keep useful
+ * source positions.
+ */
+final class HintTypeDeclarationSourcePreprocessor {
+
+	private HintTypeDeclarationSourcePreprocessor() {
+	}
+
+	static String preprocess(String source, Map<String, PatternKind> kindsByRuleId)
+			throws HintParseException {
+		if (source == null || source.isEmpty() || kindsByRuleId.isEmpty()) {
+			return source == null ? "" : source; //$NON-NLS-1$
+		}
+		String normalized= source.replace("\r\n", "\n").replace('\r', '\n'); //$NON-NLS-1$ //$NON-NLS-2$
+		String[] lines= normalized.split("\n", -1); //$NON-NLS-1$
+		StringBuilder output= new StringBuilder(normalized.length());
+		String ruleId= null;
+		boolean sourceSeen= false;
+
+		for (int index= 0; index < lines.length; index++) {
+			String line= lines[index];
+			String trimmed= line.stripLeading();
+			if (trimmed.startsWith("@id:")) { //$NON-NLS-1$
+				ruleId= trimmed.substring(4).trim();
+				sourceSeen= false;
+			}
+
+			if (!sourceSeen && kindsByRuleId.get(ruleId) == PatternKind.TYPE_DECLARATION
+					&& isSourceStart(trimmed)) {
+				int lastHeaderLine= index;
+				StringBuilder header= new StringBuilder(trimmed);
+				while (lastHeaderLine + 1 < lines.length) {
+					String next= lines[lastHeaderLine + 1].stripLeading();
+					if (next.startsWith("=>") || next.startsWith("::") || ";;".equals(next)) { //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+						break;
+					}
+					lastHeaderLine++;
+					if (!next.isBlank()) {
+						header.append(' ').append(next);
+					}
+				}
+				int indentationLength= line.length() - trimmed.length();
+				output.append(line, 0, indentationLength).append(header);
+				for (int consumed= index; consumed < lastHeaderLine; consumed++) {
+					output.append('\n');
+				}
+				index= lastHeaderLine;
+				sourceSeen= true;
+			} else {
+				output.append(line);
+			}
+
+			if (";;".equals(trimmed)) { //$NON-NLS-1$
+				ruleId= null;
+				sourceSeen= false;
+			}
+			if (index + 1 < lines.length) {
+				output.append('\n');
+			}
+		}
+		return output.toString();
+	}
+
+	private static boolean isSourceStart(String trimmed) throws HintParseException {
+		if (trimmed.isBlank() || trimmed.startsWith("@severity:") //$NON-NLS-1$
+				|| trimmed.startsWith("@id:")) { //$NON-NLS-1$
+			return false;
+		}
+		if (trimmed.startsWith("=>") || trimmed.startsWith("::") || ";;".equals(trimmed)) { //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			throw new HintParseException("Explicit type rule has no source declaration", 0); //$NON-NLS-1$
+		}
+		return !(trimmed.startsWith("\"") && trimmed.endsWith("\":")); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/HintTypeDeclarationSourcePreprocessor.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/HintTypeDeclarationSourcePreprocessor.java
@@ -44,8 +44,9 @@ final class HintTypeDeclarationSourcePreprocessor {
 				sourceSeen= false;
 			}
 
-			if (!sourceSeen && kindsByRuleId.get(ruleId) == PatternKind.TYPE_DECLARATION
-					&& isSourceStart(trimmed)) {
+			boolean explicitTypeRule= ruleId != null
+					&& kindsByRuleId.get(ruleId) == PatternKind.TYPE_DECLARATION;
+			if (!sourceSeen && explicitTypeRule && isSourceStart(trimmed)) {
 				int lastHeaderLine= index;
 				StringBuilder header= new StringBuilder(trimmed);
 				while (lastHeaderLine + 1 < lines.length) {

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/TypeDeclarationHeaderMatcher.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/TypeDeclarationHeaderMatcher.java
@@ -1,0 +1,149 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.AnnotationTypeDeclaration;
+import org.eclipse.jdt.core.dom.EnumDeclaration;
+import org.eclipse.jdt.core.dom.IExtendedModifier;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.RecordDeclaration;
+import org.eclipse.jdt.core.dom.Type;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+
+/** Placeholder-aware matcher for header-only type declaration patterns. */
+public final class TypeDeclarationHeaderMatcher extends PlaceholderAstMatcher {
+
+	@Override
+	public boolean match(TypeDeclaration pattern, Object other) {
+		if (!(other instanceof TypeDeclaration candidate)
+				|| pattern.isInterface() != candidate.isInterface()) {
+			return false;
+		}
+		return matchCommon(pattern, candidate)
+				&& matchOptionalType(pattern.getSuperclassType(), candidate.getSuperclassType())
+				&& matchTypeSubset(pattern.superInterfaceTypes(), candidate.superInterfaceTypes())
+				&& matchOptionalList(pattern.typeParameters(), candidate.typeParameters());
+	}
+
+	@Override
+	public boolean match(EnumDeclaration pattern, Object other) {
+		return other instanceof EnumDeclaration candidate
+				&& matchCommon(pattern, candidate)
+				&& matchTypeSubset(pattern.superInterfaceTypes(), candidate.superInterfaceTypes());
+	}
+
+	@Override
+	public boolean match(RecordDeclaration pattern, Object other) {
+		return other instanceof RecordDeclaration candidate
+				&& matchCommon(pattern, candidate)
+				&& matchTypeSubset(pattern.superInterfaceTypes(), candidate.superInterfaceTypes())
+				&& matchOptionalList(pattern.typeParameters(), candidate.typeParameters())
+				&& matchOptionalList(pattern.recordComponents(), candidate.recordComponents());
+	}
+
+	@Override
+	public boolean match(AnnotationTypeDeclaration pattern, Object other) {
+		return other instanceof AnnotationTypeDeclaration candidate
+				&& matchCommon(pattern, candidate);
+	}
+
+	private boolean matchCommon(org.eclipse.jdt.core.dom.AbstractTypeDeclaration pattern,
+			org.eclipse.jdt.core.dom.AbstractTypeDeclaration candidate) {
+		return pattern.getName().subtreeMatch(this, candidate.getName())
+				&& matchModifierSubset(pattern.modifiers(), candidate.modifiers());
+	}
+
+	private boolean matchModifierSubset(List<?> patternModifiers, List<?> candidateModifiers) {
+		for (Object patternModifier : patternModifiers) {
+			if (!(patternModifier instanceof IExtendedModifier required)) {
+				return false;
+			}
+			boolean found= false;
+			for (Object candidateModifier : candidateModifiers) {
+				if (candidateModifier instanceof IExtendedModifier actual
+						&& ((ASTNode) required).subtreeMatch(this, actual)) {
+					found= true;
+					break;
+				}
+			}
+			if (!found) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private boolean matchOptionalType(Type pattern, Type candidate) {
+		return pattern == null || candidate != null && matchType(pattern, candidate);
+	}
+
+	private boolean matchTypeSubset(List<?> patternTypes, List<?> candidateTypes) {
+		if (patternTypes.isEmpty()) {
+			return true;
+		}
+		List<Object> unmatched= new ArrayList<>(candidateTypes);
+		for (Object patternType : patternTypes) {
+			if (!(patternType instanceof Type required)) {
+				return false;
+			}
+			int matchingIndex= -1;
+			for (int index= 0; index < unmatched.size(); index++) {
+				if (unmatched.get(index) instanceof Type actual && matchType(required, actual)) {
+					matchingIndex= index;
+					break;
+				}
+			}
+			if (matchingIndex < 0) {
+				return false;
+			}
+			unmatched.remove(matchingIndex);
+		}
+		return true;
+	}
+
+	private boolean matchType(Type pattern, Type candidate) {
+		if (pattern.subtreeMatch(this, candidate)) {
+			return true;
+		}
+		ITypeBinding binding= candidate.resolveBinding();
+		if (binding == null) {
+			return false;
+		}
+		ITypeBinding erasure= binding.getErasure();
+		ITypeBinding declaration= (erasure == null ? binding : erasure).getTypeDeclaration();
+		if (declaration == null) {
+			return false;
+		}
+		String expected= pattern.toString().replace(" ", ""); //$NON-NLS-1$ //$NON-NLS-2$
+		return expected.equals(declaration.getQualifiedName()) || expected.equals(declaration.getName());
+	}
+
+	private boolean matchOptionalList(List<?> patternNodes, List<?> candidateNodes) {
+		if (patternNodes.isEmpty()) {
+			return true;
+		}
+		if (patternNodes.size() != candidateNodes.size()) {
+			return false;
+		}
+		for (int index= 0; index < patternNodes.size(); index++) {
+			if (!(patternNodes.get(index) instanceof ASTNode pattern)
+					|| !(candidateNodes.get(index) instanceof ASTNode candidate)
+					|| !pattern.subtreeMatch(this, candidate)) {
+				return false;
+			}
+		}
+		return true;
+	}
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/TypeDeclarationHeaderMatcher.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/TypeDeclarationHeaderMatcher.java
@@ -14,16 +14,26 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
 import org.eclipse.jdt.core.dom.AnnotationTypeDeclaration;
 import org.eclipse.jdt.core.dom.EnumDeclaration;
 import org.eclipse.jdt.core.dom.IExtendedModifier;
 import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.ParameterizedType;
 import org.eclipse.jdt.core.dom.RecordDeclaration;
 import org.eclipse.jdt.core.dom.Type;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 
 /** Placeholder-aware matcher for header-only type declaration patterns. */
 public final class TypeDeclarationHeaderMatcher extends PlaceholderAstMatcher {
+
+	private boolean caseInsensitive;
+
+	@Override
+	public void setCaseInsensitive(boolean caseInsensitive) {
+		super.setCaseInsensitive(caseInsensitive);
+		this.caseInsensitive= caseInsensitive;
+	}
 
 	@Override
 	public boolean match(TypeDeclaration pattern, Object other) {
@@ -59,28 +69,37 @@ public final class TypeDeclarationHeaderMatcher extends PlaceholderAstMatcher {
 				&& matchCommon(pattern, candidate);
 	}
 
-	private boolean matchCommon(org.eclipse.jdt.core.dom.AbstractTypeDeclaration pattern,
-			org.eclipse.jdt.core.dom.AbstractTypeDeclaration candidate) {
+	private boolean matchCommon(AbstractTypeDeclaration pattern,
+			AbstractTypeDeclaration candidate) {
 		return pattern.getName().subtreeMatch(this, candidate.getName())
 				&& matchModifierSubset(pattern.modifiers(), candidate.modifiers());
 	}
 
 	private boolean matchModifierSubset(List<?> patternModifiers, List<?> candidateModifiers) {
+		List<Object> unmatched= new ArrayList<>(candidateModifiers);
 		for (Object patternModifier : patternModifiers) {
 			if (!(patternModifier instanceof IExtendedModifier required)) {
 				return false;
 			}
-			boolean found= false;
-			for (Object candidateModifier : candidateModifiers) {
-				if (candidateModifier instanceof IExtendedModifier actual
-						&& ((ASTNode) required).subtreeMatch(this, actual)) {
-					found= true;
+			int matchingIndex= -1;
+			TypeDeclarationHeaderMatcher successfulMatcher= null;
+			for (int index= 0; index < unmatched.size(); index++) {
+				Object candidateModifier= unmatched.get(index);
+				if (!(candidateModifier instanceof IExtendedModifier actual)) {
+					continue;
+				}
+				TypeDeclarationHeaderMatcher trial= speculativeMatcher();
+				if (((ASTNode) required).subtreeMatch(trial, actual)) {
+					matchingIndex= index;
+					successfulMatcher= trial;
 					break;
 				}
 			}
-			if (!found) {
+			if (matchingIndex < 0) {
 				return false;
 			}
+			mergeBindings(successfulMatcher);
+			unmatched.remove(matchingIndex);
 		}
 		return true;
 	}
@@ -99,24 +118,62 @@ public final class TypeDeclarationHeaderMatcher extends PlaceholderAstMatcher {
 				return false;
 			}
 			int matchingIndex= -1;
+			TypeDeclarationHeaderMatcher successfulMatcher= null;
 			for (int index= 0; index < unmatched.size(); index++) {
-				if (unmatched.get(index) instanceof Type actual && matchType(required, actual)) {
+				if (!(unmatched.get(index) instanceof Type actual)) {
+					continue;
+				}
+				TypeDeclarationHeaderMatcher trial= speculativeMatcher();
+				if (trial.matchType(required, actual)) {
 					matchingIndex= index;
+					successfulMatcher= trial;
 					break;
 				}
 			}
 			if (matchingIndex < 0) {
 				return false;
 			}
+			mergeBindings(successfulMatcher);
 			unmatched.remove(matchingIndex);
 		}
 		return true;
 	}
 
 	private boolean matchType(Type pattern, Type candidate) {
-		if (pattern.subtreeMatch(this, candidate)) {
+		if (pattern instanceof ParameterizedType patternParameterized) {
+			if (!(candidate instanceof ParameterizedType candidateParameterized)) {
+				return false;
+			}
+			return matchType(patternParameterized.getType(), candidateParameterized.getType())
+					&& matchTypeList(patternParameterized.typeArguments(),
+							candidateParameterized.typeArguments());
+		}
+		if (candidate instanceof ParameterizedType candidateParameterized) {
+			return matchType(pattern, candidateParameterized.getType());
+		}
+		TypeDeclarationHeaderMatcher structural= speculativeMatcher();
+		if (pattern.subtreeMatch(structural, candidate)) {
+			mergeBindings(structural);
 			return true;
 		}
+		return bindingEquivalent(pattern, candidate);
+	}
+
+	private boolean matchTypeList(List<?> patternTypes, List<?> candidateTypes) {
+		if (patternTypes.size() != candidateTypes.size()) {
+			return false;
+		}
+		for (int index= 0; index < patternTypes.size(); index++) {
+			if (!(patternTypes.get(index) instanceof Type pattern)
+					|| !(candidateTypes.get(index) instanceof Type candidate)
+					|| !matchType(pattern, candidate)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private static boolean bindingEquivalent(Type pattern, Type candidate) {
 		ITypeBinding binding= candidate.resolveBinding();
 		if (binding == null) {
 			return false;
@@ -126,8 +183,16 @@ public final class TypeDeclarationHeaderMatcher extends PlaceholderAstMatcher {
 		if (declaration == null) {
 			return false;
 		}
-		String expected= pattern.toString().replace(" ", ""); //$NON-NLS-1$ //$NON-NLS-2$
-		return expected.equals(declaration.getQualifiedName()) || expected.equals(declaration.getName());
+		String expected= removeWhitespace(pattern.toString());
+		return expected.equals(declaration.getQualifiedName())
+				|| expected.equals(declaration.getName());
+	}
+
+	private static String removeWhitespace(String value) {
+		StringBuilder result= new StringBuilder(value.length());
+		value.codePoints().filter(character -> !Character.isWhitespace(character))
+				.forEach(result::appendCodePoint);
+		return result.toString();
 	}
 
 	private boolean matchOptionalList(List<?> patternNodes, List<?> candidateNodes) {
@@ -145,5 +210,12 @@ public final class TypeDeclarationHeaderMatcher extends PlaceholderAstMatcher {
 			}
 		}
 		return true;
+	}
+
+	private TypeDeclarationHeaderMatcher speculativeMatcher() {
+		TypeDeclarationHeaderMatcher matcher= new TypeDeclarationHeaderMatcher();
+		matcher.setCaseInsensitive(caseInsensitive);
+		matcher.mergeBindings(this);
+		return matcher;
 	}
 }

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/TypeDeclarationPatternParser.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/TypeDeclarationPatternParser.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.internal;
+
+import java.util.Map;
+
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.EnumDeclaration;
+
+/** Specialized parser used by {@code PatternIndex} for explicit type headers. */
+public final class TypeDeclarationPatternParser {
+
+	public ASTNode parse(String source) {
+		if (source == null || source.isBlank()) {
+			return null;
+		}
+		ASTParser parser= ASTParser.newParser(AST.getJLSLatest());
+		parser.setKind(ASTParser.K_COMPILATION_UNIT);
+		parser.setSource(source.toCharArray());
+		parser.setStatementsRecovery(true);
+		Map<String, String> options= JavaCore.getOptions();
+		JavaCore.setComplianceOptions(JavaCore.VERSION_21, options);
+		parser.setCompilerOptions(options);
+		CompilationUnit unit= (CompilationUnit) parser.createAST(null);
+		for (org.eclipse.jdt.core.compiler.IProblem problem : unit.getProblems()) {
+			if (problem.isError()) {
+				return null;
+			}
+		}
+		if (unit.types().size() != 1 || !(unit.types().get(0) instanceof AbstractTypeDeclaration type)) {
+			return null;
+		}
+		if (!type.bodyDeclarations().isEmpty()) {
+			return null;
+		}
+		if (type instanceof EnumDeclaration enumeration && !enumeration.enumConstants().isEmpty()) {
+			return null;
+		}
+		return type;
+	}
+}

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/internal/TypeDeclarationPatternTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/internal/TypeDeclarationPatternTest.java
@@ -79,6 +79,29 @@ class TypeDeclarationPatternTest {
 	}
 
 	@Test
+	void modifierSubsetBacktracksWithoutLeakingPlaceholderBindings() throws HintParseException {
+		HintFile hintFile= parseProgram("""
+				@id: annotation.header
+				@kind: TYPE_DECLARATION
+				@Pair(key=$key, value="expected")
+				class $name {}
+				=> class $name {}
+				;;
+				""");
+		TransformationRule rule= hintFile.getRules().get(0);
+		CompilationUnit source= parseJava("""
+				@Pair(key="first", value="wrong")
+				@Pair(key="second", value="expected")
+				class Actual {}
+				""");
+
+		List<Match> matches= new BatchTransformationProcessor(hintFile)
+				.getPatternIndex().findAllMatches(source).get(rule);
+		assertEquals(1, matches.size());
+		assertEquals("\"second\"", matches.get(0).getBinding("$key").toString()); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	@Test
 	void explicitKindRequiresStableRuleIdKnownKindAndHeaderOnlySource() {
 		assertThrows(HintParseException.class, () -> parseProgram("""
 				@kind: TYPE_DECLARATION

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/internal/TypeDeclarationPatternTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/internal/TypeDeclarationPatternTest.java
@@ -1,0 +1,143 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+
+import org.sandbox.jdt.triggerpattern.api.BatchTransformationProcessor;
+import org.sandbox.jdt.triggerpattern.api.HintFile;
+import org.sandbox.jdt.triggerpattern.api.Match;
+import org.sandbox.jdt.triggerpattern.api.PatternKind;
+import org.sandbox.jdt.triggerpattern.api.TransformationRule;
+import org.sandbox.jdt.triggerpattern.internal.HintFileParser.HintParseException;
+
+class TypeDeclarationPatternTest {
+
+	@Test
+	void explicitTypeKindMatchesAClassHeaderAndIgnoresItsBody() throws HintParseException {
+		HintFile hintFile= parseProgram("""
+				@id: class.header
+				@kind: TYPE_DECLARATION
+				public class $name {}
+				=> public class $name {}
+				;;
+				""");
+		TransformationRule rule= hintFile.getRules().get(0);
+		assertEquals(PatternKind.TYPE_DECLARATION, rule.sourcePattern().getKind());
+		CompilationUnit source= parseJava("""
+				package sample;
+				public class RealType {
+					private int value;
+					public void work() {}
+				}
+				""");
+
+		List<Match> matches= new BatchTransformationProcessor(hintFile)
+				.getPatternIndex().findAllMatches(source).get(rule);
+		assertEquals(1, matches.size());
+		assertEquals("RealType", matches.get(0).getBinding("$name").toString()); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	@Test
+	void modifiersAndTypeKindsRemainConstraints() throws HintParseException {
+		HintFile publicClass= parseProgram(program("public class $name {}")); //$NON-NLS-1$
+		HintFile interfacePattern= parseProgram(program("interface $name {}")); //$NON-NLS-1$
+		CompilationUnit packagePrivateClass= parseJava("class Sample { void work() {} }"); //$NON-NLS-1$
+		CompilationUnit actualInterface= parseJava("interface Sample { void work(); }"); //$NON-NLS-1$
+
+		assertTrue(new BatchTransformationProcessor(publicClass).process(packagePrivateClass).isEmpty());
+		assertFalse(new BatchTransformationProcessor(interfacePattern).process(actualInterface).isEmpty());
+		assertTrue(new BatchTransformationProcessor(interfacePattern).process(packagePrivateClass).isEmpty());
+	}
+
+	@Test
+	void enumRecordAndAnnotationHeadersAreSupported() throws HintParseException {
+		assertOneTypeMatch("enum $name {}", "enum Actual { ONE; void work() {} }"); //$NON-NLS-1$ //$NON-NLS-2$
+		assertOneTypeMatch("record $name() {}", "record Actual(String value) { void work() {} }"); //$NON-NLS-1$ //$NON-NLS-2$
+		assertOneTypeMatch("@interface $name {}", "@interface Actual { String value(); }"); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	@Test
+	void explicitKindRequiresStableRuleIdKnownKindAndHeaderOnlySource() {
+		assertThrows(HintParseException.class, () -> parseProgram("""
+				@kind: TYPE_DECLARATION
+				class $name {}
+				=> class $name {}
+				;;
+				"""));
+		assertThrows(HintParseException.class, () -> parseProgram("""
+				@id: bad.kind
+				@kind: PROJECT_SPECIFIC_TYPE
+				class $name {}
+				=> class $name {}
+				;;
+				"""));
+		assertThrows(HintParseException.class, () -> parseProgram("""
+				@id: bad.body
+				@kind: TYPE_DECLARATION
+				class $name { void method() {} }
+				=> class $name {}
+				;;
+				"""));
+	}
+
+	@Test
+	void ordinaryRulesRemainInferredByTheCompatibilityParser() throws HintParseException {
+		HintFile hintFile= parseProgram("""
+				void $name()
+				=> @Deprecated void $name()
+				;;
+				""");
+		assertEquals(PatternKind.METHOD_DECLARATION,
+				hintFile.getRules().get(0).sourcePattern().getKind());
+	}
+
+	private static void assertOneTypeMatch(String pattern, String source) throws HintParseException {
+		HintFile hintFile= parseProgram(program(pattern));
+		assertEquals(1, new BatchTransformationProcessor(hintFile).process(parseJava(source)).size());
+	}
+
+	private static String program(String pattern) {
+		return "@id: type.header\n@kind: TYPE_DECLARATION\n" + pattern //$NON-NLS-1$
+				+ "\n=> " + pattern + "\n;;\n"; //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	private static HintFile parseProgram(String source) throws HintParseException {
+		return new HintProgramParser().parseHintFile(source);
+	}
+
+	private static CompilationUnit parseJava(String source) {
+		ASTParser parser= ASTParser.newParser(AST.getJLSLatest());
+		parser.setKind(ASTParser.K_COMPILATION_UNIT);
+		parser.setSource(source.toCharArray());
+		parser.setUnitName("Sample.java"); //$NON-NLS-1$
+		parser.setResolveBindings(true);
+		parser.setBindingsRecovery(true);
+		parser.setEnvironment(new String[0], new String[0], null, true);
+		Map<String, String> options= JavaCore.getOptions();
+		JavaCore.setComplianceOptions(JavaCore.VERSION_21, options);
+		parser.setCompilerOptions(options);
+		return (CompilationUnit) parser.createAST(null);
+	}
+}

--- a/sandbox_common_test/src/org/sandbox/jdt/triggerpattern/editor/SandboxHintStructuredActionEditorTest.java
+++ b/sandbox_common_test/src/org/sandbox/jdt/triggerpattern/editor/SandboxHintStructuredActionEditorTest.java
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -23,6 +24,7 @@ import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.rules.IToken;
 import org.eclipse.jface.text.rules.Token;
 
+import org.sandbox.jdt.triggerpattern.api.PatternKind;
 import org.sandbox.jdt.triggerpattern.api.RewriteActionCatalog;
 import org.sandbox.jdt.triggerpattern.cleanup.actions.StructuredRewriteActionRegistry;
 
@@ -58,6 +60,24 @@ class SandboxHintStructuredActionEditorTest {
 		assertTrue(addAnnotation.replacement().contains("target=")); //$NON-NLS-1$
 		assertFalse(addAnnotation.replacement().contains("?")); //$NON-NLS-1$
 		assertTrue(addAnnotation.cursorPosition() > addAnnotation.replacement().indexOf('='));
+	}
+
+	@Test
+	void patternKindCompletionIsRestrictedToKindMetadataValues() {
+		String kindLine= "@kind: TYPE_D"; //$NON-NLS-1$
+		String ordinaryLine= "class TYPE_D"; //$NON-NLS-1$
+		assertTrue(SandboxHintContentAssistProcessor.isPatternKindContext(kindLine, kindLine.length()));
+		assertFalse(SandboxHintContentAssistProcessor.isPatternKindContext(
+				ordinaryLine, ordinaryLine.length()));
+
+		Map<String, SandboxHintContentAssistProcessor.CompletionEntry> entries=
+				SandboxHintContentAssistProcessor.completionEntries(kindLine, false, false, true).stream()
+						.collect(Collectors.toMap(
+								SandboxHintContentAssistProcessor.CompletionEntry::name,
+								entry -> entry));
+		assertEquals(Arrays.stream(PatternKind.values()).map(Enum::name).collect(Collectors.toSet()),
+				entries.keySet());
+		assertEquals("TYPE_DECLARATION", entries.get("TYPE_DECLARATION").replacement()); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
 	@Test

--- a/sandbox_common_test/src/org/sandbox/jdt/triggerpattern/test/RuleInferenceEngineTest.java
+++ b/sandbox_common_test/src/org/sandbox/jdt/triggerpattern/test/RuleInferenceEngineTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.sandbox.jdt.triggerpattern.test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -59,6 +60,20 @@ public class RuleInferenceEngineTest {
 		InferredRule rule = result.get();
 		assertNotNull(rule.sourcePattern());
 		assertNotNull(rule.replacementPattern());
+	}
+
+	@Test
+	public void testTypeDeclarationKindsDoNotUseSyntheticClassCasts() {
+		String[][] changes = {
+				{ "class C {}", "final class C {}" }, //$NON-NLS-1$ //$NON-NLS-2$
+				{ "interface I {}", "interface I extends java.io.Serializable {}" }, //$NON-NLS-1$ //$NON-NLS-2$
+				{ "enum E { A }", "enum E { A, B }" }, //$NON-NLS-1$ //$NON-NLS-2$
+				{ "record R(int value) {}", "record R(long value) {}" }, //$NON-NLS-1$ //$NON-NLS-2$
+				{ "@interface A {}", "@interface A { String value(); }" } //$NON-NLS-1$ //$NON-NLS-2$
+		};
+		for (String[] change : changes) {
+			assertDoesNotThrow(() -> engine.inferRule(change[0], change[1], PatternKind.TYPE_DECLARATION));
+		}
 	}
 
 	@Test


### PR DESCRIPTION
## Purpose

TriggerPattern can now perform schema-validated structured actions, but it still needs an explicit source-pattern kind for type declarations. Inferring a class header from expression or method heuristics would be fragile and would push JUnit-specific logic into the planner. This PR adds one generic, explicit and header-only type pattern contract.

## Explicit rule kind

A rule may opt into a stable kind through per-rule metadata:

```text
@id: hierarchy.root
@kind: TYPE_DECLARATION
class $name {}
=>! removeSupertype(target=$name, type="junit.framework.TestCase")
;;
```

- `@kind` requires an explicit `@id` in the same rule;
- unknown, duplicate or unterminated kind declarations fail closed;
- `HintProgramParser` composes explicit kinds with predicates and structured actions before delegating ordinary parsing to the compatibility parser;
- ordinary rules continue to use the established inference path unchanged.

## Header-only semantics

- supports classes, interfaces, enums, records and annotation types;
- an empty pattern body intentionally ignores the candidate body;
- type kind, name placeholders and every explicitly declared modifier remain constraints;
- explicitly declared type parameters, record components and supertypes remain constraints;
- absent modifiers, parameters and supertypes are unconstrained;
- non-empty pattern bodies and enum constants are rejected by the specialized parser.

## Matching safety

Modifier and supertype subsets use speculative child matchers. Placeholder bindings from a failed candidate are discarded and are committed only after the complete candidate matches. This prevents a first same-shape annotation or interface from poisoning a later valid candidate, while preserving exact multiplicity.

## Engine and editor integration

- adds `PatternKind.TYPE_DECLARATION` without removing the existing API documentation;
- uses dedicated type-header parser and matcher classes rather than expanding the general parser and matcher;
- `PatternIndex` dispatches every `AbstractTypeDeclaration` during its existing one-pass traversal;
- type patterns expose normal placeholder bindings;
- rule inference passes complete classes, interfaces, enums, records and annotation types directly to JDT;
- content assist proposes explicit pattern kinds only in `@kind:` value positions.

## Verification

Tests cover:

- a header pattern matching a type with fields and methods;
- modifier and type-kind constraints;
- enum, record and annotation-type support;
- explicit-kind validation and compatibility with ordinary inferred rules;
- inference stability for all supported top-level type forms;
- failed speculative annotation matching without leaked placeholder bindings.

## Base

The branch was reconstructed on the squash-merged #1347 head so the structured-action security and build hardening from that PR is retained. The diff contains only the type-declaration language, matching, editor, inference and test changes.

Refs #1334 and #1217.