### PR TITLE
Let the persistence context own repository lifecycle

### DIFF
--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/JGitServerApplication.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/JGitServerApplication.java
@@ -83,7 +83,7 @@ public class JGitServerApplication {
 		persistenceContext= Objects.requireNonNull(context, "context"); //$NON-NLS-1$
 		try {
 			SessionFactory sessionFactory= persistenceContext.sessionFactory();
-			repositoryResolver= new HibernateRepositoryResolver(sessionFactory);
+			repositoryResolver= new HibernateRepositoryResolver(persistenceContext.repositoryService());
 			SandboxRepositoryService repositories= repositoryResolver.getRepositoryService();
 			if (defaultRepositories != null && !defaultRepositories.isBlank()) {
 				RepositoryManagerConfig.initDefaultRepositories(repositories, defaultRepositories);
@@ -161,7 +161,7 @@ public class JGitServerApplication {
 		}
 	}
 
-	/** Stops the server and closes repository handles before the owned factory. */
+	/** Stops the server and closes the application-owned persistence context. */
 	public void stop() throws Exception {
 		Exception failure= null;
 		try {
@@ -170,17 +170,6 @@ public class JGitServerApplication {
 			}
 		} catch (Exception exception) {
 			failure= exception;
-		}
-		try {
-			if (repositoryResolver != null) {
-				repositoryResolver.close();
-			}
-		} catch (RuntimeException exception) {
-			if (failure == null) {
-				failure= exception;
-			} else {
-				failure.addSuppressed(exception);
-			}
 		}
 		try {
 			if (persistenceContext != null) {

--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/config/CopiedServerPersistenceContext.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/config/CopiedServerPersistenceContext.java
@@ -13,6 +13,8 @@ package org.eclipse.jgit.server.config;
 import java.util.Objects;
 import java.util.Properties;
 
+import org.eclipse.jgit.server.repository.CopiedHibernateRepositoryService;
+import org.eclipse.jgit.server.repository.SandboxRepositoryService;
 import org.eclipse.jgit.storage.hibernate.config.HibernateSessionFactoryProvider;
 import org.hibernate.SessionFactory;
 
@@ -20,6 +22,7 @@ import org.hibernate.SessionFactory;
 final class CopiedServerPersistenceContext implements ServerPersistenceContext {
 
 	private final HibernateSessionFactoryProvider owner;
+	private final SandboxRepositoryService repositories;
 
 	CopiedServerPersistenceContext(Properties properties) {
 		this(new HibernateSessionFactoryProvider(Objects.requireNonNull(properties, "properties"))); //$NON-NLS-1$
@@ -27,6 +30,7 @@ final class CopiedServerPersistenceContext implements ServerPersistenceContext {
 
 	CopiedServerPersistenceContext(HibernateSessionFactoryProvider owner) {
 		this.owner= Objects.requireNonNull(owner, "owner"); //$NON-NLS-1$
+		this.repositories= new CopiedHibernateRepositoryService(owner.getSessionFactory());
 	}
 
 	@Override
@@ -35,7 +39,29 @@ final class CopiedServerPersistenceContext implements ServerPersistenceContext {
 	}
 
 	@Override
+	public SandboxRepositoryService repositoryService() {
+		return repositories;
+	}
+
+	@Override
 	public void close() {
-		owner.close();
+		RuntimeException failure= null;
+		try {
+			repositories.close();
+		} catch (RuntimeException exception) {
+			failure= exception;
+		}
+		try {
+			owner.close();
+		} catch (RuntimeException exception) {
+			if (failure == null) {
+				failure= exception;
+			} else {
+				failure.addSuppressed(exception);
+			}
+		}
+		if (failure != null) {
+			throw failure;
+		}
 	}
 }

--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/config/ServerPersistenceContext.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/config/ServerPersistenceContext.java
@@ -10,22 +10,31 @@
  *******************************************************************************/
 package org.eclipse.jgit.server.config;
 
+import org.eclipse.jgit.server.repository.SandboxRepositoryService;
 import org.hibernate.SessionFactory;
 
 /**
  * Application-owned persistence context used by server resources and repository
  * adapters.
  *
- * <p>The boundary exposes only the native Hibernate contract and lifecycle. It
- * deliberately does not expose copied or released JGit storage implementation
- * types, so entity registration can be replaced independently from callers.</p>
+ * <p>The boundary exposes only the native Hibernate contract, the
+ * application-owned repository-service contract and their coordinated
+ * lifecycle. It deliberately does not expose copied or released JGit storage
+ * implementation types, so entity registration and the active Core backend can
+ * be replaced independently from REST and Smart HTTP callers.</p>
  */
 public interface ServerPersistenceContext extends AutoCloseable {
 
 	/** Returns the application-owned native Hibernate session factory. */
 	SessionFactory sessionFactory();
 
-	/** Closes the owned session factory and its connection/search resources. */
+	/**
+	 * Returns the application-owned repository service sharing this persistence
+	 * context's lifecycle.
+	 */
+	SandboxRepositoryService repositoryService();
+
+	/** Closes repository handles before the owned session factory. */
 	@Override
 	void close();
 }

--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/resolver/HibernateRepositoryResolver.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/resolver/HibernateRepositoryResolver.java
@@ -32,31 +32,37 @@ public class HibernateRepositoryResolver
 
 	private final HibernateSessionFactoryProvider sessionFactoryProvider;
 	private final SandboxRepositoryService repositories;
+	private final boolean ownsRepositoryService;
 
-	/** Creates a resolver from the application-owned native session factory. */
+	/** Creates a resolver that owns a copied adapter for the native session factory. */
 	public HibernateRepositoryResolver(SessionFactory sessionFactory) {
-		this(null, new CopiedHibernateRepositoryService(sessionFactory));
+		this(null, new CopiedHibernateRepositoryService(sessionFactory), true);
 	}
 
 	/**
-	 * Creates a resolver using the temporary copied-backend adapter.
+	 * Creates a resolver using and owning the temporary copied-backend adapter.
 	 *
-	 * @deprecated application wiring should pass the native {@link SessionFactory}
+	 * @deprecated application wiring should pass its application-owned
+	 *             {@link SandboxRepositoryService}
 	 */
 	@Deprecated(forRemoval = true)
 	public HibernateRepositoryResolver(HibernateSessionFactoryProvider sessionFactoryProvider) {
-		this(sessionFactoryProvider, new CopiedHibernateRepositoryService(sessionFactoryProvider));
+		this(sessionFactoryProvider, new CopiedHibernateRepositoryService(sessionFactoryProvider), true);
 	}
 
-	/** Creates a resolver for an application-owned repository service. */
+	/**
+	 * Creates a resolver for an application-owned repository service without
+	 * taking lifecycle ownership.
+	 */
 	public HibernateRepositoryResolver(SandboxRepositoryService repositories) {
-		this(null, repositories);
+		this(null, repositories, false);
 	}
 
 	private HibernateRepositoryResolver(HibernateSessionFactoryProvider sessionFactoryProvider,
-			SandboxRepositoryService repositories) {
+			SandboxRepositoryService repositories, boolean ownsRepositoryService) {
 		this.sessionFactoryProvider= sessionFactoryProvider;
 		this.repositories= Objects.requireNonNull(repositories, "repositories"); //$NON-NLS-1$
+		this.ownsRepositoryService= ownsRepositoryService;
 	}
 
 	@Override
@@ -104,6 +110,8 @@ public class HibernateRepositoryResolver
 
 	@Override
 	public void close() {
-		repositories.close();
+		if (ownsRepositoryService) {
+			repositories.close();
+		}
 	}
 }

--- a/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/JGitServerApplicationLifecycleTest.java
+++ b/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/JGitServerApplicationLifecycleTest.java
@@ -19,6 +19,7 @@ import java.lang.reflect.Method;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.jgit.server.config.ServerPersistenceContext;
+import org.eclipse.jgit.server.repository.SandboxRepositoryService;
 import org.hibernate.SessionFactory;
 import org.junit.Test;
 
@@ -32,6 +33,11 @@ public class JGitServerApplicationLifecycleTest {
 			@Override
 			public SessionFactory sessionFactory() {
 				throw new IllegalStateException("factory unavailable"); //$NON-NLS-1$
+			}
+
+			@Override
+			public SandboxRepositoryService repositoryService() {
+				throw new AssertionError("Repository service must not be requested after factory failure"); //$NON-NLS-1$
 			}
 
 			@Override

--- a/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/config/ServerPersistenceContextTest.java
+++ b/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/config/ServerPersistenceContextTest.java
@@ -19,6 +19,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Properties;
 
+import org.eclipse.jgit.server.repository.SandboxRepositoryService;
 import org.hibernate.SessionFactory;
 import org.junit.Test;
 
@@ -26,9 +27,11 @@ import org.junit.Test;
 public class ServerPersistenceContextTest {
 
 	@Test
-	public void exposesOnlyNativeHibernateContract() throws Exception {
+	public void exposesOnlyApplicationOwnedContracts() throws Exception {
 		Method sessionFactory= ServerPersistenceContext.class.getMethod("sessionFactory"); //$NON-NLS-1$
+		Method repositoryService= ServerPersistenceContext.class.getMethod("repositoryService"); //$NON-NLS-1$
 		assertEquals(SessionFactory.class, sessionFactory.getReturnType());
+		assertEquals(SandboxRepositoryService.class, repositoryService.getReturnType());
 		assertFalse(Modifier.isPublic(CopiedServerPersistenceContext.class.getModifiers()));
 		for (Method method : ServerPersistenceContext.class.getMethods()) {
 			assertFalse(isStorageImplementation(method.getReturnType()));
@@ -42,7 +45,7 @@ public class ServerPersistenceContextTest {
 	}
 
 	@Test
-	public void ownsAndClosesNativeSessionFactory() {
+	public void ownsRepositoryServiceAndClosesNativeSessionFactory() {
 		Properties properties= new Properties();
 		properties.setProperty("hibernate.connection.url", //$NON-NLS-1$
 				"jdbc:h2:mem:server-persistence-context;DB_CLOSE_DELAY=-1"); //$NON-NLS-1$
@@ -56,7 +59,9 @@ public class ServerPersistenceContextTest {
 
 		ServerPersistenceContext context= HibernateConfig.createPersistenceContext(properties);
 		SessionFactory sessionFactory= context.sessionFactory();
+		SandboxRepositoryService repositories= context.repositoryService();
 		assertSame(sessionFactory, context.sessionFactory());
+		assertSame(repositories, context.repositoryService());
 		assertFalse(sessionFactory.isClosed());
 
 		context.close();

--- a/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/resolver/HibernateRepositoryResolverOwnershipTest.java
+++ b/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/resolver/HibernateRepositoryResolverOwnershipTest.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jgit.server.resolver;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.server.repository.SandboxRepositoryInfo;
+import org.eclipse.jgit.server.repository.SandboxRepositoryService;
+import org.junit.Test;
+
+/** Ownership contracts for repository resolvers. */
+public class HibernateRepositoryResolverOwnershipTest {
+
+	@Test
+	public void doesNotCloseApplicationOwnedRepositoryService() {
+		AtomicInteger closeCount= new AtomicInteger();
+		SandboxRepositoryService repositories= new SandboxRepositoryService() {
+			@Override
+			public Repository openOrCreate(String name) throws IOException {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public SandboxRepositoryInfo info(String name) throws IOException {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public SandboxRepositoryInfo setDescription(String name, String description) throws IOException {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public boolean isOpen(String name) {
+				return false;
+			}
+
+			@Override
+			public void close() {
+				closeCount.incrementAndGet();
+			}
+		};
+
+		HibernateRepositoryResolver resolver= new HibernateRepositoryResolver(repositories);
+		resolver.close();
+
+		assertEquals("The application context, not its resolver, owns the supplied service", //$NON-NLS-1$
+				0, closeCount.get());
+	}
+}


### PR DESCRIPTION
## Purpose

Move active repository-service selection and handle ownership into the application-owned `ServerPersistenceContext`.

## Changes

- expose `SandboxRepositoryService` beside the native `SessionFactory` without leaking copied or released implementation types;
- let `CopiedServerPersistenceContext` construct and own the transitional copied adapter;
- close repository handles before closing Hibernate, with suppressed-failure preservation;
- make `JGitServerApplication` consume the context-owned service instead of implicitly selecting the copied backend through `HibernateRepositoryResolver(SessionFactory)`;
- encode resolver ownership explicitly: resolvers close adapters they construct themselves, but never close a service supplied by the application context;
- stop closing the same repository service through both resolver and context during application shutdown;
- extend boundary, resolver-ownership and startup-failure tests.

## Architectural effect

The normal server startup now has one local cut-over point. A later external-Core persistence context can provide `ExternalHibernateRepositoryService` without changing Jetty, REST, Smart HTTP or default-repository provisioning. This PR deliberately does not activate external Core or run schema migration.

Refs #1303.