### PR TITLE
Prepare a guarded external Core persistence context

### DIFF
--- a/docs/jgit-storage-legacy-adoption.md
+++ b/docs/jgit-storage-legacy-adoption.md
@@ -14,7 +14,7 @@ The preflight command:
 
 - opens a plain JDBC connection using the normal `JGIT_DB_*` environment variables;
 - accepts PostgreSQL, HSQLDB and SQL Server, matching the published 0.1.15 legacy-adoption migrations;
-- requires `;ifexists=true` in an HSQLDB URL so a mistyped file path cannot create a new database;
+- requires `;ifexists=true` in an HSQLDB URL so a mistyped file path cannot create a database;
 - marks the opened JDBC connection read-only before the first schema query;
 - calls `LegacyCoreSchemaAdoption.requireSafeToAdopt(...)` from the pinned non-SNAPSHOT Core release;
 - does not build a Hibernate `SessionFactory`;
@@ -116,3 +116,30 @@ Before enabling writers:
 - archive Flyway output and deployed artifact checksums.
 
 Rollback is database restore plus the previous application artifact; no reverse migration is assumed.
+
+## Prepared external-Core runtime boundary
+
+After the database-specific adoption or installation has established the normal Core Flyway history, application code can explicitly construct the prepared runtime boundary with:
+
+```java
+ServerPersistenceContext context =
+    HibernateConfig.createExternalPersistenceContext(properties);
+```
+
+This factory is deliberately separate from the normal server startup path. Before Hibernate starts, it requires:
+
+- `hibernate.hbm2ddl.auto=validate` exactly;
+- the normal `jgit_storage_hibernate_core_schema_history` table in the selected schema;
+- no unsuccessful row in that history;
+- at least one successful versioned Core migration.
+
+The subsequent Hibernate bootstrap performs the definitive physical-schema validation. The startup guard neither runs Flyway nor repairs a history table.
+
+The external context registers the released `CoreEntities` exactly once and adds only the explicitly reviewed Sandbox projections `GitCommitIndex`, `JavaBlobIndex` and `FilePathHistory`. It deliberately excludes:
+
+- the copied `GitPackEntity` and `GitReflogEntity`, whose Hibernate entity names collide with released Core mappings;
+- the copied `GitObjectEntity` and `GitRefEntity`, because the released pack/reftable backend does not maintain those legacy tables.
+
+Repository handles are served through `ExternalHibernateRepositoryService` and closed before the application-owned `SessionFactory`. This makes the Core lifecycle executable without leaking the external implementation into REST or Smart HTTP callers.
+
+Normal `JGitServerApplication` startup still selects the copied persistence context. Activating the external context globally remains blocked until Search, analytics and Java-analysis queries no longer depend on copied Core/query entities and their schema/data transition has independent integration evidence. No environment switch is provided that could bypass this boundary accidentally.

--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/config/ExternalCoreStartupGuard.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/config/ExternalCoreStartupGuard.java
@@ -91,19 +91,48 @@ final class ExternalCoreStartupGuard {
 		DatabaseMetaData metadata= connection.getMetaData();
 		TableReference history= findHistoryTable(connection, metadata,
 				preferredSchema);
-		Map<String, String> columns= columns(metadata, history);
+		ValidatedHistoryQuery query= validatedHistoryQuery(metadata, history,
+				columns(metadata, history));
+		HistoryEvidence evidence= readValidatedHistory(connection, query);
+		if (!evidence.sawRow() || !evidence.sawVersionedSuccess()) {
+			throw new IllegalStateException(
+					"Core Flyway history contains no successful versioned migration."); //$NON-NLS-1$
+		}
+	}
+
+	private static ValidatedHistoryQuery validatedHistoryQuery(
+			DatabaseMetaData metadata, TableReference history,
+			Map<String, String> columns) throws SQLException {
+		if (!CoreSchemaMigrations.SCHEMA_HISTORY_TABLE
+				.equalsIgnoreCase(history.name())) {
+			throw new IllegalStateException(
+					"Refusing to query an unexpected schema-history table: " //$NON-NLS-1$
+							+ history.name());
+		}
 		String installedRank= requiredColumn(columns, "installed_rank"); //$NON-NLS-1$
 		String version= requiredColumn(columns, "version"); //$NON-NLS-1$
 		String success= requiredColumn(columns, "success"); //$NON-NLS-1$
-		String sql= "SELECT " + quote(metadata, version) + ", " //$NON-NLS-1$ //$NON-NLS-2$
-				+ quote(metadata, success) + " FROM " //$NON-NLS-1$
-				+ qualifiedName(metadata, history) + " ORDER BY " //$NON-NLS-1$
-				+ quote(metadata, installedRank);
+		return new ValidatedHistoryQuery(
+				"SELECT " + quote(metadata, version) + ", " //$NON-NLS-1$ //$NON-NLS-2$
+						+ quote(metadata, success) + " FROM " //$NON-NLS-1$
+						+ qualifiedName(metadata, history) + " ORDER BY " //$NON-NLS-1$
+						+ quote(metadata, installedRank));
+	}
 
+	/**
+	 * Execute a query produced only by {@link #validatedHistoryQuery}.
+	 *
+	 * <p>The SQL contains no value supplied by a caller. Its table and column
+	 * names are exact allow-listed Flyway identifiers obtained from JDBC metadata;
+	 * the optional schema also comes from metadata, and every identifier is quoted
+	 * with the driver's quote string with embedded quotes doubled.</p>
+	 */
+	private static HistoryEvidence readValidatedHistory(Connection connection,
+			ValidatedHistoryQuery query) throws SQLException {
 		boolean sawRow= false;
 		boolean sawVersionedSuccess= false;
 		try (Statement statement= connection.createStatement();
-				ResultSet rows= statement.executeQuery(sql)) {
+				ResultSet rows= statement.executeQuery(query.sql())) {
 			while (rows.next()) {
 				sawRow= true;
 				String migrationVersion= rows.getString(1);
@@ -117,10 +146,7 @@ final class ExternalCoreStartupGuard {
 				}
 			}
 		}
-		if (!sawRow || !sawVersionedSuccess) {
-			throw new IllegalStateException(
-					"Core Flyway history contains no successful versioned migration."); //$NON-NLS-1$
-		}
+		return new HistoryEvidence(sawRow, sawVersionedSuccess);
 	}
 
 	private static TableReference findHistoryTable(Connection connection,
@@ -205,6 +231,11 @@ final class ExternalCoreStartupGuard {
 					"Core Flyway history table is missing required column " //$NON-NLS-1$
 							+ logicalName + '.');
 		}
+		if (!logicalName.equalsIgnoreCase(actualName)) {
+			throw new IllegalStateException(
+					"Core Flyway history column has an unexpected identifier: " //$NON-NLS-1$
+							+ actualName);
+		}
 		return actualName;
 	}
 
@@ -235,6 +266,13 @@ final class ExternalCoreStartupGuard {
 		return value;
 	}
 
+	private record HistoryEvidence(boolean sawRow,
+			boolean sawVersionedSuccess) {
+	}
+
 	private record TableReference(String catalog, String schema, String name) {
+	}
+
+	private record ValidatedHistoryQuery(String sql) {
 	}
 }

--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/config/ExternalCoreStartupGuard.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/config/ExternalCoreStartupGuard.java
@@ -1,0 +1,240 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jgit.server.config;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.Statement;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+
+import io.github.carstenartur.jgit.storage.hibernate.schema.CoreSchemaMigrations;
+
+/**
+ * Read-only startup gate for the released Core persistence context.
+ *
+ * <p>The external backend is accepted only after a normal Core Flyway history
+ * exists without failed rows and Hibernate is configured for schema validation.
+ * The guard performs no migration and starts no Hibernate services.</p>
+ */
+final class ExternalCoreStartupGuard {
+
+	private static final String CONNECTION_URL= "hibernate.connection.url"; //$NON-NLS-1$
+	private static final String CONNECTION_USER= "hibernate.connection.username"; //$NON-NLS-1$
+	private static final String CONNECTION_PASSWORD= "hibernate.connection.password"; //$NON-NLS-1$
+	private static final String CONNECTION_DRIVER= "hibernate.connection.driver_class"; //$NON-NLS-1$
+	private static final String DEFAULT_SCHEMA= "hibernate.default_schema"; //$NON-NLS-1$
+	private static final String DDL_AUTO= "hibernate.hbm2ddl.auto"; //$NON-NLS-1$
+
+	private ExternalCoreStartupGuard() {
+	}
+
+	/** Require migration evidence and validate-only Hibernate startup. */
+	static void requireReady(Properties properties) {
+		Objects.requireNonNull(properties, "properties"); //$NON-NLS-1$
+		String ddlAuto= properties.getProperty(DDL_AUTO);
+		if (ddlAuto == null || !"validate".equalsIgnoreCase(ddlAuto.strip())) { //$NON-NLS-1$
+			throw new IllegalStateException(
+					"External Core requires hibernate.hbm2ddl.auto=validate; " //$NON-NLS-1$
+							+ "run the matching Flyway adoption or installation first."); //$NON-NLS-1$
+		}
+		try {
+			inspectHistory(properties);
+		} catch (ClassNotFoundException | SQLException exception) {
+			throw new IllegalStateException(
+					"Could not verify the released Core Flyway history before Hibernate startup.", //$NON-NLS-1$
+					exception);
+		}
+	}
+
+	static void inspectHistory(Properties properties)
+			throws ClassNotFoundException, SQLException {
+		Objects.requireNonNull(properties, "properties"); //$NON-NLS-1$
+		String url= requireProperty(properties, CONNECTION_URL);
+		String driver= properties.getProperty(CONNECTION_DRIVER);
+		if (driver != null && !driver.isBlank()) {
+			Class.forName(driver);
+		}
+		String user= properties.getProperty(CONNECTION_USER, ""); //$NON-NLS-1$
+		String password= properties.getProperty(CONNECTION_PASSWORD, ""); //$NON-NLS-1$
+		try (Connection connection= DriverManager.getConnection(url, user, password)) {
+			try {
+				connection.setReadOnly(true);
+			} catch (SQLFeatureNotSupportedException exception) {
+				// The guard only executes SELECT statements even when a driver cannot
+				// advertise the connection as read-only.
+			}
+			requireSuccessfulHistory(connection,
+					properties.getProperty(DEFAULT_SCHEMA));
+		}
+	}
+
+	static void requireSuccessfulHistory(Connection connection,
+			String preferredSchema) throws SQLException {
+		Objects.requireNonNull(connection, "connection"); //$NON-NLS-1$
+		DatabaseMetaData metadata= connection.getMetaData();
+		TableReference history= findHistoryTable(connection, metadata,
+				preferredSchema);
+		Map<String, String> columns= columns(metadata, history);
+		String installedRank= requiredColumn(columns, "installed_rank"); //$NON-NLS-1$
+		String version= requiredColumn(columns, "version"); //$NON-NLS-1$
+		String success= requiredColumn(columns, "success"); //$NON-NLS-1$
+		String sql= "SELECT " + quote(metadata, version) + ", " //$NON-NLS-1$ //$NON-NLS-2$
+				+ quote(metadata, success) + " FROM " //$NON-NLS-1$
+				+ qualifiedName(metadata, history) + " ORDER BY " //$NON-NLS-1$
+				+ quote(metadata, installedRank);
+
+		boolean sawRow= false;
+		boolean sawVersionedSuccess= false;
+		try (Statement statement= connection.createStatement();
+				ResultSet rows= statement.executeQuery(sql)) {
+			while (rows.next()) {
+				sawRow= true;
+				String migrationVersion= rows.getString(1);
+				boolean successful= rows.getBoolean(2);
+				if (rows.wasNull() || !successful) {
+					throw new IllegalStateException(
+							"Core Flyway history contains an unsuccessful migration row."); //$NON-NLS-1$
+				}
+				if (migrationVersion != null && !migrationVersion.isBlank()) {
+					sawVersionedSuccess= true;
+				}
+			}
+		}
+		if (!sawRow || !sawVersionedSuccess) {
+			throw new IllegalStateException(
+					"Core Flyway history contains no successful versioned migration."); //$NON-NLS-1$
+		}
+	}
+
+	private static TableReference findHistoryTable(Connection connection,
+			DatabaseMetaData metadata, String preferredSchema) throws SQLException {
+		String catalog= connection.getCatalog();
+		String schema= preferredSchema;
+		if (schema == null || schema.isBlank()) {
+			try {
+				schema= connection.getSchema();
+			} catch (SQLFeatureNotSupportedException exception) {
+				schema= null;
+			}
+		}
+
+		Map<String, TableReference> matches= new LinkedHashMap<>();
+		for (String pattern : tableNamePatterns()) {
+			collectTables(metadata, catalog, schema, pattern, matches);
+		}
+		if (matches.isEmpty() && schema != null && !schema.isBlank()) {
+			for (String pattern : tableNamePatterns()) {
+				collectTables(metadata, catalog, null, pattern, matches);
+			}
+		}
+		if (matches.isEmpty()) {
+			throw new IllegalStateException(
+					"Missing Core Flyway history table " //$NON-NLS-1$
+							+ CoreSchemaMigrations.SCHEMA_HISTORY_TABLE + '.');
+		}
+		if (matches.size() > 1) {
+			throw new IllegalStateException(
+					"Core Flyway history table is ambiguous across schemas: " //$NON-NLS-1$
+							+ matches.values());
+		}
+		return matches.values().iterator().next();
+	}
+
+	private static void collectTables(DatabaseMetaData metadata, String catalog,
+			String schema, String pattern,
+			Map<String, TableReference> matches) throws SQLException {
+		try (ResultSet tables= metadata.getTables(catalog, schema, pattern,
+				new String[] { "TABLE" })) { //$NON-NLS-1$
+			while (tables.next()) {
+				String tableName= tables.getString("TABLE_NAME"); //$NON-NLS-1$
+				if (!CoreSchemaMigrations.SCHEMA_HISTORY_TABLE
+						.equalsIgnoreCase(tableName)) {
+					continue;
+				}
+				TableReference reference= new TableReference(
+						tables.getString("TABLE_CAT"), //$NON-NLS-1$
+						tables.getString("TABLE_SCHEM"), tableName); //$NON-NLS-1$
+				String key= String.valueOf(reference.schema()).toLowerCase(Locale.ROOT)
+						+ '.' + tableName.toLowerCase(Locale.ROOT);
+				matches.putIfAbsent(key, reference);
+			}
+		}
+	}
+
+	private static List<String> tableNamePatterns() {
+		String name= CoreSchemaMigrations.SCHEMA_HISTORY_TABLE;
+		return List.of(name, name.toLowerCase(Locale.ROOT),
+				name.toUpperCase(Locale.ROOT));
+	}
+
+	private static Map<String, String> columns(DatabaseMetaData metadata,
+			TableReference table) throws SQLException {
+		Map<String, String> columns= new LinkedHashMap<>();
+		try (ResultSet result= metadata.getColumns(table.catalog(), table.schema(),
+				table.name(), null)) {
+			while (result.next()) {
+				String name= result.getString("COLUMN_NAME"); //$NON-NLS-1$
+				columns.putIfAbsent(name.toLowerCase(Locale.ROOT), name);
+			}
+		}
+		return columns;
+	}
+
+	private static String requiredColumn(Map<String, String> columns,
+			String logicalName) {
+		String actualName= columns.get(logicalName.toLowerCase(Locale.ROOT));
+		if (actualName == null) {
+			throw new IllegalStateException(
+					"Core Flyway history table is missing required column " //$NON-NLS-1$
+							+ logicalName + '.');
+		}
+		return actualName;
+	}
+
+	private static String qualifiedName(DatabaseMetaData metadata,
+			TableReference table) throws SQLException {
+		if (table.schema() == null || table.schema().isBlank()) {
+			return quote(metadata, table.name());
+		}
+		return quote(metadata, table.schema()) + '.'
+				+ quote(metadata, table.name());
+	}
+
+	private static String quote(DatabaseMetaData metadata, String identifier)
+			throws SQLException {
+		String quote= metadata.getIdentifierQuoteString();
+		if (quote == null || quote.isBlank()) {
+			return identifier;
+		}
+		return quote + identifier.replace(quote, quote + quote) + quote;
+	}
+
+	private static String requireProperty(Properties properties, String name) {
+		String value= properties.getProperty(name);
+		if (value == null || value.isBlank()) {
+			throw new IllegalArgumentException(
+					"Missing required database property: " + name); //$NON-NLS-1$
+		}
+		return value;
+	}
+
+	private record TableReference(String catalog, String schema, String name) {
+	}
+}

--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/config/ExternalServerPersistenceContext.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/config/ExternalServerPersistenceContext.java
@@ -33,12 +33,15 @@ import io.github.carstenartur.jgit.storage.hibernate.config.HibernateSessionFact
  */
 final class ExternalServerPersistenceContext implements ServerPersistenceContext {
 
+	private static final String LUCENE= "lucene"; //$NON-NLS-1$
+	private static final String LOCAL_FILESYSTEM= "local-filesystem"; //$NON-NLS-1$
+
 	private final HibernateSessionFactoryProvider owner;
 	private final SandboxRepositoryService repositories;
 
 	ExternalServerPersistenceContext(Properties properties) {
 		this(new HibernateSessionFactoryProvider(
-				copyOf(Objects.requireNonNull(properties, "properties")), //$NON-NLS-1$
+				serverProperties(Objects.requireNonNull(properties, "properties")), //$NON-NLS-1$
 				SandboxProjectionEntities.annotatedClasses()));
 	}
 
@@ -80,9 +83,38 @@ final class ExternalServerPersistenceContext implements ServerPersistenceContext
 		}
 	}
 
-	private static Properties copyOf(Properties properties) {
+	private static Properties serverProperties(Properties properties) {
 		Properties copy= new Properties();
 		copy.putAll(properties);
+
+		copy.putIfAbsent("hibernate.search.backend.type", LUCENE); //$NON-NLS-1$
+		String backend= copy.getProperty("hibernate.search.backend.type"); //$NON-NLS-1$
+		if (LUCENE.equalsIgnoreCase(backend)) {
+			copy.putIfAbsent("hibernate.search.backend.directory.type", //$NON-NLS-1$
+					LOCAL_FILESYSTEM);
+			if (LOCAL_FILESYSTEM.equalsIgnoreCase(copy.getProperty(
+					"hibernate.search.backend.directory.type"))) { //$NON-NLS-1$
+				String root= System.getenv("JGIT_SEARCH_INDEX_DIR"); //$NON-NLS-1$
+				if (root == null || root.isBlank()) {
+					root= "jgit-search-index"; //$NON-NLS-1$
+				}
+				copy.putIfAbsent("hibernate.search.backend.directory.root", root); //$NON-NLS-1$
+			}
+		}
+		copy.putIfAbsent("hibernate.search.backend.analysis.configurer", //$NON-NLS-1$
+				"class:org.eclipse.jgit.storage.hibernate.search.JavaSourceAnalysisConfigurer"); //$NON-NLS-1$
+
+		copy.putIfAbsent("hibernate.connection.provider_class", //$NON-NLS-1$
+				"org.hibernate.hikaricp.internal.HikariCPConnectionProvider"); //$NON-NLS-1$
+		copy.putIfAbsent("hibernate.hikari.minimumIdle", "5"); //$NON-NLS-1$ //$NON-NLS-2$
+		copy.putIfAbsent("hibernate.hikari.maximumPoolSize", "20"); //$NON-NLS-1$ //$NON-NLS-2$
+		copy.putIfAbsent("hibernate.hikari.idleTimeout", "300000"); //$NON-NLS-1$ //$NON-NLS-2$
+		copy.putIfAbsent("hibernate.hikari.connectionTimeout", "20000"); //$NON-NLS-1$ //$NON-NLS-2$
+		copy.putIfAbsent("hibernate.hikari.maxLifetime", "1200000"); //$NON-NLS-1$ //$NON-NLS-2$
+		copy.putIfAbsent("hibernate.connection.handling_mode", //$NON-NLS-1$
+				"DELAYED_ACQUISITION_AND_RELEASE_AFTER_TRANSACTION"); //$NON-NLS-1$
+		copy.putIfAbsent("hibernate.cache.use_second_level_cache", "true"); //$NON-NLS-1$ //$NON-NLS-2$
+		copy.putIfAbsent("hibernate.cache.region.factory_class", "jcache"); //$NON-NLS-1$ //$NON-NLS-2$
 		return copy;
 	}
 }

--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/config/ExternalServerPersistenceContext.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/config/ExternalServerPersistenceContext.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jgit.server.config;
+
+import java.util.Objects;
+import java.util.Properties;
+
+import org.eclipse.jgit.server.repository.ExternalHibernateRepositoryService;
+import org.eclipse.jgit.server.repository.SandboxRepositoryService;
+import org.hibernate.SessionFactory;
+import org.sandbox.jgit.storage.integration.SandboxProjectionEntities;
+
+import io.github.carstenartur.jgit.storage.hibernate.DefaultHibernateRepositoryFactory;
+import io.github.carstenartur.jgit.storage.hibernate.config.HibernateSessionFactoryProvider;
+
+/**
+ * Application-owned persistence context backed by the released generic Core
+ * implementation.
+ *
+ * <p>This context is intentionally not the normal server default yet. It
+ * registers the released Core mappings exactly once together with the explicit
+ * compatible Sandbox projection list. Production construction must go through
+ * {@link HibernateConfig#createExternalPersistenceContext(Properties)}, which
+ * verifies the Flyway history and Hibernate validation mode before bootstrap.</p>
+ */
+final class ExternalServerPersistenceContext implements ServerPersistenceContext {
+
+	private final HibernateSessionFactoryProvider owner;
+	private final SandboxRepositoryService repositories;
+
+	ExternalServerPersistenceContext(Properties properties) {
+		this(new HibernateSessionFactoryProvider(
+				copyOf(Objects.requireNonNull(properties, "properties")), //$NON-NLS-1$
+				SandboxProjectionEntities.annotatedClasses()));
+	}
+
+	ExternalServerPersistenceContext(HibernateSessionFactoryProvider owner) {
+		this.owner= Objects.requireNonNull(owner, "owner"); //$NON-NLS-1$
+		this.repositories= new ExternalHibernateRepositoryService(
+				new DefaultHibernateRepositoryFactory(owner.getSessionFactory()));
+	}
+
+	@Override
+	public SessionFactory sessionFactory() {
+		return owner.getSessionFactory();
+	}
+
+	@Override
+	public SandboxRepositoryService repositoryService() {
+		return repositories;
+	}
+
+	@Override
+	public void close() {
+		RuntimeException failure= null;
+		try {
+			repositories.close();
+		} catch (RuntimeException exception) {
+			failure= exception;
+		}
+		try {
+			owner.close();
+		} catch (RuntimeException exception) {
+			if (failure == null) {
+				failure= exception;
+			} else {
+				failure.addSuppressed(exception);
+			}
+		}
+		if (failure != null) {
+			throw failure;
+		}
+	}
+
+	private static Properties copyOf(Properties properties) {
+		Properties copy= new Properties();
+		copy.putAll(properties);
+		return copy;
+	}
+}

--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/config/HibernateConfig.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/config/HibernateConfig.java
@@ -75,6 +75,28 @@ public class HibernateConfig {
 	}
 
 	/**
+	 * Create an explicitly requested persistence context backed by the released
+	 * generic Core implementation.
+	 *
+	 * <p>The method fails before Hibernate bootstrap unless the normal Core Flyway
+	 * history is present without failed rows and
+	 * {@code hibernate.hbm2ddl.auto=validate}. Normal server startup deliberately
+	 * continues to use {@link #createPersistenceContext(Properties)} until the
+	 * remaining copied Search/query implementation has its own migration boundary.</p>
+	 *
+	 * @param properties
+	 *            Hibernate configuration properties for an already migrated schema
+	 * @return the external-Core persistence context
+	 * @throws IllegalStateException
+	 *             if migration evidence or validate-only startup is missing
+	 */
+	public static ServerPersistenceContext createExternalPersistenceContext(
+			Properties properties) {
+		ExternalCoreStartupGuard.requireReady(properties);
+		return new ExternalServerPersistenceContext(properties);
+	}
+
+	/**
 	 * Create a copied session-factory provider configured from environment variables.
 	 *
 	 * @return the configured session factory provider

--- a/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/config/ExternalCoreStartupGuardTest.java
+++ b/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/config/ExternalCoreStartupGuardTest.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.jgit.server.config;
 
-import static org.junit.Assert.assertDoesNotThrow;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -67,8 +66,7 @@ public class ExternalCoreStartupGuardTest {
 		Properties properties= properties(databaseUrl());
 		createHistory(properties, true);
 
-		assertDoesNotThrow(
-				() -> ExternalCoreStartupGuard.requireReady(properties));
+		ExternalCoreStartupGuard.requireReady(properties);
 	}
 
 	private static Properties properties(String url) {

--- a/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/config/ExternalCoreStartupGuardTest.java
+++ b/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/config/ExternalCoreStartupGuardTest.java
@@ -69,6 +69,27 @@ public class ExternalCoreStartupGuardTest {
 		ExternalCoreStartupGuard.requireReady(properties);
 	}
 
+	@Test
+	public void acceptsMetadataQuotedConfiguredSchema() throws Exception {
+		Properties properties= properties(databaseUrl());
+		String schema= "tenant\"one"; //$NON-NLS-1$
+		properties.setProperty("hibernate.default_schema", schema); //$NON-NLS-1$
+		Class.forName(properties.getProperty("hibernate.connection.driver_class")); //$NON-NLS-1$
+		try (Connection connection= connection(properties);
+				Statement statement= connection.createStatement()) {
+			String quotedSchema= '"' + schema.replace("\"", "\"\"") + '"'; //$NON-NLS-1$ //$NON-NLS-2$
+			statement.execute("CREATE SCHEMA " + quotedSchema); //$NON-NLS-1$
+			statement.execute("CREATE TABLE " + quotedSchema + '.' //$NON-NLS-1$
+					+ CoreSchemaMigrations.SCHEMA_HISTORY_TABLE
+					+ " (installed_rank INT PRIMARY KEY, version VARCHAR(50), success BOOLEAN NOT NULL)"); //$NON-NLS-1$
+			statement.execute("INSERT INTO " + quotedSchema + '.' //$NON-NLS-1$
+					+ CoreSchemaMigrations.SCHEMA_HISTORY_TABLE
+					+ " (installed_rank, version, success) VALUES (1, '0.1.15', TRUE)"); //$NON-NLS-1$
+		}
+
+		ExternalCoreStartupGuard.requireReady(properties);
+	}
+
 	private static Properties properties(String url) {
 		Properties properties= new Properties();
 		properties.setProperty("hibernate.connection.url", url); //$NON-NLS-1$
@@ -87,10 +108,7 @@ public class ExternalCoreStartupGuardTest {
 	private static void createHistory(Properties properties, boolean success)
 			throws Exception {
 		Class.forName(properties.getProperty("hibernate.connection.driver_class")); //$NON-NLS-1$
-		try (Connection connection= DriverManager.getConnection(
-				properties.getProperty("hibernate.connection.url"), //$NON-NLS-1$
-				properties.getProperty("hibernate.connection.username"), //$NON-NLS-1$
-				properties.getProperty("hibernate.connection.password")); //$NON-NLS-1$
+		try (Connection connection= connection(properties);
 				Statement statement= connection.createStatement()) {
 			statement.execute("CREATE TABLE " //$NON-NLS-1$
 					+ CoreSchemaMigrations.SCHEMA_HISTORY_TABLE
@@ -100,5 +118,12 @@ public class ExternalCoreStartupGuardTest {
 					+ " (installed_rank, version, success) VALUES (1, '0.1.15', " //$NON-NLS-1$
 					+ success + ')');
 		}
+	}
+
+	private static Connection connection(Properties properties) throws Exception {
+		return DriverManager.getConnection(
+				properties.getProperty("hibernate.connection.url"), //$NON-NLS-1$
+				properties.getProperty("hibernate.connection.username"), //$NON-NLS-1$
+				properties.getProperty("hibernate.connection.password")); //$NON-NLS-1$
 	}
 }

--- a/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/config/ExternalCoreStartupGuardTest.java
+++ b/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/config/ExternalCoreStartupGuardTest.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jgit.server.config;
+
+import static org.junit.Assert.assertDoesNotThrow;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+import io.github.carstenartur.jgit.storage.hibernate.schema.CoreSchemaMigrations;
+
+/** Tests the read-only Flyway-history and validate-mode gate. */
+public class ExternalCoreStartupGuardTest {
+
+	private static final AtomicInteger DATABASE_COUNTER= new AtomicInteger();
+
+	@Test
+	public void rejectsAnyHibernateSchemaMutationModeBeforeConnecting() {
+		Properties properties= properties("jdbc:invalid:not-opened"); //$NON-NLS-1$
+		properties.setProperty("hibernate.hbm2ddl.auto", "update"); //$NON-NLS-1$ //$NON-NLS-2$
+
+		IllegalStateException failure= assertThrows(IllegalStateException.class,
+				() -> ExternalCoreStartupGuard.requireReady(properties));
+
+		assertTrue(failure.getMessage().contains("hbm2ddl.auto=validate")); //$NON-NLS-1$
+	}
+
+	@Test
+	public void rejectsDatabaseWithoutNormalCoreHistory() {
+		Properties properties= properties(databaseUrl());
+
+		IllegalStateException failure= assertThrows(IllegalStateException.class,
+				() -> ExternalCoreStartupGuard.requireReady(properties));
+
+		assertTrue(failure.getMessage().contains(
+				CoreSchemaMigrations.SCHEMA_HISTORY_TABLE));
+	}
+
+	@Test
+	public void rejectsUnsuccessfulFlywayHistoryRow() throws Exception {
+		Properties properties= properties(databaseUrl());
+		createHistory(properties, false);
+
+		IllegalStateException failure= assertThrows(IllegalStateException.class,
+				() -> ExternalCoreStartupGuard.requireReady(properties));
+
+		assertTrue(failure.getMessage().contains("unsuccessful migration")); //$NON-NLS-1$
+	}
+
+	@Test
+	public void acceptsSuccessfulVersionedCoreHistory() throws Exception {
+		Properties properties= properties(databaseUrl());
+		createHistory(properties, true);
+
+		assertDoesNotThrow(
+				() -> ExternalCoreStartupGuard.requireReady(properties));
+	}
+
+	private static Properties properties(String url) {
+		Properties properties= new Properties();
+		properties.setProperty("hibernate.connection.url", url); //$NON-NLS-1$
+		properties.setProperty("hibernate.connection.username", "sa"); //$NON-NLS-1$ //$NON-NLS-2$
+		properties.setProperty("hibernate.connection.password", ""); //$NON-NLS-1$ //$NON-NLS-2$
+		properties.setProperty("hibernate.connection.driver_class", "org.h2.Driver"); //$NON-NLS-1$ //$NON-NLS-2$
+		properties.setProperty("hibernate.hbm2ddl.auto", "validate"); //$NON-NLS-1$ //$NON-NLS-2$
+		return properties;
+	}
+
+	private static String databaseUrl() {
+		return "jdbc:h2:mem:external-core-history-" //$NON-NLS-1$
+				+ DATABASE_COUNTER.incrementAndGet() + ";DB_CLOSE_DELAY=-1"; //$NON-NLS-1$
+	}
+
+	private static void createHistory(Properties properties, boolean success)
+			throws Exception {
+		Class.forName(properties.getProperty("hibernate.connection.driver_class")); //$NON-NLS-1$
+		try (Connection connection= DriverManager.getConnection(
+				properties.getProperty("hibernate.connection.url"), //$NON-NLS-1$
+				properties.getProperty("hibernate.connection.username"), //$NON-NLS-1$
+				properties.getProperty("hibernate.connection.password")); //$NON-NLS-1$
+				Statement statement= connection.createStatement()) {
+			statement.execute("CREATE TABLE " //$NON-NLS-1$
+					+ CoreSchemaMigrations.SCHEMA_HISTORY_TABLE
+					+ " (installed_rank INT PRIMARY KEY, version VARCHAR(50), success BOOLEAN NOT NULL)"); //$NON-NLS-1$
+			statement.execute("INSERT INTO " //$NON-NLS-1$
+					+ CoreSchemaMigrations.SCHEMA_HISTORY_TABLE
+					+ " (installed_rank, version, success) VALUES (1, '0.1.15', " //$NON-NLS-1$
+					+ success + ')');
+		}
+	}
+}

--- a/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/config/ExternalServerPersistenceContextTest.java
+++ b/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/config/ExternalServerPersistenceContextTest.java
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jgit.server.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.server.repository.ExternalHibernateRepositoryService;
+import org.hibernate.SessionFactory;
+import org.junit.Test;
+
+import io.github.carstenartur.jgit.storage.hibernate.schema.CoreSchemaMigrations;
+
+/** Integration contracts for the prepared external-Core persistence context. */
+public class ExternalServerPersistenceContextTest {
+
+	private static final AtomicInteger DATABASE_COUNTER= new AtomicInteger();
+
+	@Test
+	public void registersReleasedCoreAndOnlyCompatibleSandboxProjections()
+			throws Exception {
+		Properties properties= properties(databaseUrl(), "create-drop"); //$NON-NLS-1$
+		SessionFactory sessionFactory;
+
+		try (ServerPersistenceContext context=
+				new ExternalServerPersistenceContext(properties)) {
+			sessionFactory= context.sessionFactory();
+			List<String> entityNames= sessionFactory.getMetamodel().getEntities()
+					.stream().map(entity -> entity.getJavaType().getName())
+					.sorted().toList();
+
+			assertEquals(List.of(
+					"io.github.carstenartur.jgit.storage.hibernate.entity.GitPackChunkEntity", //$NON-NLS-1$
+					"io.github.carstenartur.jgit.storage.hibernate.entity.GitPackEntity", //$NON-NLS-1$
+					"io.github.carstenartur.jgit.storage.hibernate.entity.GitReflogEntity", //$NON-NLS-1$
+					"io.github.carstenartur.jgit.storage.hibernate.entity.GitRepositoryLockEntity", //$NON-NLS-1$
+					"org.eclipse.jgit.storage.hibernate.entity.FilePathHistory", //$NON-NLS-1$
+					"org.eclipse.jgit.storage.hibernate.entity.GitCommitIndex", //$NON-NLS-1$
+					"org.eclipse.jgit.storage.hibernate.entity.JavaBlobIndex"), //$NON-NLS-1$
+					entityNames);
+			assertFalse(entityNames.contains(
+					"org.eclipse.jgit.storage.hibernate.entity.GitPackEntity")); //$NON-NLS-1$
+			assertFalse(entityNames.contains(
+					"org.eclipse.jgit.storage.hibernate.entity.GitReflogEntity")); //$NON-NLS-1$
+			assertFalse(entityNames.contains(
+					"org.eclipse.jgit.storage.hibernate.entity.GitObjectEntity")); //$NON-NLS-1$
+			assertFalse(entityNames.contains(
+					"org.eclipse.jgit.storage.hibernate.entity.GitRefEntity")); //$NON-NLS-1$
+			assertTrue(context.repositoryService()
+					instanceof ExternalHibernateRepositoryService);
+
+			Repository repository= context.repositoryService()
+					.openOrCreate("external-context"); //$NON-NLS-1$
+			assertNotNull(repository);
+			assertTrue(repository.isBare());
+			assertFalse(sessionFactory.isClosed());
+		}
+
+		assertTrue(sessionFactory.isClosed());
+	}
+
+	@Test
+	public void guardedFactoryStartsOnlyAfterSchemaAndHistoryExist()
+			throws Exception {
+		String url= databaseUrl();
+		Properties createProperties= properties(url, "create"); //$NON-NLS-1$
+		try (ServerPersistenceContext ignored=
+				new ExternalServerPersistenceContext(createProperties)) {
+			// Disposable test bootstrap creates the exact mapped schema.
+		}
+		createSuccessfulHistory(createProperties);
+
+		Properties validateProperties= properties(url, "validate"); //$NON-NLS-1$
+		try (ServerPersistenceContext context= HibernateConfig
+				.createExternalPersistenceContext(validateProperties)) {
+			assertNotNull(context.repositoryService()
+					.openOrCreate("guarded-external-context")); //$NON-NLS-1$
+		}
+	}
+
+	private static Properties properties(String url, String ddlAuto) {
+		Properties properties= new Properties();
+		properties.setProperty("hibernate.connection.url", url); //$NON-NLS-1$
+		properties.setProperty("hibernate.connection.username", "sa"); //$NON-NLS-1$ //$NON-NLS-2$
+		properties.setProperty("hibernate.connection.password", ""); //$NON-NLS-1$ //$NON-NLS-2$
+		properties.setProperty("hibernate.connection.driver_class", "org.h2.Driver"); //$NON-NLS-1$ //$NON-NLS-2$
+		properties.setProperty("hibernate.dialect", "org.hibernate.dialect.H2Dialect"); //$NON-NLS-1$ //$NON-NLS-2$
+		properties.setProperty("hibernate.hbm2ddl.auto", ddlAuto); //$NON-NLS-1$
+		properties.setProperty("hibernate.show_sql", "false"); //$NON-NLS-1$ //$NON-NLS-2$
+		properties.setProperty("hibernate.search.backend.type", "lucene"); //$NON-NLS-1$ //$NON-NLS-2$
+		properties.setProperty("hibernate.search.backend.directory.type", "local-heap"); //$NON-NLS-1$ //$NON-NLS-2$
+		properties.setProperty("hibernate.search.backend.analysis.configurer", //$NON-NLS-1$
+				"class:org.eclipse.jgit.storage.hibernate.search.JavaSourceAnalysisConfigurer"); //$NON-NLS-1$
+		properties.setProperty("hibernate.cache.use_second_level_cache", "false"); //$NON-NLS-1$ //$NON-NLS-2$
+		properties.setProperty("hibernate.connection.provider_class", //$NON-NLS-1$
+				"org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl"); //$NON-NLS-1$
+		return properties;
+	}
+
+	private static String databaseUrl() {
+		return "jdbc:h2:mem:external-server-context-" //$NON-NLS-1$
+				+ DATABASE_COUNTER.incrementAndGet() + ";DB_CLOSE_DELAY=-1"; //$NON-NLS-1$
+	}
+
+	private static void createSuccessfulHistory(Properties properties)
+			throws Exception {
+		Class.forName(properties.getProperty("hibernate.connection.driver_class")); //$NON-NLS-1$
+		try (Connection connection= DriverManager.getConnection(
+				properties.getProperty("hibernate.connection.url"), //$NON-NLS-1$
+				properties.getProperty("hibernate.connection.username"), //$NON-NLS-1$
+				properties.getProperty("hibernate.connection.password")); //$NON-NLS-1$
+				Statement statement= connection.createStatement()) {
+			statement.execute("CREATE TABLE " //$NON-NLS-1$
+					+ CoreSchemaMigrations.SCHEMA_HISTORY_TABLE
+					+ " (installed_rank INT PRIMARY KEY, version VARCHAR(50), success BOOLEAN NOT NULL)"); //$NON-NLS-1$
+			statement.execute("INSERT INTO " //$NON-NLS-1$
+					+ CoreSchemaMigrations.SCHEMA_HISTORY_TABLE
+					+ " (installed_rank, version, success) VALUES (1, '0.1.15', TRUE)"); //$NON-NLS-1$
+		}
+	}
+}

--- a/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/config/ServerPersistenceContextTest.java
+++ b/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/config/ServerPersistenceContextTest.java
@@ -33,6 +33,7 @@ public class ServerPersistenceContextTest {
 		assertEquals(SessionFactory.class, sessionFactory.getReturnType());
 		assertEquals(SandboxRepositoryService.class, repositoryService.getReturnType());
 		assertFalse(Modifier.isPublic(CopiedServerPersistenceContext.class.getModifiers()));
+		assertFalse(Modifier.isPublic(ExternalServerPersistenceContext.class.getModifiers()));
 		for (Method method : ServerPersistenceContext.class.getMethods()) {
 			assertFalse(isStorageImplementation(method.getReturnType()));
 			for (Class<?> parameterType : method.getParameterTypes()) {

--- a/sandbox-jgit-storage-hibernate/src/org/sandbox/jgit/storage/integration/SandboxProjectionEntities.java
+++ b/sandbox-jgit-storage-hibernate/src/org/sandbox/jgit/storage/integration/SandboxProjectionEntities.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jgit.storage.integration;
+
+import java.util.List;
+
+import org.eclipse.jgit.storage.hibernate.entity.FilePathHistory;
+import org.eclipse.jgit.storage.hibernate.entity.GitCommitIndex;
+import org.eclipse.jgit.storage.hibernate.entity.JavaBlobIndex;
+
+/**
+ * Transitional registry of Sandbox-owned derived projections that can share a
+ * persistence context with the released Core entities.
+ *
+ * <p>The list deliberately excludes every copied storage mapping. In
+ * particular, copied pack and reflog entities would collide with the released
+ * Core entity names, while copied object and ref entities are not maintained by
+ * the released pack/reftable backend. Keeping the list explicit prevents a
+ * package scan from silently reintroducing those incompatible mappings during
+ * the cut-over.</p>
+ */
+public final class SandboxProjectionEntities {
+
+	private static final List<Class<?>> ANNOTATED_CLASSES= List.of(
+			GitCommitIndex.class, JavaBlobIndex.class, FilePathHistory.class);
+
+	private SandboxProjectionEntities() {
+	}
+
+	/**
+	 * Return the immutable, explicitly reviewed projection entity list.
+	 *
+	 * @return compatible Sandbox projection entities in stable registration order
+	 */
+	public static List<Class<?>> annotatedClasses() {
+		return ANNOTATED_CLASSES;
+	}
+}

--- a/sandbox-jgit-storage-hibernate/tst/org/sandbox/jgit/storage/integration/SandboxProjectionEntitiesTest.java
+++ b/sandbox-jgit-storage-hibernate/tst/org/sandbox/jgit/storage/integration/SandboxProjectionEntitiesTest.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jgit.storage.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+/** Contracts for the transitional external-Core projection boundary. */
+class SandboxProjectionEntitiesTest {
+
+	@Test
+	void exposesOnlyExplicitDerivedProjectionMappings() {
+		List<Class<?>> entities= SandboxProjectionEntities.annotatedClasses();
+
+		assertEquals(List.of(
+				"org.eclipse.jgit.storage.hibernate.entity.GitCommitIndex", //$NON-NLS-1$
+				"org.eclipse.jgit.storage.hibernate.entity.JavaBlobIndex", //$NON-NLS-1$
+				"org.eclipse.jgit.storage.hibernate.entity.FilePathHistory"), //$NON-NLS-1$
+				entities.stream().map(Class::getName).toList());
+		assertThrows(UnsupportedOperationException.class,
+				() -> entities.add(Object.class));
+	}
+
+	@Test
+	void doesNotCollideWithReleasedCoreEntityNames() {
+		Set<String> coreEntityNames= new HashSet<>(
+				JGitStorageLibraryBoundary.coreEntities().stream()
+						.map(Class::getSimpleName).toList());
+
+		assertTrue(SandboxProjectionEntities.annotatedClasses().stream()
+				.map(Class::getSimpleName)
+				.allMatch(name -> !coreEntityNames.contains(name)));
+	}
+}

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -29,13 +29,13 @@
     <Bug pattern="SE_BAD_FIELD"/>
     <Class name="~edu.umd.cs.findbugs.gui.*"/>
   </Match>
-  <Match>
+   <Match>
     <Bug pattern="UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD"/>
   </Match>
-  <Match>
+   <Match>
     <Bug pattern="DLS_DEAD_LOCAL_STORE"/>
   </Match>
-  <Match>
+   <Match>
     <Bug pattern="URF_UNREAD_FIELD"/>
   </Match>
   <Match>

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -29,13 +29,13 @@
     <Bug pattern="SE_BAD_FIELD"/>
     <Class name="~edu.umd.cs.findbugs.gui.*"/>
   </Match>
-   <Match>
+  <Match>
     <Bug pattern="UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD"/>
   </Match>
-   <Match>
+  <Match>
     <Bug pattern="DLS_DEAD_LOCAL_STORE"/>
   </Match>
-   <Match>
+  <Match>
     <Bug pattern="URF_UNREAD_FIELD"/>
   </Match>
   <Match>
@@ -67,5 +67,14 @@
          These servlets are used with embedded Jetty and never serialized in practice. -->
     <Bug pattern="SE_BAD_FIELD"/>
     <Class name="~org\.eclipse\.jgit\.server\.rest\.\w+Resource"/>
+  </Match>
+  <Match>
+    <!-- The method executes only a ValidatedHistoryQuery. Table and column names
+         are exact allow-listed Flyway identifiers discovered through JDBC metadata;
+         the optional metadata schema is driver-quoted with embedded quotes escaped.
+         Quoted-schema integration coverage protects this trust boundary. -->
+    <Bug pattern="SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE"/>
+    <Class name="org.eclipse.jgit.server.config.ExternalCoreStartupGuard"/>
+    <Method name="readValidatedHistory"/>
   </Match>
 </FindBugsFilter>


### PR DESCRIPTION
## Summary

Prepare the next safe cut-over slice for #1303 without changing the normal server backend yet.

- add an application-owned `ExternalServerPersistenceContext` backed by the released `jgit-storage-hibernate-core:0.1.15` provider and factory;
- register released Core mappings exactly once plus an explicit list of compatible Sandbox projections;
- exclude copied pack/reflog mappings that collide by Hibernate entity name and copied object/ref mappings that the released pack/reftable backend does not maintain;
- preserve the server's existing Lucene, analysis, Hikari, connection-handling and cache defaults while respecting explicit properties;
- add a read-only startup guard requiring `hibernate.hbm2ddl.auto=validate`, an unambiguous normal Core Flyway history table, no failed history rows and at least one successful versioned migration;
- expose the prepared context only through the explicit `HibernateConfig.createExternalPersistenceContext(Properties)` factory;
- keep `JGitServerApplication` on the copied context until Search, analytics and Java-analysis query dependencies have an independent migration boundary;
- document the runtime boundary and cover entity registration, repository opening, lifecycle and guarded validate-mode restart on H2.

## Safety boundary

This PR does **not** run Flyway, mutate an existing schema, add an environment switch, or activate the external backend for normal server startup. Hibernate validation remains the definitive physical-schema check after the read-only history gate.

## Remaining work for #1303

The copied Search/query layer still references copied Core entities and tables. It must be separated or replaced, with database-specific migration and reindex evidence, before the external context can become the production default and the copied storage module can be removed.

Refs #1303