### PR TITLE
Expose structured Parameterized migration rejection diagnostics

### DIFF
--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/ClosedParameterizedTestJUnitPlugin.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/ClosedParameterizedTestJUnitPlugin.java
@@ -12,11 +12,9 @@ package org.sandbox.jdt.internal.corext.fix;
 
 import static org.sandbox.jdt.internal.corext.fix.helper.lib.JUnitConstants.ORG_JUNIT_RUNWITH;
 
-import org.eclipse.jdt.core.dom.Annotation;
-import org.eclipse.jdt.core.dom.ITypeBinding;
-import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 
+import org.sandbox.jdt.internal.corext.fix.helper.ParameterizedMigrationEligibility;
 import org.sandbox.jdt.internal.corext.fix.helper.ParameterizedTestJUnitPlugin;
 import org.sandbox.jdt.internal.corext.fix.helper.lib.JunitHolder;
 import org.sandbox.jdt.triggerpattern.api.CleanupPattern;
@@ -33,43 +31,14 @@ import org.sandbox.jdt.triggerpattern.api.PatternKind;
 		displayName = "JUnit 4 @RunWith(Parameterized) → JUnit 5 @ParameterizedTest")
 final class ClosedParameterizedTestJUnitPlugin extends ParameterizedTestJUnitPlugin {
 
-	private static final String PARAMETERS_ANNOTATION= "org.junit.runners.Parameterized.Parameters"; //$NON-NLS-1$
-
 	@Override
 	protected JunitHolder createHolder(Match match) {
 		JunitHolder holder= super.createHolder(match);
 		if (holder == null || !(holder.getAdditionalInfo() instanceof TypeDeclaration type)) {
 			return holder;
 		}
-		return hasSupportedLocalContract(type) ? holder : null;
-	}
-
-	private static boolean hasSupportedLocalContract(TypeDeclaration type) {
-		int providers= 0;
-		int constructors= 0;
-		boolean parameterizedConstructor= false;
-		for (MethodDeclaration method : type.getMethods()) {
-			if (method.isConstructor()) {
-				constructors++;
-				parameterizedConstructor= !method.parameters().isEmpty();
-				continue;
-			}
-			for (Object modifier : method.modifiers()) {
-				if (modifier instanceof Annotation annotation && isParametersAnnotation(annotation)) {
-					providers++;
-					break;
-				}
-			}
-		}
-		return providers == 1 && constructors == 1 && parameterizedConstructor;
-	}
-
-	private static boolean isParametersAnnotation(Annotation annotation) {
-		ITypeBinding binding= annotation.resolveTypeBinding();
-		if (binding != null) {
-			return PARAMETERS_ANNOTATION.equals(binding.getQualifiedName());
-		}
-		String name= annotation.getTypeName().getFullyQualifiedName();
-		return "Parameters".equals(name) || PARAMETERS_ANNOTATION.equals(name); //$NON-NLS-1$
+		return ParameterizedMigrationEligibility.assess(type).eligible()
+				? holder
+				: null;
 	}
 }

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/ParameterizedMigrationEligibility.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/ParameterizedMigrationEligibility.java
@@ -17,9 +17,12 @@ import static org.sandbox.jdt.internal.corext.fix.helper.lib.JUnitConstants.ORG_
 import java.util.Objects;
 
 import org.eclipse.jdt.core.dom.Annotation;
+import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.FieldDeclaration;
 import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.MemberValuePair;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.NormalAnnotation;
 import org.eclipse.jdt.core.dom.SingleMemberAnnotation;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.TypeLiteral;
@@ -58,13 +61,14 @@ public final class ParameterizedMigrationEligibility {
 	public static boolean hasParameterizedRunner(TypeDeclaration type) {
 		Objects.requireNonNull(type);
 		for (Object modifier : type.modifiers()) {
-			if (!(modifier instanceof SingleMemberAnnotation annotation)) {
+			if (!(modifier instanceof Annotation annotation)) {
 				continue;
 			}
 			ITypeBinding annotationBinding= annotation.resolveTypeBinding();
+			Expression value= runnerValue(annotation);
 			if (annotationBinding == null
 					|| !ORG_JUNIT_RUNWITH.equals(annotationBinding.getQualifiedName())
-					|| !(annotation.getValue() instanceof TypeLiteral literal)) {
+					|| !(value instanceof TypeLiteral literal)) {
 				continue;
 			}
 			ITypeBinding runnerBinding= literal.getType().resolveBinding();
@@ -120,6 +124,21 @@ public final class ParameterizedMigrationEligibility {
 		}
 		return new Assessment(true, "PARAMETERIZED_LOCAL_CONTRACT", //$NON-NLS-1$
 				"One local provider and one parameterized constructor form the supported local rewrite contract."); //$NON-NLS-1$
+	}
+
+	private static Expression runnerValue(Annotation annotation) {
+		if (annotation instanceof SingleMemberAnnotation single) {
+			return single.getValue();
+		}
+		if (annotation instanceof NormalAnnotation normal) {
+			for (Object value : normal.values()) {
+				if (value instanceof MemberValuePair pair
+						&& "value".equals(pair.getName().getIdentifier())) { //$NON-NLS-1$
+					return pair.getValue();
+				}
+			}
+		}
+		return null;
 	}
 
 	private static boolean hasParametersAnnotation(MethodDeclaration method) {

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/ParameterizedMigrationEligibility.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/ParameterizedMigrationEligibility.java
@@ -1,0 +1,164 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.corext.fix.helper;
+
+import static org.sandbox.jdt.internal.corext.fix.helper.lib.JUnitConstants.ORG_JUNIT_RUNNERS_PARAMETERIZED;
+import static org.sandbox.jdt.internal.corext.fix.helper.lib.JUnitConstants.ORG_JUNIT_RUNNERS_PARAMETERIZED_PARAMETERS;
+import static org.sandbox.jdt.internal.corext.fix.helper.lib.JUnitConstants.ORG_JUNIT_RUNWITH;
+
+import java.util.Objects;
+
+import org.eclipse.jdt.core.dom.Annotation;
+import org.eclipse.jdt.core.dom.FieldDeclaration;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.SingleMemberAnnotation;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.core.dom.TypeLiteral;
+
+/**
+ * One shared fail-closed contract for the local JUnit 4 Parameterized rewrite
+ * and its project-planning diagnostics.
+ */
+public final class ParameterizedMigrationEligibility {
+
+	private static final String PARAMETER_ANNOTATION=
+			"org.junit.runners.Parameterized.Parameter"; //$NON-NLS-1$
+
+	/** Immutable eligibility decision with a stable diagnostic reason code. */
+	public record Assessment(boolean eligible, String reasonCode,
+			String explanation) {
+
+		/** Validate and normalize an assessment. */
+		public Assessment {
+			reasonCode= Objects.requireNonNull(reasonCode);
+			explanation= Objects.requireNonNull(explanation);
+		}
+	}
+
+	private ParameterizedMigrationEligibility() {
+	}
+
+	/**
+	 * Return whether a type declares the JUnit 4 Parameterized runner.
+	 *
+	 * @param type
+	 *            source type
+	 * @return {@code true} when bindings prove
+	 *         {@code @RunWith(Parameterized.class)}
+	 */
+	public static boolean hasParameterizedRunner(TypeDeclaration type) {
+		Objects.requireNonNull(type);
+		for (Object modifier : type.modifiers()) {
+			if (!(modifier instanceof SingleMemberAnnotation annotation)) {
+				continue;
+			}
+			ITypeBinding annotationBinding= annotation.resolveTypeBinding();
+			if (annotationBinding == null
+					|| !ORG_JUNIT_RUNWITH.equals(annotationBinding.getQualifiedName())
+					|| !(annotation.getValue() instanceof TypeLiteral literal)) {
+				continue;
+			}
+			ITypeBinding runnerBinding= literal.getType().resolveBinding();
+			if (runnerBinding != null && ORG_JUNIT_RUNNERS_PARAMETERIZED
+					.equals(runnerBinding.getErasure().getQualifiedName())) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Assess the exact local source contract understood by the existing rewrite.
+	 *
+	 * @param type
+	 *            Parameterized test type
+	 * @return eligibility or one stable fail-closed reason
+	 */
+	public static Assessment assess(TypeDeclaration type) {
+		Objects.requireNonNull(type);
+		int providers= 0;
+		int constructors= 0;
+		MethodDeclaration constructor= null;
+		for (MethodDeclaration method : type.getMethods()) {
+			if (method.isConstructor()) {
+				constructors++;
+				constructor= method;
+				continue;
+			}
+			if (hasParametersAnnotation(method)) {
+				providers++;
+			}
+		}
+		if (providers == 0) {
+			return rejected("PARAMETERIZED_PROVIDER_NOT_LOCAL", //$NON-NLS-1$
+					"No local @Parameters provider is declared; inherited or external providers require a coordinated migration."); //$NON-NLS-1$
+		}
+		if (providers > 1) {
+			return rejected("PARAMETERIZED_MULTIPLE_LOCAL_PROVIDERS", //$NON-NLS-1$
+					"More than one local @Parameters provider is declared, so a unique MethodSource cannot be selected safely."); //$NON-NLS-1$
+		}
+		if (usesFieldInjection(type)) {
+			return rejected("PARAMETERIZED_FIELD_INJECTION", //$NON-NLS-1$
+					"@Parameterized.Parameter field injection is not represented by the constructor-based local rewrite."); //$NON-NLS-1$
+		}
+		if (constructors != 1) {
+			return rejected("PARAMETERIZED_CONSTRUCTOR_NOT_UNIQUE", //$NON-NLS-1$
+					"Exactly one explicit constructor is required before constructor parameters can become test-method parameters."); //$NON-NLS-1$
+		}
+		if (constructor == null || constructor.parameters().isEmpty()) {
+			return rejected("PARAMETERIZED_CONSTRUCTOR_HAS_NO_PARAMETERS", //$NON-NLS-1$
+					"The unique constructor has no parameters to propagate to ParameterizedTest methods."); //$NON-NLS-1$
+		}
+		return new Assessment(true, "PARAMETERIZED_LOCAL_CONTRACT", //$NON-NLS-1$
+				"One local provider and one parameterized constructor form the supported local rewrite contract."); //$NON-NLS-1$
+	}
+
+	private static boolean hasParametersAnnotation(MethodDeclaration method) {
+		for (Object modifier : method.modifiers()) {
+			if (modifier instanceof Annotation annotation
+					&& isAnnotation(annotation,
+							ORG_JUNIT_RUNNERS_PARAMETERIZED_PARAMETERS,
+							"Parameters")) { //$NON-NLS-1$
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static boolean usesFieldInjection(TypeDeclaration type) {
+		for (FieldDeclaration field : type.getFields()) {
+			for (Object modifier : field.modifiers()) {
+				if (modifier instanceof Annotation annotation
+						&& isAnnotation(annotation, PARAMETER_ANNOTATION,
+								"Parameter")) { //$NON-NLS-1$
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	private static boolean isAnnotation(Annotation annotation,
+			String qualifiedName, String simpleName) {
+		ITypeBinding binding= annotation.resolveTypeBinding();
+		if (binding != null) {
+			return qualifiedName.equals(binding.getQualifiedName());
+		}
+		String sourceName= annotation.getTypeName().getFullyQualifiedName();
+		return simpleName.equals(sourceName) || qualifiedName.equals(sourceName);
+	}
+
+	private static Assessment rejected(String reasonCode,
+			String explanation) {
+		return new Assessment(false, reasonCode, explanation);
+	}
+}

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnitMultiFilePlanner.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnitMultiFilePlanner.java
@@ -19,6 +19,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.core.runtime.CoreException;
@@ -54,11 +55,24 @@ import org.sandbox.jdt.cleanup.multifile.MultiFilePlanningLimits;
 import org.sandbox.jdt.cleanup.multifile.MultiFilePlanningMetrics;
 import org.sandbox.jdt.cleanup.multifile.MultiFileScopeDiagnostic;
 import org.sandbox.jdt.cleanup.multifile.SelectedCompilationUnitPlan;
+import org.sandbox.jdt.internal.corext.fix.helper.ParameterizedMigrationEligibility;
+import org.sandbox.jdt.internal.corext.fix.helper.ParameterizedMigrationEligibility.Assessment;
 
 /** Builds the source-wide JUnit migration plan before per-file rewrites start. */
 public final class JUnitMultiFilePlanner {
 
 	private static final String CLEANUP_ID= "junit-coordinated-migration"; //$NON-NLS-1$
+
+	/** Enabled project-planning contracts for one cleanup run. */
+	public record PlanningOptions(boolean migrateExternalResourceRules,
+			boolean migrateJUnit3Hierarchies,
+			boolean diagnoseParameterizedCandidates) {
+
+		boolean hasPlanningWork() {
+			return migrateExternalResourceRules || migrateJUnit3Hierarchies
+					|| diagnoseParameterizedCandidates;
+		}
+	}
 
 	private record ResourceType(String compilationUnitHandle, String typeBindingKey, String typeName) {
 	}
@@ -111,12 +125,29 @@ public final class JUnitMultiFilePlanner {
 		return createCoordinated(project, selectedUnits, migrateExternalResourceRules, false, closedScope, monitor);
 	}
 
-	/** Plans all enabled coordinated JUnit migrations for a project selection. */
+	/** Compatibility entry point for established coordinated planning callers. */
 	public static MultiFileCleanUpPlanResult<JUnitMigrationPlan> createCoordinated(IJavaProject project,
 			ICompilationUnit[] selectedUnits, boolean migrateExternalResourceRules,
 			boolean migrateJUnit3Hierarchies, IProgressMonitor monitor) throws CoreException {
+		return createCoordinated(project, selectedUnits,
+				new PlanningOptions(migrateExternalResourceRules, migrateJUnit3Hierarchies, false), monitor);
+	}
+
+	/** Compatibility entry point for established closed-scope planning callers. */
+	public static MultiFileCleanUpPlanResult<JUnitMigrationPlan> createCoordinated(IJavaProject project,
+			ICompilationUnit[] selectedUnits, boolean migrateExternalResourceRules,
+			boolean migrateJUnit3Hierarchies, boolean closedScope, IProgressMonitor monitor) throws CoreException {
+		return createCoordinated(project, selectedUnits,
+				new PlanningOptions(migrateExternalResourceRules, migrateJUnit3Hierarchies, false), closedScope, monitor);
+	}
+
+	/** Plans all enabled coordinated JUnit migrations for a project selection. */
+	public static MultiFileCleanUpPlanResult<JUnitMigrationPlan> createCoordinated(IJavaProject project,
+			ICompilationUnit[] selectedUnits, PlanningOptions options,
+			IProgressMonitor monitor) throws CoreException {
+		Objects.requireNonNull(options);
 		SelectedCompilationUnitPlan selectedScope= SelectedCompilationUnitPlan.of(project, selectedUnits);
-		if ((!migrateExternalResourceRules && !migrateJUnit3Hierarchies) || selectedUnits.length == 0) {
+		if (!options.hasPlanningWork() || selectedUnits.length == 0) {
 			return MultiFileCleanUpPlanResult.success(emptyPlan(selectedScope));
 		}
 		if (monitor != null && monitor.isCanceled()) {
@@ -127,20 +158,21 @@ public final class JUnitMultiFilePlanner {
 		for (ICompilationUnit unit : allProjectUnits) {
 			projectHandles.add(unit.getPrimary().getHandleIdentifier());
 		}
-		return createCoordinated(project, selectedUnits, migrateExternalResourceRules, migrateJUnit3Hierarchies,
+		return createCoordinated(project, selectedUnits, options,
 				selectedScope.compilationUnitHandles().equals(projectHandles), monitor);
 	}
 
 	/** Plans enabled migrations after the caller has classified the selected source scope. */
 	public static MultiFileCleanUpPlanResult<JUnitMigrationPlan> createCoordinated(IJavaProject project,
-			ICompilationUnit[] selectedUnits, boolean migrateExternalResourceRules,
-			boolean migrateJUnit3Hierarchies, boolean closedScope, IProgressMonitor monitor) throws CoreException {
+			ICompilationUnit[] selectedUnits, PlanningOptions options,
+			boolean closedScope, IProgressMonitor monitor) throws CoreException {
+		Objects.requireNonNull(options);
 		SelectedCompilationUnitPlan selectedScope= SelectedCompilationUnitPlan.of(project, selectedUnits);
-		if ((!migrateExternalResourceRules && !migrateJUnit3Hierarchies) || selectedUnits.length == 0) {
+		if (!options.hasPlanningWork() || selectedUnits.length == 0) {
 			return MultiFileCleanUpPlanResult.success(emptyPlan(selectedScope));
 		}
-		if (!closedScope) {
-			JUnitTestTypeInventory inventory= migrateJUnit3Hierarchies
+		if (!closedScope && !options.diagnoseParameterizedCandidates()) {
+			JUnitTestTypeInventory inventory= options.migrateJUnit3Hierarchies()
 					? JUnitTestTypeInventory.capture(project, monitor)
 					: new JUnitTestTypeInventory(List.of());
 			MultiFileCleanUpDiagnostics diagnostics= diagnostics(selectedUnits, false, List.of());
@@ -155,22 +187,39 @@ public final class JUnitMultiFilePlanner {
 				MultiFilePlanningLimits.fromSystemProperties(), monitor);
 		if (!budget.mayProceed()) {
 			return new MultiFileCleanUpPlanResult<>(null, budget.status(), budget.metrics(),
-					diagnostics(selectedUnits, true, List.of()));
+					diagnostics(selectedUnits, closedScope, List.of()));
 		}
 		long parseStarted= System.nanoTime();
 		Map<String, CompilationUnit> rootsByHandle= parse(project, selectedUnits, monitor);
 		long parseNanos= System.nanoTime() - parseStarted;
 		RefactoringStatus status= budget.status();
+		List<MultiFileCandidateDiagnostic> parameterizedDiagnostics=
+				options.diagnoseParameterizedCandidates()
+						? diagnoseParameterizedCandidates(rootsByHandle, monitor)
+						: List.of();
 
-		MigrationResult externalResult= migrateExternalResourceRules
+		if (!closedScope) {
+			JUnitTestTypeInventory inventory= options.migrateJUnit3Hierarchies()
+					? JUnitTestTypeInventory.capture(project, monitor)
+					: new JUnitTestTypeInventory(List.of());
+			MultiFilePlanningMetrics metrics= budget.metrics()
+					.withDurations(parseNanos, System.nanoTime() - planningStarted)
+					.withRetainedPlanEntries(0);
+			MultiFileCleanUpDiagnostics diagnostics= diagnostics(selectedUnits, false,
+					parameterizedDiagnostics);
+			JUnitMigrationPlan plan= new JUnitMigrationPlan(selectedScope, List.of(), List.of(), inventory);
+			return MultiFileCleanUpPlanResult.success(plan, status, metrics, diagnostics);
+		}
+
+		MigrationResult externalResult= options.migrateExternalResourceRules()
 				? planExternalResources(rootsByHandle, status, monitor)
 				: new MigrationResult(List.of(), List.of());
 		MultiFilePlanningBudget.checkCanceled(monitor);
-		JUnit3HierarchyPlanner.Result junit3Result= migrateJUnit3Hierarchies
+		JUnit3HierarchyPlanner.Result junit3Result= options.migrateJUnit3Hierarchies()
 				? JUnit3HierarchyPlanner.create(project, selectedUnits, rootsByHandle, true, monitor)
 				: new JUnit3HierarchyPlanner.Result(List.of(), List.of(), new JUnitTestTypeInventory(List.of()));
 
-		List<MultiFileCandidateDiagnostic> candidateDiagnostics= new ArrayList<>();
+		List<MultiFileCandidateDiagnostic> candidateDiagnostics= new ArrayList<>(parameterizedDiagnostics);
 		candidateDiagnostics.addAll(externalResult.diagnostics());
 		candidateDiagnostics.addAll(junit3Result.diagnostics());
 		int retainedEntries= externalResult.migrations().size() + junit3Result.migrations().size();
@@ -198,6 +247,44 @@ public final class JUnitMultiFilePlanner {
 		List<RuleField> ruleFields= collectRuleFields(rootsByHandle, resourcesByTypeKey, monitor);
 		MultiFilePlanningBudget.checkCanceled(monitor);
 		return createMigrations(ruleFields, resourcesByTypeKey, status, monitor);
+	}
+
+	private static List<MultiFileCandidateDiagnostic> diagnoseParameterizedCandidates(
+			Map<String, CompilationUnit> rootsByHandle, IProgressMonitor monitor) {
+		List<MultiFileCandidateDiagnostic> diagnostics= new ArrayList<>();
+		for (Map.Entry<String, CompilationUnit> entry : rootsByHandle.entrySet()) {
+			MultiFilePlanningBudget.checkCanceled(monitor);
+			String ownerHandle= entry.getKey();
+			entry.getValue().accept(new ASTVisitor() {
+				@Override
+				public boolean visit(TypeDeclaration node) {
+					MultiFilePlanningBudget.checkCanceled(monitor);
+					if (!ParameterizedMigrationEligibility.hasParameterizedRunner(node)) {
+						return true;
+					}
+					Assessment assessment= ParameterizedMigrationEligibility.assess(node);
+					if (!assessment.eligible()) {
+						String typeName= sourceTypeName(node);
+						String message= "Parameterized test " + typeName //$NON-NLS-1$
+								+ " was left unchanged: " + assessment.explanation(); //$NON-NLS-1$
+						diagnostics.add(MultiFileCandidateDiagnostic.rejected(
+								"parameterized:" + typeName, ownerHandle, //$NON-NLS-1$
+								assessment.reasonCode(), message, List.of(ownerHandle)));
+					}
+					return true;
+				}
+			});
+		}
+		return diagnostics;
+	}
+
+	private static String sourceTypeName(TypeDeclaration type) {
+		ITypeBinding binding= type.resolveBinding();
+		if (binding != null && binding.getQualifiedName() != null
+				&& !binding.getQualifiedName().isBlank()) {
+			return binding.getQualifiedName();
+		}
+		return type.getName().getIdentifier();
 	}
 
 	private static MultiFileCleanUpDiagnostics diagnostics(ICompilationUnit[] selectedUnits, boolean complete,

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/ui/fix/JUnitCleanUpCore.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/ui/fix/JUnitCleanUpCore.java
@@ -91,13 +91,15 @@ public class JUnitCleanUpCore extends AbstractPlannedMultiFileCleanUp<JUnitMigra
 			throw new OperationCanceledException();
 		}
 		Boolean closedScope= consumeClosedScopeDecision(project, compilationUnits);
-		boolean migrateExternalResourceRules= fixes.contains(JUnitCleanUpFixCore.RULEEXTERNALRESOURCE);
-		boolean migrateJUnit3Hierarchies= fixes.contains(JUnitCleanUpFixCore.TEST3);
+		JUnitMultiFilePlanner.PlanningOptions planningOptions=
+				new JUnitMultiFilePlanner.PlanningOptions(
+						fixes.contains(JUnitCleanUpFixCore.RULEEXTERNALRESOURCE),
+						fixes.contains(JUnitCleanUpFixCore.TEST3),
+						fixes.contains(JUnitCleanUpFixCore.PARAMETERIZED));
 		return closedScope == null
-				? JUnitMultiFilePlanner.createCoordinated(project, compilationUnits, migrateExternalResourceRules,
-						migrateJUnit3Hierarchies, monitor)
-				: JUnitMultiFilePlanner.createCoordinated(project, compilationUnits, migrateExternalResourceRules,
-						migrateJUnit3Hierarchies, closedScope.booleanValue(), monitor);
+				? JUnitMultiFilePlanner.createCoordinated(project, compilationUnits, planningOptions, monitor)
+				: JUnitMultiFilePlanner.createCoordinated(project, compilationUnits, planningOptions,
+						closedScope.booleanValue(), monitor);
 	}
 
 	@Override

--- a/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/ParameterizedMigrationDiagnosticsTest.java
+++ b/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/ParameterizedMigrationDiagnosticsTest.java
@@ -146,6 +146,35 @@ public class ParameterizedMigrationDiagnosticsTest {
 	}
 
 	@Test
+	public void recognizesExplicitRunWithValueSyntax() throws CoreException {
+		ICompilationUnit unit= compilationUnit("explicitrunner", "ExplicitRunnerTest", """ //$NON-NLS-1$ //$NON-NLS-2$
+				import java.util.List;
+				import org.junit.Test;
+				import org.junit.runner.RunWith;
+				import org.junit.runners.Parameterized;
+				import org.junit.runners.Parameterized.Parameter;
+				import org.junit.runners.Parameterized.Parameters;
+
+				@RunWith(value = Parameterized.class)
+				public class ExplicitRunnerTest {
+					@Parameter
+					public int value;
+
+					@Parameters
+					public static List<Object[]> data() {
+						return List.<Object[]>of(new Object[] { 1 });
+					}
+
+					@Test
+					public void testValue() {
+					}
+				}
+				""");
+
+		assertReason(planClosed(unit), "PARAMETERIZED_FIELD_INJECTION"); //$NON-NLS-1$
+	}
+
+	@Test
 	public void supportedLocalContractHasNoRejectionDiagnostic()
 			throws CoreException {
 		ICompilationUnit unit= compilationUnit("supported", "SupportedTest", """ //$NON-NLS-1$ //$NON-NLS-2$

--- a/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/ParameterizedMigrationDiagnosticsTest.java
+++ b/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/ParameterizedMigrationDiagnosticsTest.java
@@ -1,0 +1,209 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.corext.fix.multifile;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.junit.JUnitCore;
+
+import org.sandbox.jdt.cleanup.multifile.MultiFileCandidateDiagnostic;
+import org.sandbox.jdt.cleanup.multifile.MultiFileCandidateOutcome;
+import org.sandbox.jdt.cleanup.multifile.MultiFileCleanUpPlanResult;
+import org.sandbox.jdt.internal.corext.fix.multifile.JUnitMultiFilePlanner.PlanningOptions;
+import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
+import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava17;
+
+/** Structured diagnostic contract for fail-closed Parameterized candidates. */
+public class ParameterizedMigrationDiagnosticsTest {
+
+	private static final PlanningOptions PARAMETERIZED_DIAGNOSTICS=
+			new PlanningOptions(false, false, true);
+
+	@RegisterExtension
+	AbstractEclipseJava context= new EclipseJava17();
+
+	private IPackageFragmentRoot root;
+
+	@BeforeEach
+	public void setup() throws CoreException {
+		root= context.createClasspathForJUnit(JUnitCore.JUNIT5_CONTAINER_PATH);
+	}
+
+	@Test
+	public void reportsInheritedOrExternalProviderContractInIncompleteScope()
+			throws CoreException {
+		ICompilationUnit unit= compilationUnit("missingprovider", "MissingProviderTest", """ //$NON-NLS-1$ //$NON-NLS-2$
+				import org.junit.Test;
+				import org.junit.runner.RunWith;
+				import org.junit.runners.Parameterized;
+
+				@RunWith(Parameterized.class)
+				public class MissingProviderTest {
+					private final int value;
+
+					public MissingProviderTest(int value) {
+						this.value = value;
+					}
+
+					@Test
+					public void testValue() {
+					}
+				}
+				""");
+
+		MultiFileCleanUpPlanResult<JUnitMigrationPlan> result=
+				JUnitMultiFilePlanner.createCoordinated(context.getJavaProject(),
+						new ICompilationUnit[] { unit }, PARAMETERIZED_DIAGNOSTICS,
+						false, null);
+
+		assertFalse(result.diagnostics().scope().complete());
+		assertReason(result, "PARAMETERIZED_PROVIDER_NOT_LOCAL"); //$NON-NLS-1$
+	}
+
+	@Test
+	public void reportsMultipleLocalProviders() throws CoreException {
+		ICompilationUnit unit= compilationUnit("multipleproviders", "MultipleProvidersTest", """ //$NON-NLS-1$ //$NON-NLS-2$
+				import java.util.List;
+				import org.junit.Test;
+				import org.junit.runner.RunWith;
+				import org.junit.runners.Parameterized;
+				import org.junit.runners.Parameterized.Parameters;
+
+				@RunWith(Parameterized.class)
+				public class MultipleProvidersTest {
+					private final int value;
+
+					public MultipleProvidersTest(int value) {
+						this.value = value;
+					}
+
+					@Parameters
+					public static List<Object[]> first() {
+						return List.of(new Object[] { 1 });
+					}
+
+					@Parameters
+					public static List<Object[]> second() {
+						return List.of(new Object[] { 2 });
+					}
+
+					@Test
+					public void testValue() {
+					}
+				}
+				""");
+
+		assertReason(planClosed(unit),
+				"PARAMETERIZED_MULTIPLE_LOCAL_PROVIDERS"); //$NON-NLS-1$
+	}
+
+	@Test
+	public void reportsFieldInjection() throws CoreException {
+		ICompilationUnit unit= compilationUnit("fieldinjection", "FieldInjectionTest", """ //$NON-NLS-1$ //$NON-NLS-2$
+				import java.util.List;
+				import org.junit.Test;
+				import org.junit.runner.RunWith;
+				import org.junit.runners.Parameterized;
+				import org.junit.runners.Parameterized.Parameter;
+				import org.junit.runners.Parameterized.Parameters;
+
+				@RunWith(Parameterized.class)
+				public class FieldInjectionTest {
+					@Parameter
+					public int value;
+
+					@Parameters
+					public static List<Object[]> data() {
+						return List.of(new Object[] { 1 });
+					}
+
+					@Test
+					public void testValue() {
+					}
+				}
+				""");
+
+		assertReason(planClosed(unit), "PARAMETERIZED_FIELD_INJECTION"); //$NON-NLS-1$
+	}
+
+	@Test
+	public void supportedLocalContractHasNoRejectionDiagnostic()
+			throws CoreException {
+		ICompilationUnit unit= compilationUnit("supported", "SupportedTest", """ //$NON-NLS-1$ //$NON-NLS-2$
+				import java.util.List;
+				import org.junit.Test;
+				import org.junit.runner.RunWith;
+				import org.junit.runners.Parameterized;
+				import org.junit.runners.Parameterized.Parameters;
+
+				@RunWith(Parameterized.class)
+				public class SupportedTest {
+					private final int value;
+
+					public SupportedTest(int value) {
+						this.value = value;
+					}
+
+					@Parameters
+					public static List<Object[]> data() {
+						return List.of(new Object[] { 1 });
+					}
+
+					@Test
+					public void testValue() {
+					}
+				}
+				""");
+
+		MultiFileCleanUpPlanResult<JUnitMigrationPlan> result= planClosed(unit);
+
+		assertFalse(result.status().hasFatalError());
+		assertTrue(result.diagnostics().candidates().isEmpty());
+	}
+
+	private MultiFileCleanUpPlanResult<JUnitMigrationPlan> planClosed(
+			ICompilationUnit unit) throws CoreException {
+		return JUnitMultiFilePlanner.createCoordinated(context.getJavaProject(),
+				new ICompilationUnit[] { unit }, PARAMETERIZED_DIAGNOSTICS, true,
+				null);
+	}
+
+	private ICompilationUnit compilationUnit(String packageName,
+			String typeName, String body) throws CoreException {
+		IPackageFragment pack= root.createPackageFragment(packageName, true, null);
+		return pack.createCompilationUnit(typeName + ".java", //$NON-NLS-1$
+				"package " + packageName + ";\n\n" + body, false, null); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	private static void assertReason(
+			MultiFileCleanUpPlanResult<JUnitMigrationPlan> result,
+			String reasonCode) {
+		assertFalse(result.status().hasFatalError());
+		assertEquals(1, result.diagnostics().candidates().size());
+		MultiFileCandidateDiagnostic diagnostic=
+				result.diagnostics().candidates().get(0);
+		assertEquals(MultiFileCandidateOutcome.REJECTED,
+				diagnostic.outcome());
+		assertEquals(reasonCode, diagnostic.reasonCode());
+		assertTrue(diagnostic.message().contains("left unchanged")); //$NON-NLS-1$
+	}
+}

--- a/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/ParameterizedMigrationDiagnosticsTest.java
+++ b/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/ParameterizedMigrationDiagnosticsTest.java
@@ -51,7 +51,9 @@ public class ParameterizedMigrationDiagnosticsTest {
 	@Test
 	public void reportsInheritedOrExternalProviderContractInIncompleteScope()
 			throws CoreException {
-		ICompilationUnit unit= compilationUnit("missingprovider", "MissingProviderTest", """ //$NON-NLS-1$ //$NON-NLS-2$
+		ICompilationUnit unit= compilationUnit("missingprovider", //$NON-NLS-1$
+				"MissingProviderTest", //$NON-NLS-1$
+				"""
 				import org.junit.Test;
 				import org.junit.runner.RunWith;
 				import org.junit.runners.Parameterized;
@@ -68,7 +70,7 @@ public class ParameterizedMigrationDiagnosticsTest {
 					public void testValue() {
 					}
 				}
-				""");
+				"""); //$NON-NLS-1$
 
 		MultiFileCleanUpPlanResult<JUnitMigrationPlan> result=
 				JUnitMultiFilePlanner.createCoordinated(context.getJavaProject(),
@@ -81,7 +83,9 @@ public class ParameterizedMigrationDiagnosticsTest {
 
 	@Test
 	public void reportsMultipleLocalProviders() throws CoreException {
-		ICompilationUnit unit= compilationUnit("multipleproviders", "MultipleProvidersTest", """ //$NON-NLS-1$ //$NON-NLS-2$
+		ICompilationUnit unit= compilationUnit("multipleproviders", //$NON-NLS-1$
+				"MultipleProvidersTest", //$NON-NLS-1$
+				"""
 				import java.util.List;
 				import org.junit.Test;
 				import org.junit.runner.RunWith;
@@ -110,7 +114,7 @@ public class ParameterizedMigrationDiagnosticsTest {
 					public void testValue() {
 					}
 				}
-				""");
+				"""); //$NON-NLS-1$
 
 		assertReason(planClosed(unit),
 				"PARAMETERIZED_MULTIPLE_LOCAL_PROVIDERS"); //$NON-NLS-1$
@@ -118,7 +122,9 @@ public class ParameterizedMigrationDiagnosticsTest {
 
 	@Test
 	public void reportsFieldInjection() throws CoreException {
-		ICompilationUnit unit= compilationUnit("fieldinjection", "FieldInjectionTest", """ //$NON-NLS-1$ //$NON-NLS-2$
+		ICompilationUnit unit= compilationUnit("fieldinjection", //$NON-NLS-1$
+				"FieldInjectionTest", //$NON-NLS-1$
+				"""
 				import java.util.List;
 				import org.junit.Test;
 				import org.junit.runner.RunWith;
@@ -140,14 +146,16 @@ public class ParameterizedMigrationDiagnosticsTest {
 					public void testValue() {
 					}
 				}
-				""");
+				"""); //$NON-NLS-1$
 
 		assertReason(planClosed(unit), "PARAMETERIZED_FIELD_INJECTION"); //$NON-NLS-1$
 	}
 
 	@Test
 	public void recognizesExplicitRunWithValueSyntax() throws CoreException {
-		ICompilationUnit unit= compilationUnit("explicitrunner", "ExplicitRunnerTest", """ //$NON-NLS-1$ //$NON-NLS-2$
+		ICompilationUnit unit= compilationUnit("explicitrunner", //$NON-NLS-1$
+				"ExplicitRunnerTest", //$NON-NLS-1$
+				"""
 				import java.util.List;
 				import org.junit.Test;
 				import org.junit.runner.RunWith;
@@ -169,7 +177,7 @@ public class ParameterizedMigrationDiagnosticsTest {
 					public void testValue() {
 					}
 				}
-				""");
+				"""); //$NON-NLS-1$
 
 		assertReason(planClosed(unit), "PARAMETERIZED_FIELD_INJECTION"); //$NON-NLS-1$
 	}
@@ -177,7 +185,9 @@ public class ParameterizedMigrationDiagnosticsTest {
 	@Test
 	public void supportedLocalContractHasNoRejectionDiagnostic()
 			throws CoreException {
-		ICompilationUnit unit= compilationUnit("supported", "SupportedTest", """ //$NON-NLS-1$ //$NON-NLS-2$
+		ICompilationUnit unit= compilationUnit("supported", //$NON-NLS-1$
+				"SupportedTest", //$NON-NLS-1$
+				"""
 				import java.util.List;
 				import org.junit.Test;
 				import org.junit.runner.RunWith;
@@ -201,7 +211,7 @@ public class ParameterizedMigrationDiagnosticsTest {
 					public void testValue() {
 					}
 				}
-				""");
+				"""); //$NON-NLS-1$
 
 		MultiFileCleanUpPlanResult<JUnitMigrationPlan> result= planClosed(unit);
 

--- a/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/ParameterizedMigrationDiagnosticsTest.java
+++ b/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/ParameterizedMigrationDiagnosticsTest.java
@@ -98,12 +98,12 @@ public class ParameterizedMigrationDiagnosticsTest {
 
 					@Parameters
 					public static List<Object[]> first() {
-						return List.of(new Object[] { 1 });
+						return List.<Object[]>of(new Object[] { 1 });
 					}
 
 					@Parameters
 					public static List<Object[]> second() {
-						return List.of(new Object[] { 2 });
+						return List.<Object[]>of(new Object[] { 2 });
 					}
 
 					@Test
@@ -133,7 +133,7 @@ public class ParameterizedMigrationDiagnosticsTest {
 
 					@Parameters
 					public static List<Object[]> data() {
-						return List.of(new Object[] { 1 });
+						return List.<Object[]>of(new Object[] { 1 });
 					}
 
 					@Test
@@ -165,7 +165,7 @@ public class ParameterizedMigrationDiagnosticsTest {
 
 					@Parameters
 					public static List<Object[]> data() {
-						return List.of(new Object[] { 1 });
+						return List.<Object[]>of(new Object[] { 1 });
 					}
 
 					@Test


### PR DESCRIPTION
## Summary

Implement the next bounded Stage 3 slice from #1217 without pretending to migrate inherited or external providers.

- introduce one shared `ParameterizedMigrationEligibility` contract used by both the local TriggerPattern rewrite and project planning;
- preserve the supported one-local-provider/one-parameterized-constructor rewrite unchanged;
- classify fail-closed candidates with stable reason codes:
  - `PARAMETERIZED_PROVIDER_NOT_LOCAL`
  - `PARAMETERIZED_MULTIPLE_LOCAL_PROVIDERS`
  - `PARAMETERIZED_FIELD_INJECTION`
  - `PARAMETERIZED_CONSTRUCTOR_NOT_UNIQUE`
  - `PARAMETERIZED_CONSTRUCTOR_HAS_NO_PARAMETERS`;
- publish those rejections through the existing privacy-preserving `MultiFileCleanUpDiagnostics` model only when the Parameterized cleanup option is enabled;
- parse selected local candidates even when the coordinated source scope is incomplete, while retaining the explicit incomplete-scope diagnostic;
- retain all established planner entry points and use a typed `PlanningOptions` value for the new contract;
- add active planner tests for missing/inherited providers, multiple providers, field injection and the supported local form.

## Safety boundary

This PR does not invent a `MethodSource`, copy an inherited provider, select among overloaded constructors, or migrate field injection. Unsupported shapes remain unchanged; the new behavior is an actionable explanation of that refusal.

Refs #1217