### PR TITLE
Classify unsupported JUnit 3 harness semantics precisely

### DIFF
--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnit3HarnessSemantics.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnit3HarnessSemantics.java
@@ -16,13 +16,19 @@ import java.util.Optional;
 import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.Modifier;
 import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
+import org.eclipse.jdt.core.dom.Type;
 
 /**
  * Stable fail-closed taxonomy for JUnit 3 execution semantics that are not
  * equivalent to ordinary annotation-driven Jupiter tests.
  */
 final class JUnit3HarnessSemantics {
+
+	private static final String JAVA_LANG_STRING= "java.lang.String"; //$NON-NLS-1$
+	private static final String JUNIT_FRAMEWORK_TEST= "junit.framework.Test"; //$NON-NLS-1$
+	private static final String JUNIT_FRAMEWORK_TEST_RESULT= "junit.framework.TestResult"; //$NON-NLS-1$
 
 	record Rejection(String reasonCode, String explanation) {
 		Rejection {
@@ -54,41 +60,145 @@ final class JUnit3HarnessSemantics {
 
 		String name= method.getName().getIdentifier();
 		return switch (name) {
-			case "suite" -> Optional.of(new Rejection( //$NON-NLS-1$
+			case "suite" when isSuiteBuilder(method) -> Optional.of(new Rejection( //$NON-NLS-1$
 					"CUSTOM_JUNIT3_SUITE_BUILDER", //$NON-NLS-1$
 					"The hierarchy declares suite(), so test composition, nesting, duplication or ordering must be migrated as an explicit suite model.")); //$NON-NLS-1$
-			case "runTest" -> Optional.of(new Rejection( //$NON-NLS-1$
+			case "runTest" when isRunTestHook(method) -> Optional.of(new Rejection( //$NON-NLS-1$
 					"CUSTOM_JUNIT3_TEST_SELECTION", //$NON-NLS-1$
 					"The hierarchy overrides runTest(), so runtime test selection is not equivalent to method-name discovery.")); //$NON-NLS-1$
-			case "runBare" -> Optional.of(new Rejection( //$NON-NLS-1$
+			case "runBare" when isRunBareHook(method) -> Optional.of(new Rejection( //$NON-NLS-1$
 					"CUSTOM_JUNIT3_LIFECYCLE_WRAPPER", //$NON-NLS-1$
 					"The hierarchy overrides runBare(), so its setup/test/teardown wrapper and exception behavior require an explicit extension or invocation migration.")); //$NON-NLS-1$
-			case "createResult", "countTestCases" -> Optional.of(new Rejection( //$NON-NLS-1$ //$NON-NLS-2$
+			case "createResult" when isCreateResultHook(method), //$NON-NLS-1$
+					"countTestCases" when isCountTestCasesHook(method) -> Optional.of(new Rejection( //$NON-NLS-1$
 					"CUSTOM_JUNIT3_RESULT_MODEL", //$NON-NLS-1$
 					"The hierarchy customizes JUnit 3 result creation or test counting, which has no ordinary Jupiter annotation equivalent.")); //$NON-NLS-1$
-			case "getName", "setName" -> Optional.of(new Rejection( //$NON-NLS-1$ //$NON-NLS-2$
+			case "getName" when isGetNameHook(method), //$NON-NLS-1$
+					"setName" when isSetNameHook(method) -> Optional.of(new Rejection( //$NON-NLS-1$
 					"NAMED_JUNIT3_TEST_CONTRACT", //$NON-NLS-1$
 					"The hierarchy customizes the mutable JUnit 3 test name used for selected-method execution and reporting.")); //$NON-NLS-1$
-			case "run" -> Optional.of(new Rejection( //$NON-NLS-1$
+			case "run" when isRunHook(method) -> Optional.of(new Rejection( //$NON-NLS-1$
 					"CUSTOM_JUNIT3_RUNNER_INTEGRATION", //$NON-NLS-1$
-					"The hierarchy overrides run(), so listener, result or execution delegation semantics require an explicit framework migration.")); //$NON-NLS-1$
+					"The hierarchy overrides run(TestResult), so listener, result or execution delegation semantics require an explicit framework migration.")); //$NON-NLS-1$
 			default -> Optional.empty();
 		};
 	}
 
 	private static boolean isNamedTestConstructor(MethodDeclaration method) {
+		return hasParameters(method, JAVA_LANG_STRING);
+	}
+
+	private static boolean isSuiteBuilder(MethodDeclaration method) {
+		return Modifier.isPublic(method.getModifiers())
+				&& Modifier.isStatic(method.getModifiers())
+				&& hasReturnType(method, JUNIT_FRAMEWORK_TEST)
+				&& hasParameters(method);
+	}
+
+	private static boolean isRunTestHook(MethodDeclaration method) {
+		return isProtectedOrPublic(method)
+				&& !Modifier.isStatic(method.getModifiers())
+				&& hasReturnType(method, "void") //$NON-NLS-1$
+				&& hasParameters(method);
+	}
+
+	private static boolean isRunBareHook(MethodDeclaration method) {
+		return Modifier.isPublic(method.getModifiers())
+				&& !Modifier.isStatic(method.getModifiers())
+				&& hasReturnType(method, "void") //$NON-NLS-1$
+				&& hasParameters(method);
+	}
+
+	private static boolean isCreateResultHook(MethodDeclaration method) {
+		return isProtectedOrPublic(method)
+				&& !Modifier.isStatic(method.getModifiers())
+				&& hasReturnType(method, JUNIT_FRAMEWORK_TEST_RESULT)
+				&& hasParameters(method);
+	}
+
+	private static boolean isCountTestCasesHook(MethodDeclaration method) {
+		return Modifier.isPublic(method.getModifiers())
+				&& !Modifier.isStatic(method.getModifiers())
+				&& hasReturnType(method, "int") //$NON-NLS-1$
+				&& hasParameters(method);
+	}
+
+	private static boolean isGetNameHook(MethodDeclaration method) {
+		return Modifier.isPublic(method.getModifiers())
+				&& !Modifier.isStatic(method.getModifiers())
+				&& hasReturnType(method, JAVA_LANG_STRING)
+				&& hasParameters(method);
+	}
+
+	private static boolean isSetNameHook(MethodDeclaration method) {
+		return Modifier.isPublic(method.getModifiers())
+				&& !Modifier.isStatic(method.getModifiers())
+				&& hasReturnType(method, "void") //$NON-NLS-1$
+				&& hasParameters(method, JAVA_LANG_STRING);
+	}
+
+	private static boolean isRunHook(MethodDeclaration method) {
+		return Modifier.isPublic(method.getModifiers())
+				&& !Modifier.isStatic(method.getModifiers())
+				&& hasReturnType(method, "void") //$NON-NLS-1$
+				&& hasParameters(method, JUNIT_FRAMEWORK_TEST_RESULT);
+	}
+
+	private static boolean isProtectedOrPublic(MethodDeclaration method) {
+		return Modifier.isProtected(method.getModifiers())
+				|| Modifier.isPublic(method.getModifiers());
+	}
+
+	private static boolean hasReturnType(MethodDeclaration method, String qualifiedName) {
 		IMethodBinding binding= method.resolveBinding();
-		if (binding != null && binding.getParameterTypes().length == 1) {
-			ITypeBinding parameter= binding.getParameterTypes()[0];
-			return parameter != null && "java.lang.String" //$NON-NLS-1$
-					.equals(parameter.getErasure().getQualifiedName());
+		if (binding != null) {
+			return isType(binding.getReturnType(), qualifiedName);
 		}
-		if (method.parameters().size() != 1
-				|| !(method.parameters().get(0) instanceof SingleVariableDeclaration parameter)
-				|| parameter.isVarargs()) {
+		return isType(method.getReturnType2(), qualifiedName);
+	}
+
+	private static boolean hasParameters(MethodDeclaration method, String... qualifiedNames) {
+		IMethodBinding binding= method.resolveBinding();
+		if (binding != null) {
+			ITypeBinding[] parameters= binding.getParameterTypes();
+			if (parameters.length != qualifiedNames.length) {
+				return false;
+			}
+			for (int index= 0; index < parameters.length; index++) {
+				if (!isType(parameters[index], qualifiedNames[index])) {
+					return false;
+				}
+			}
+			return true;
+		}
+		if (method.parameters().size() != qualifiedNames.length) {
 			return false;
 		}
-		String sourceType= parameter.getType().toString();
-		return "String".equals(sourceType) || "java.lang.String".equals(sourceType); //$NON-NLS-1$ //$NON-NLS-2$
+		for (int index= 0; index < qualifiedNames.length; index++) {
+			if (!(method.parameters().get(index) instanceof SingleVariableDeclaration parameter)
+					|| parameter.isVarargs()
+					|| !isType(parameter.getType(), qualifiedNames[index])) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private static boolean isType(ITypeBinding binding, String qualifiedName) {
+		return binding != null && qualifiedName.equals(binding.getErasure().getQualifiedName());
+	}
+
+	private static boolean isType(Type type, String qualifiedName) {
+		if (type == null) {
+			return false;
+		}
+		ITypeBinding binding= type.resolveBinding();
+		if (binding != null) {
+			return isType(binding, qualifiedName);
+		}
+		String sourceType= type.toString();
+		int lastDot= qualifiedName.lastIndexOf('.');
+		String simpleName= lastDot < 0 ? qualifiedName : qualifiedName.substring(lastDot + 1);
+		return qualifiedName.equals(sourceType) || simpleName.equals(sourceType);
 	}
 }

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnit3HarnessSemantics.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnit3HarnessSemantics.java
@@ -59,29 +59,33 @@ final class JUnit3HarnessSemantics {
 		}
 
 		String name= method.getName().getIdentifier();
-		return switch (name) {
-			case "suite" when isSuiteBuilder(method) -> Optional.of(new Rejection( //$NON-NLS-1$
-					"CUSTOM_JUNIT3_SUITE_BUILDER", //$NON-NLS-1$
+		if ("suite".equals(name) && isSuiteBuilder(method)) { //$NON-NLS-1$
+			return Optional.of(new Rejection("CUSTOM_JUNIT3_SUITE_BUILDER", //$NON-NLS-1$
 					"The hierarchy declares suite(), so test composition, nesting, duplication or ordering must be migrated as an explicit suite model.")); //$NON-NLS-1$
-			case "runTest" when isRunTestHook(method) -> Optional.of(new Rejection( //$NON-NLS-1$
-					"CUSTOM_JUNIT3_TEST_SELECTION", //$NON-NLS-1$
+		}
+		if ("runTest".equals(name) && isRunTestHook(method)) { //$NON-NLS-1$
+			return Optional.of(new Rejection("CUSTOM_JUNIT3_TEST_SELECTION", //$NON-NLS-1$
 					"The hierarchy overrides runTest(), so runtime test selection is not equivalent to method-name discovery.")); //$NON-NLS-1$
-			case "runBare" when isRunBareHook(method) -> Optional.of(new Rejection( //$NON-NLS-1$
-					"CUSTOM_JUNIT3_LIFECYCLE_WRAPPER", //$NON-NLS-1$
+		}
+		if ("runBare".equals(name) && isRunBareHook(method)) { //$NON-NLS-1$
+			return Optional.of(new Rejection("CUSTOM_JUNIT3_LIFECYCLE_WRAPPER", //$NON-NLS-1$
 					"The hierarchy overrides runBare(), so its setup/test/teardown wrapper and exception behavior require an explicit extension or invocation migration.")); //$NON-NLS-1$
-			case "createResult" when isCreateResultHook(method), //$NON-NLS-1$
-					"countTestCases" when isCountTestCasesHook(method) -> Optional.of(new Rejection( //$NON-NLS-1$
-					"CUSTOM_JUNIT3_RESULT_MODEL", //$NON-NLS-1$
+		}
+		if (("createResult".equals(name) && isCreateResultHook(method)) //$NON-NLS-1$
+				|| ("countTestCases".equals(name) && isCountTestCasesHook(method))) { //$NON-NLS-1$
+			return Optional.of(new Rejection("CUSTOM_JUNIT3_RESULT_MODEL", //$NON-NLS-1$
 					"The hierarchy customizes JUnit 3 result creation or test counting, which has no ordinary Jupiter annotation equivalent.")); //$NON-NLS-1$
-			case "getName" when isGetNameHook(method), //$NON-NLS-1$
-					"setName" when isSetNameHook(method) -> Optional.of(new Rejection( //$NON-NLS-1$
-					"NAMED_JUNIT3_TEST_CONTRACT", //$NON-NLS-1$
+		}
+		if (("getName".equals(name) && isGetNameHook(method)) //$NON-NLS-1$
+				|| ("setName".equals(name) && isSetNameHook(method))) { //$NON-NLS-1$
+			return Optional.of(new Rejection("NAMED_JUNIT3_TEST_CONTRACT", //$NON-NLS-1$
 					"The hierarchy customizes the mutable JUnit 3 test name used for selected-method execution and reporting.")); //$NON-NLS-1$
-			case "run" when isRunHook(method) -> Optional.of(new Rejection( //$NON-NLS-1$
-					"CUSTOM_JUNIT3_RUNNER_INTEGRATION", //$NON-NLS-1$
+		}
+		if ("run".equals(name) && isRunHook(method)) { //$NON-NLS-1$
+			return Optional.of(new Rejection("CUSTOM_JUNIT3_RUNNER_INTEGRATION", //$NON-NLS-1$
 					"The hierarchy overrides run(TestResult), so listener, result or execution delegation semantics require an explicit framework migration.")); //$NON-NLS-1$
-			default -> Optional.empty();
-		};
+		}
+		return Optional.empty();
 	}
 
 	private static boolean isNamedTestConstructor(MethodDeclaration method) {

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnit3HarnessSemantics.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnit3HarnessSemantics.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.corext.fix.multifile;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
+
+/**
+ * Stable fail-closed taxonomy for JUnit 3 execution semantics that are not
+ * equivalent to ordinary annotation-driven Jupiter tests.
+ */
+final class JUnit3HarnessSemantics {
+
+	record Rejection(String reasonCode, String explanation) {
+		Rejection {
+			reasonCode= Objects.requireNonNull(reasonCode);
+			explanation= Objects.requireNonNull(explanation);
+		}
+	}
+
+	private JUnit3HarnessSemantics() {
+	}
+
+	/**
+	 * Classify a method or constructor that changes the JUnit 3 harness contract.
+	 *
+	 * @param method
+	 *            source declaration to inspect
+	 * @return a precise rejection, or empty for an ordinary test/helper method
+	 */
+	static Optional<Rejection> rejection(MethodDeclaration method) {
+		Objects.requireNonNull(method);
+		if (method.isConstructor()) {
+			if (isNamedTestConstructor(method)) {
+				return Optional.of(new Rejection("NAMED_JUNIT3_TEST_CONSTRUCTION", //$NON-NLS-1$
+						"The hierarchy constructs named JUnit 3 test instances through a String constructor; preserving selected method identity requires an explicit framework migration.")); //$NON-NLS-1$
+			}
+			return Optional.of(new Rejection("CUSTOM_JUNIT3_CONSTRUCTOR", //$NON-NLS-1$
+					"The hierarchy declares an explicit constructor whose instantiation contract is not represented by ordinary Jupiter test discovery.")); //$NON-NLS-1$
+		}
+
+		String name= method.getName().getIdentifier();
+		return switch (name) {
+			case "suite" -> Optional.of(new Rejection( //$NON-NLS-1$
+					"CUSTOM_JUNIT3_SUITE_BUILDER", //$NON-NLS-1$
+					"The hierarchy declares suite(), so test composition, nesting, duplication or ordering must be migrated as an explicit suite model.")); //$NON-NLS-1$
+			case "runTest" -> Optional.of(new Rejection( //$NON-NLS-1$
+					"CUSTOM_JUNIT3_TEST_SELECTION", //$NON-NLS-1$
+					"The hierarchy overrides runTest(), so runtime test selection is not equivalent to method-name discovery.")); //$NON-NLS-1$
+			case "runBare" -> Optional.of(new Rejection( //$NON-NLS-1$
+					"CUSTOM_JUNIT3_LIFECYCLE_WRAPPER", //$NON-NLS-1$
+					"The hierarchy overrides runBare(), so its setup/test/teardown wrapper and exception behavior require an explicit extension or invocation migration.")); //$NON-NLS-1$
+			case "createResult", "countTestCases" -> Optional.of(new Rejection( //$NON-NLS-1$ //$NON-NLS-2$
+					"CUSTOM_JUNIT3_RESULT_MODEL", //$NON-NLS-1$
+					"The hierarchy customizes JUnit 3 result creation or test counting, which has no ordinary Jupiter annotation equivalent.")); //$NON-NLS-1$
+			case "getName", "setName" -> Optional.of(new Rejection( //$NON-NLS-1$ //$NON-NLS-2$
+					"NAMED_JUNIT3_TEST_CONTRACT", //$NON-NLS-1$
+					"The hierarchy customizes the mutable JUnit 3 test name used for selected-method execution and reporting.")); //$NON-NLS-1$
+			case "run" -> Optional.of(new Rejection( //$NON-NLS-1$
+					"CUSTOM_JUNIT3_RUNNER_INTEGRATION", //$NON-NLS-1$
+					"The hierarchy overrides run(), so listener, result or execution delegation semantics require an explicit framework migration.")); //$NON-NLS-1$
+			default -> Optional.empty();
+		};
+	}
+
+	private static boolean isNamedTestConstructor(MethodDeclaration method) {
+		IMethodBinding binding= method.resolveBinding();
+		if (binding != null && binding.getParameterTypes().length == 1) {
+			ITypeBinding parameter= binding.getParameterTypes()[0];
+			return parameter != null && "java.lang.String" //$NON-NLS-1$
+					.equals(parameter.getErasure().getQualifiedName());
+		}
+		if (method.parameters().size() != 1
+				|| !(method.parameters().get(0) instanceof SingleVariableDeclaration parameter)
+				|| parameter.isVarargs()) {
+			return false;
+		}
+		String sourceType= parameter.getType().toString();
+		return "String".equals(sourceType) || "java.lang.String".equals(sourceType); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+}

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnit3HierarchyPlanner.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnit3HierarchyPlanner.java
@@ -53,10 +53,6 @@ import org.sandbox.jdt.internal.corext.fix.multifile.JUnit3HierarchyMigration.Ty
 /** Classifies and plans ordinary closed JUnit 3 source hierarchies. */
 final class JUnit3HierarchyPlanner {
 
-	private static final Set<String> CUSTOM_EXECUTION_METHODS= Set.of(
-			"suite", "runTest", "runBare", "createResult", "countTestCases", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
-			"getName", "setName", "run"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-
 	/** Mirrors JUnit 4's {@code org.junit.internal.MethodSorter.DEFAULT}. */
 	private static final Comparator<MethodDeclaration> JUNIT3_METHOD_ORDER=
 			Comparator.comparingInt((MethodDeclaration method) -> method.getName().getIdentifier().hashCode())
@@ -281,19 +277,17 @@ final class JUnit3HierarchyPlanner {
 			Map<String, Integer> executionOrders= plannedExecutionOrders(type, maxDepth, depth, orderStride);
 			List<MethodMigration> methods= new ArrayList<>();
 			for (MethodDeclaration method : type.declaration().getMethods()) {
-				if (method.isConstructor()) {
-					return Classification.rejected("CUSTOM_JUNIT3_CONSTRUCTOR", //$NON-NLS-1$
-							"Explicit JUnit 3 constructors require a project-specific migration."); //$NON-NLS-1$
+				JUnit3HarnessSemantics.Rejection harnessRejection=
+						JUnit3HarnessSemantics.rejection(method).orElse(null);
+				if (harnessRejection != null) {
+					return Classification.rejected(harnessRejection.reasonCode(),
+							harnessRejection.explanation());
 				}
 				if (hasJUnitAnnotation(method)) {
 					return Classification.rejected("MIXED_JUNIT_GENERATIONS", //$NON-NLS-1$
 							"The hierarchy already mixes annotation-driven and JUnit 3 execution semantics."); //$NON-NLS-1$
 				}
 				String name= method.getName().getIdentifier();
-				if (CUSTOM_EXECUTION_METHODS.contains(name)) {
-					return Classification.rejected("CUSTOM_JUNIT3_EXECUTION", //$NON-NLS-1$
-							"The hierarchy customizes JUnit 3 execution through " + name + "()."); //$NON-NLS-1$ //$NON-NLS-2$
-				}
 				String bindingKey= methodKey(method);
 				if (name.startsWith("test")) { //$NON-NLS-1$
 					if (!JUnit3SemanticSupport.isExactTestMethod(method) || bindingKey == null) {

--- a/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnit3HarnessPlannerDiagnosticsTest.java
+++ b/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnit3HarnessPlannerDiagnosticsTest.java
@@ -46,7 +46,8 @@ class JUnit3HarnessPlannerDiagnosticsTest {
 	@Test
 	void reportsNamedTestConstruction() throws CoreException {
 		IPackageFragment pack= root.createPackageFragment("namedconstruction", true, null); //$NON-NLS-1$
-		ICompilationUnit base= pack.createCompilationUnit("BaseTest.java", """ //$NON-NLS-1$
+		ICompilationUnit base= pack.createCompilationUnit("BaseTest.java", //$NON-NLS-1$
+				"""
 				package namedconstruction;
 				import junit.framework.TestCase;
 
@@ -58,8 +59,9 @@ class JUnit3HarnessPlannerDiagnosticsTest {
 					public void testInherited() {
 					}
 				}
-				""", false, null);
-		ICompilationUnit concrete= pack.createCompilationUnit("ConcreteTest.java", """ //$NON-NLS-1$
+				""", false, null); //$NON-NLS-1$
+		ICompilationUnit concrete= pack.createCompilationUnit("ConcreteTest.java", //$NON-NLS-1$
+				"""
 				package namedconstruction;
 
 				public class ConcreteTest extends BaseTest {
@@ -67,7 +69,7 @@ class JUnit3HarnessPlannerDiagnosticsTest {
 						super(name);
 					}
 				}
-				""", false, null);
+				""", false, null); //$NON-NLS-1$
 
 		assertReason(plan(base, concrete), "NAMED_JUNIT3_TEST_CONSTRUCTION"); //$NON-NLS-1$
 	}
@@ -75,7 +77,8 @@ class JUnit3HarnessPlannerDiagnosticsTest {
 	@Test
 	void reportsCustomSuiteBuilder() throws CoreException {
 		IPackageFragment pack= root.createPackageFragment("suitebuilder", true, null); //$NON-NLS-1$
-		ICompilationUnit base= pack.createCompilationUnit("BaseTest.java", """ //$NON-NLS-1$
+		ICompilationUnit base= pack.createCompilationUnit("BaseTest.java", //$NON-NLS-1$
+				"""
 				package suitebuilder;
 				import junit.framework.Test;
 				import junit.framework.TestCase;
@@ -89,13 +92,14 @@ class JUnit3HarnessPlannerDiagnosticsTest {
 					public void testInherited() {
 					}
 				}
-				""", false, null);
-		ICompilationUnit concrete= pack.createCompilationUnit("ConcreteTest.java", """ //$NON-NLS-1$
+				""", false, null); //$NON-NLS-1$
+		ICompilationUnit concrete= pack.createCompilationUnit("ConcreteTest.java", //$NON-NLS-1$
+				"""
 				package suitebuilder;
 
 				public class ConcreteTest extends BaseTest {
 				}
-				""", false, null);
+				""", false, null); //$NON-NLS-1$
 
 		assertReason(plan(base, concrete), "CUSTOM_JUNIT3_SUITE_BUILDER"); //$NON-NLS-1$
 	}

--- a/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnit3HarnessPlannerDiagnosticsTest.java
+++ b/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnit3HarnessPlannerDiagnosticsTest.java
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.corext.fix.multifile;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.junit.JUnitCore;
+
+import org.sandbox.jdt.cleanup.multifile.MultiFileCandidateDiagnostic;
+import org.sandbox.jdt.cleanup.multifile.MultiFileCandidateOutcome;
+import org.sandbox.jdt.cleanup.multifile.MultiFileCleanUpPlanResult;
+import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
+import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava17;
+
+/** Planner integration for precise unsupported JUnit 3 harness diagnostics. */
+class JUnit3HarnessPlannerDiagnosticsTest {
+
+	@RegisterExtension
+	AbstractEclipseJava context= new EclipseJava17();
+
+	private IPackageFragmentRoot root;
+
+	@BeforeEach
+	void setup() throws CoreException {
+		root= context.createClasspathForJUnit(JUnitCore.JUNIT5_CONTAINER_PATH);
+	}
+
+	@Test
+	void reportsNamedTestConstruction() throws CoreException {
+		IPackageFragment pack= root.createPackageFragment("namedconstruction", true, null); //$NON-NLS-1$
+		ICompilationUnit base= pack.createCompilationUnit("BaseTest.java", """ //$NON-NLS-1$
+				package namedconstruction;
+				import junit.framework.TestCase;
+
+				public abstract class BaseTest extends TestCase {
+					protected BaseTest(String name) {
+						super(name);
+					}
+
+					public void testInherited() {
+					}
+				}
+				""", false, null);
+		ICompilationUnit concrete= pack.createCompilationUnit("ConcreteTest.java", """ //$NON-NLS-1$
+				package namedconstruction;
+
+				public class ConcreteTest extends BaseTest {
+					public ConcreteTest(String name) {
+						super(name);
+					}
+				}
+				""", false, null);
+
+		assertReason(plan(base, concrete), "NAMED_JUNIT3_TEST_CONSTRUCTION"); //$NON-NLS-1$
+	}
+
+	@Test
+	void reportsCustomSuiteBuilder() throws CoreException {
+		IPackageFragment pack= root.createPackageFragment("suitebuilder", true, null); //$NON-NLS-1$
+		ICompilationUnit base= pack.createCompilationUnit("BaseTest.java", """ //$NON-NLS-1$
+				package suitebuilder;
+				import junit.framework.Test;
+				import junit.framework.TestCase;
+				import junit.framework.TestSuite;
+
+				public abstract class BaseTest extends TestCase {
+					public static Test suite() {
+						return new TestSuite(ConcreteTest.class);
+					}
+
+					public void testInherited() {
+					}
+				}
+				""", false, null);
+		ICompilationUnit concrete= pack.createCompilationUnit("ConcreteTest.java", """ //$NON-NLS-1$
+				package suitebuilder;
+
+				public class ConcreteTest extends BaseTest {
+				}
+				""", false, null);
+
+		assertReason(plan(base, concrete), "CUSTOM_JUNIT3_SUITE_BUILDER"); //$NON-NLS-1$
+	}
+
+	private MultiFileCleanUpPlanResult<JUnitMigrationPlan> plan(
+			ICompilationUnit... units) throws CoreException {
+		return JUnitMultiFilePlanner.createCoordinated(context.getJavaProject(),
+				units, false, true, true, null);
+	}
+
+	private static void assertReason(
+			MultiFileCleanUpPlanResult<JUnitMigrationPlan> result,
+			String reasonCode) {
+		assertFalse(result.status().hasFatalError());
+		assertEquals(1, result.diagnostics().candidates().size());
+		MultiFileCandidateDiagnostic diagnostic=
+				result.diagnostics().candidates().get(0);
+		assertEquals(MultiFileCandidateOutcome.REJECTED,
+				diagnostic.outcome());
+		assertEquals(reasonCode, diagnostic.reasonCode());
+		assertFalse(diagnostic.message().isBlank());
+	}
+}

--- a/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnit3HarnessSemanticsTest.java
+++ b/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnit3HarnessSemanticsTest.java
@@ -35,7 +35,7 @@ class JUnit3HarnessSemanticsTest {
 
 	@Test
 	void distinguishesSuiteSelectionAndLifecycleContracts() {
-		assertReason("public static Object suite() { return null; }", //$NON-NLS-1$
+		assertReason("public static junit.framework.Test suite() { return null; }", //$NON-NLS-1$
 				"CUSTOM_JUNIT3_SUITE_BUILDER"); //$NON-NLS-1$
 		assertReason("protected void runTest() {}", //$NON-NLS-1$
 				"CUSTOM_JUNIT3_TEST_SELECTION"); //$NON-NLS-1$
@@ -45,7 +45,7 @@ class JUnit3HarnessSemanticsTest {
 
 	@Test
 	void distinguishesResultNameAndRunnerContracts() {
-		assertReason("protected Object createResult() { return null; }", //$NON-NLS-1$
+		assertReason("protected junit.framework.TestResult createResult() { return null; }", //$NON-NLS-1$
 				"CUSTOM_JUNIT3_RESULT_MODEL"); //$NON-NLS-1$
 		assertReason("public int countTestCases() { return 1; }", //$NON-NLS-1$
 				"CUSTOM_JUNIT3_RESULT_MODEL"); //$NON-NLS-1$
@@ -53,18 +53,25 @@ class JUnit3HarnessSemanticsTest {
 				"NAMED_JUNIT3_TEST_CONTRACT"); //$NON-NLS-1$
 		assertReason("public void setName(String name) {}", //$NON-NLS-1$
 				"NAMED_JUNIT3_TEST_CONTRACT"); //$NON-NLS-1$
-		assertReason("public void run(Object result) {}", //$NON-NLS-1$
+		assertReason("public void run(junit.framework.TestResult result) {}", //$NON-NLS-1$
 				"CUSTOM_JUNIT3_RUNNER_INTEGRATION"); //$NON-NLS-1$
 	}
 
 	@Test
+	void ignoresSameNamedMethodsThatAreNotJUnit3Hooks() {
+		assertUnclassified("public void suite(int value) {}"); //$NON-NLS-1$
+		assertUnclassified("public static Object suite() { return null; }"); //$NON-NLS-1$
+		assertUnclassified("public void run() {}"); //$NON-NLS-1$
+		assertUnclassified("public void run(Object result) {}"); //$NON-NLS-1$
+		assertUnclassified("public String getName(int index) { return null; }"); //$NON-NLS-1$
+		assertUnclassified("public void setName(Object name) {}"); //$NON-NLS-1$
+		assertUnclassified("private void runBare() {}"); //$NON-NLS-1$
+	}
+
+	@Test
 	void leavesOrdinaryTestsAndHelpersUnclassified() {
-		assertTrue(JUnit3HarnessSemantics
-				.rejection(parseMethod("public void testOne() {}")) //$NON-NLS-1$
-				.isEmpty());
-		assertTrue(JUnit3HarnessSemantics
-				.rejection(parseMethod("private int helper() { return 1; }")) //$NON-NLS-1$
-				.isEmpty());
+		assertUnclassified("public void testOne() {}"); //$NON-NLS-1$
+		assertUnclassified("private int helper() { return 1; }"); //$NON-NLS-1$
 	}
 
 	private static void assertReason(String member, String reasonCode) {
@@ -72,6 +79,10 @@ class JUnit3HarnessSemanticsTest {
 				.rejection(parseMethod(member)).orElseThrow();
 		assertEquals(reasonCode, rejection.reasonCode());
 		assertFalse(rejection.explanation().isBlank());
+	}
+
+	private static void assertUnclassified(String member) {
+		assertTrue(JUnit3HarnessSemantics.rejection(parseMethod(member)).isEmpty());
 	}
 
 	private static MethodDeclaration parseMethod(String member) {

--- a/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnit3HarnessSemanticsTest.java
+++ b/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnit3HarnessSemanticsTest.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.corext.fix.multifile;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+
+/** Stable reason-code contract for unsupported JUnit 3 harness semantics. */
+class JUnit3HarnessSemanticsTest {
+
+	@Test
+	void distinguishesNamedAndCustomConstructors() {
+		assertReason("Sample(String name) {}", //$NON-NLS-1$
+				"NAMED_JUNIT3_TEST_CONSTRUCTION"); //$NON-NLS-1$
+		assertReason("Sample(int value) {}", //$NON-NLS-1$
+				"CUSTOM_JUNIT3_CONSTRUCTOR"); //$NON-NLS-1$
+	}
+
+	@Test
+	void distinguishesSuiteSelectionAndLifecycleContracts() {
+		assertReason("public static Object suite() { return null; }", //$NON-NLS-1$
+				"CUSTOM_JUNIT3_SUITE_BUILDER"); //$NON-NLS-1$
+		assertReason("protected void runTest() {}", //$NON-NLS-1$
+				"CUSTOM_JUNIT3_TEST_SELECTION"); //$NON-NLS-1$
+		assertReason("public void runBare() {}", //$NON-NLS-1$
+				"CUSTOM_JUNIT3_LIFECYCLE_WRAPPER"); //$NON-NLS-1$
+	}
+
+	@Test
+	void distinguishesResultNameAndRunnerContracts() {
+		assertReason("protected Object createResult() { return null; }", //$NON-NLS-1$
+				"CUSTOM_JUNIT3_RESULT_MODEL"); //$NON-NLS-1$
+		assertReason("public int countTestCases() { return 1; }", //$NON-NLS-1$
+				"CUSTOM_JUNIT3_RESULT_MODEL"); //$NON-NLS-1$
+		assertReason("public String getName() { return null; }", //$NON-NLS-1$
+				"NAMED_JUNIT3_TEST_CONTRACT"); //$NON-NLS-1$
+		assertReason("public void setName(String name) {}", //$NON-NLS-1$
+				"NAMED_JUNIT3_TEST_CONTRACT"); //$NON-NLS-1$
+		assertReason("public void run(Object result) {}", //$NON-NLS-1$
+				"CUSTOM_JUNIT3_RUNNER_INTEGRATION"); //$NON-NLS-1$
+	}
+
+	@Test
+	void leavesOrdinaryTestsAndHelpersUnclassified() {
+		assertTrue(JUnit3HarnessSemantics
+				.rejection(parseMethod("public void testOne() {}")) //$NON-NLS-1$
+				.isEmpty());
+		assertTrue(JUnit3HarnessSemantics
+				.rejection(parseMethod("private int helper() { return 1; }")) //$NON-NLS-1$
+				.isEmpty());
+	}
+
+	private static void assertReason(String member, String reasonCode) {
+		JUnit3HarnessSemantics.Rejection rejection= JUnit3HarnessSemantics
+				.rejection(parseMethod(member)).orElseThrow();
+		assertEquals(reasonCode, rejection.reasonCode());
+		assertTrue(!rejection.explanation().isBlank());
+	}
+
+	private static MethodDeclaration parseMethod(String member) {
+		ASTParser parser= ASTParser.newParser(AST.JLS21);
+		parser.setKind(ASTParser.K_COMPILATION_UNIT);
+		parser.setSource(("class Sample { " + member + " }").toCharArray()); //$NON-NLS-1$ //$NON-NLS-2$
+		CompilationUnit root= (CompilationUnit) parser.createAST(null);
+		TypeDeclaration type= (TypeDeclaration) root.types().get(0);
+		return type.getMethods()[0];
+	}
+}

--- a/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnit3HarnessSemanticsTest.java
+++ b/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/JUnit3HarnessSemanticsTest.java
@@ -11,6 +11,7 @@
 package org.sandbox.jdt.internal.corext.fix.multifile;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -70,7 +71,7 @@ class JUnit3HarnessSemanticsTest {
 		JUnit3HarnessSemantics.Rejection rejection= JUnit3HarnessSemantics
 				.rejection(parseMethod(member)).orElseThrow();
 		assertEquals(reasonCode, rejection.reasonCode());
-		assertTrue(!rejection.explanation().isBlank());
+		assertFalse(rejection.explanation().isBlank());
 	}
 
 	private static MethodDeclaration parseMethod(String member) {


### PR DESCRIPTION
## Summary

Turn the remaining custom-harness boundary from #1334 into a stable, actionable taxonomy without widening the migration surface.

- replace the single `CUSTOM_JUNIT3_EXECUTION` bucket with exact fail-closed classifications for:
  - named `TestCase(String)` construction;
  - custom constructors;
  - `suite()` composition;
  - `runTest()` selection;
  - `runBare()` lifecycle/exception wrapping;
  - custom result creation/counting;
  - mutable JUnit 3 test naming;
  - `run(...)` integration;
- keep external suite/harness owners under the existing conservative `CUSTOM_JUNIT3_HARNESS` boundary until their reference semantics are analyzed explicitly;
- route the hierarchy planner through one reusable `JUnit3HarnessSemantics` classifier;
- add pure taxonomy tests for every reason-code family;
- add planner integration tests proving named construction and local suite builders reach the public coordinated-cleanup diagnostics.

## Safety boundary

This PR does not translate a custom suite, constructor, decorator, filter, order, performance callback or runner hook. Every classified shape remains unchanged. The narrower reason codes identify the distinct semantic migration work that must be proven with dedicated runtime-tree fixtures before support can be widened.

Refs #1334