### PR TITLE
Preserve freely selectable next release versions

### DIFF
--- a/.github/scripts/release-version-plan.py
+++ b/.github/scripts/release-version-plan.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Resolve an exact or conventional next development version for a release."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import re
+import sys
+from typing import Mapping
+
+_RELEASE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+_SNAPSHOT = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+-SNAPSHOT$")
+_INCREMENTS = {"patch", "minor", "major"}
+_OUTPUT_KEYS = ("release", "next", "next_release", "maintenance_branch")
+
+
+def version_tuple(version: str) -> tuple[int, int, int]:
+    return tuple(map(int, version.removesuffix("-SNAPSHOT").split(".")))
+
+
+def normalize(value: str, field: str, pattern: re.Pattern[str]) -> str:
+    normalized = value.strip()
+    if not pattern.fullmatch(normalized):
+        expected = "X.Y.Z-SNAPSHOT" if pattern is _SNAPSHOT else "X.Y.Z"
+        raise ValueError(f"{field} must use {expected}")
+    return normalized
+
+
+def conventional_next(release: str, increment: str) -> str:
+    increment = increment.strip().lower()
+    if increment not in _INCREMENTS:
+        raise ValueError("increment must be patch, minor or major")
+    major, minor, patch = version_tuple(release)
+    if increment == "patch":
+        patch += 1
+    elif increment == "minor":
+        minor += 1
+        patch = 0
+    else:
+        major += 1
+        minor = 0
+        patch = 0
+    return f"{major}.{minor}.{patch}-SNAPSHOT"
+
+
+def resolve_plan(
+    release_version: str,
+    next_development_version: str = "",
+    increment: str = "patch",
+) -> dict[str, str]:
+    release = normalize(release_version, "release_version", _RELEASE)
+    exact_next = next_development_version.strip()
+    next_version = (
+        normalize(exact_next, "next_development_version", _SNAPSHOT)
+        if exact_next
+        else conventional_next(release, increment)
+    )
+    if version_tuple(next_version) <= version_tuple(release):
+        raise ValueError(
+            f"next development version {next_version} must be newer than release {release}"
+        )
+    major, minor, _ = version_tuple(release)
+    return {
+        "release": release,
+        "next": next_version,
+        "next_release": next_version.removesuffix("-SNAPSHOT"),
+        "maintenance_branch": f"maintenance/{major}.{minor}.x",
+    }
+
+
+def append_outputs(path: Path, plan: Mapping[str, str]) -> None:
+    with path.open("a", encoding="utf-8") as output:
+        for key in _OUTPUT_KEYS:
+            print(f"{key}={plan[key]}", file=output)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--release", required=True)
+    parser.add_argument("--next-development-version", default="")
+    parser.add_argument("--increment", default="patch")
+    parser.add_argument("--github-output", type=Path)
+    args = parser.parse_args()
+    try:
+        plan = resolve_plan(
+            args.release,
+            args.next_development_version,
+            args.increment,
+        )
+        if args.github_output:
+            append_outputs(args.github_output, plan)
+        for key in _OUTPUT_KEYS:
+            print(f"{key}={plan[key]}")
+    except ValueError as error:
+        print(f"::error::{error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test-release-version-plan.py
+++ b/.github/scripts/test-release-version-plan.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Regression tests for freely selectable next release versions."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import unittest
+
+SCRIPT = Path(__file__).with_name("release-version-plan.py")
+SPEC = importlib.util.spec_from_file_location("release_version_plan", SCRIPT)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"Cannot load {SCRIPT}")
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class ReleaseVersionPlanTest(unittest.TestCase):
+    def test_exact_major_version_is_preserved(self) -> None:
+        plan = MODULE.resolve_plan("1.2.9", " 2.0.0-SNAPSHOT ", "patch")
+        self.assertEqual("2.0.0-SNAPSHOT", plan["next"])
+        self.assertEqual("2.0.0", plan["next_release"])
+
+    def test_arbitrary_later_version_is_allowed(self) -> None:
+        plan = MODULE.resolve_plan("1.2.9", "3.7.4-SNAPSHOT", "minor")
+        self.assertEqual("3.7.4-SNAPSHOT", plan["next"])
+
+    def test_exact_version_overrides_increment(self) -> None:
+        plan = MODULE.resolve_plan("1.2.9", "2.1.3-SNAPSHOT", "not-used")
+        self.assertEqual("2.1.3-SNAPSHOT", plan["next"])
+
+    def test_empty_exact_value_uses_patch_fallback(self) -> None:
+        plan = MODULE.resolve_plan("1.2.9", "   ", "patch")
+        self.assertEqual("1.2.10-SNAPSHOT", plan["next"])
+
+    def test_minor_and_major_fallbacks_are_available(self) -> None:
+        self.assertEqual(
+            "1.3.0-SNAPSHOT", MODULE.resolve_plan("1.2.9", "", "minor")["next"]
+        )
+        self.assertEqual(
+            "2.0.0-SNAPSHOT", MODULE.resolve_plan("1.2.9", "", "major")["next"]
+        )
+
+    def test_next_version_must_be_newer(self) -> None:
+        with self.assertRaisesRegex(ValueError, "must be newer"):
+            MODULE.resolve_plan("1.2.9", "1.2.9-SNAPSHOT")
+
+    def test_malformed_version_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "X.Y.Z-SNAPSHOT"):
+            MODULE.resolve_plan("1.2.9", "2.0-SNAPSHOT")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -10,6 +10,20 @@ on:
         description: Stable version matching the current SNAPSHOT without -SNAPSHOT
         required: true
         type: string
+      next_development_version:
+        description: Exact next development version (X.Y.Z-SNAPSHOT); leave empty to use the increment choice
+        required: false
+        default: ''
+        type: string
+      next_version_increment:
+        description: Fallback when the exact next development version is empty
+        required: false
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
       skip_tests:
         description: Skip tests for a dry-run diagnostic build only
         required: false
@@ -80,11 +94,16 @@ jobs:
 
       - name: Test release publication helpers
         run: |
+          python3 .github/scripts/test-release-version-plan.py
           python3 .github/scripts/test_verify_release_identity.py
           python3 .github/scripts/test_wait_for_pages_build.py
           python3 .github/scripts/test_verify_published_repository.py
 
       - name: Validate requested version and immutable starting state
+        env:
+          RELEASE_VERSION_INPUT: ${{ inputs.release_version }}
+          NEXT_DEVELOPMENT_VERSION_INPUT: ${{ inputs.next_development_version }}
+          NEXT_VERSION_INCREMENT_INPUT: ${{ inputs.next_version_increment }}
         run: |
           set -euo pipefail
           starting_sha=$(git rev-parse HEAD)
@@ -96,7 +115,9 @@ jobs:
 
           current_version=$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version | tail -n 1)
           if [[ "${{ github.event_name }}" == 'workflow_dispatch' ]]; then
-            release_version='${{ inputs.release_version }}'
+            release_version_input="$RELEASE_VERSION_INPUT"
+            next_development_version_input="$NEXT_DEVELOPMENT_VERSION_INPUT"
+            next_version_increment="${NEXT_VERSION_INCREMENT_INPUT:-patch}"
           else
             git fetch --no-tags origin "${{ github.sha }}"
             branch_version="${GITHUB_REF_NAME#release-request/}"
@@ -105,13 +126,27 @@ jobs:
               echo "::error::Release request branch '$branch_version' differs from marker '$marker_version'."
               exit 1
             fi
-            release_version="$marker_version"
+            release_version_input="$marker_version"
+            if git cat-file -e "${{ github.sha }}:.github/next-development-version" 2>/dev/null; then
+              next_development_version_input=$(git show "${{ github.sha }}:.github/next-development-version")
+            else
+              next_development_version_input=''
+            fi
+            next_version_increment=patch
           fi
 
-          if ! [[ "$release_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Invalid stable release version '$release_version'."
-            exit 1
-          fi
+          plan_file="$RUNNER_TEMP/release-version-plan"
+          : > "$plan_file"
+          python3 .github/scripts/release-version-plan.py \
+            --release "$release_version_input" \
+            --next-development-version "$next_development_version_input" \
+            --increment "$next_version_increment" \
+            --github-output "$plan_file"
+          # Values are regex-validated semantic versions produced by the planner.
+          source "$plan_file"
+          release_version="$release"
+          next_snapshot="$next"
+
           if [[ "$current_version" != "${release_version}-SNAPSHOT" ]]; then
             echo "::error::Requested release '$release_version' does not match project version '$current_version'."
             exit 1
@@ -134,10 +169,6 @@ jobs:
             echo "::error::GitHub Release v${release_version} already exists."
             exit 1
           fi
-
-          IFS='.' read -r major minor patch <<< "$release_version"
-          next_snapshot="${major}.${minor}.$((patch + 1))-SNAPSHOT"
-          next_release="${major}.${minor}.$((patch + 1))"
 
           {
             echo "STARTING_SHA=$starting_sha"


### PR DESCRIPTION
## What changed

- add optional exact `next_development_version` input
- keep `patch` / `minor` / `major` as fallback only when the exact value is empty
- support exact next versions on automated release-request branches through optional `.github/next-development-version`
- numerically require the next version to be newer than the release
- test major transitions, arbitrary later versions, whitespace normalization and fallback behavior
- leave the existing distribution, p2, provenance, rollback and publication sequence unchanged

A release such as `1.2.9` can now explicitly continue as `2.0.0-SNAPSHOT` or any other valid newer `X.Y.Z-SNAPSHOT` version.