### PR TITLE
Use the Maven already installed on GitHub runners

### DIFF
--- a/.github/actions/use-runner-maven/action.yml
+++ b/.github/actions/use-runner-maven/action.yml
@@ -1,0 +1,22 @@
+name: Use runner Maven
+description: Verify and use the Maven installation supplied by the GitHub-hosted runner.
+
+runs:
+  using: composite
+  steps:
+    - name: Verify runner Maven
+      shell: bash
+      run: |
+        set -euo pipefail
+        command -v mvn
+        maven_version="$(mvn --version | awk '/Apache Maven/ { print $3; exit }')"
+        required_version=3.9.0
+        if [ -z "$maven_version" ]; then
+          echo "::error::Could not determine the Maven version supplied by the runner."
+          exit 1
+        fi
+        if [ "$(printf '%s\n%s\n' "$required_version" "$maven_version" | sort -V | head -n 1)" != "$required_version" ]; then
+          echo "::error::Maven $maven_version is older than the required $required_version."
+          exit 1
+        fi
+        mvn --version

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -10,6 +10,7 @@ on:
       - '**/pom.xml'
       - '.codacy.yml'
       - 'ruleset.xml'
+      - '.github/actions/use-runner-maven/**'
       - '.github/workflows/codacy.yml'
 
 concurrency:
@@ -29,11 +30,6 @@ jobs:
       LANG: C.UTF-8
       JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8
     steps:
-      - name: Set up Maven
-        uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
-        with:
-          maven-version: 3.9.14
-
       - name: Checkout code
         uses: actions/checkout@v6
 
@@ -43,6 +39,9 @@ jobs:
           java-version: '21'
           distribution: temurin
           cache: maven
+
+      - name: Use runner Maven
+        uses: ./.github/actions/use-runner-maven
 
       # This is the authoritative analysis gate. The parent POM binds the
       # SpotBugs Maven plugin with failOnError=true to the compile phase, so

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,7 +43,7 @@ jobs:
       matrix:
         language: [ 'java' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Learn more about GitHub language support at https://aka.ms/codeql-docs/language-support
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
     - name: Checkout repository
@@ -72,7 +72,7 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified queries in the config file.
+        # By default, queries listed here will override any specified queries in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
 
     # Build with the versions declared by the reactor. Hard-coding Tycho here can

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,6 +20,7 @@ on:
     paths:
       - '**.java'
       - '**/pom.xml'
+      - '.github/actions/use-runner-maven/**'
       - '.github/workflows/codeql.yml'
   schedule:
     - cron: '37 10 * * 6'
@@ -42,13 +43,9 @@ jobs:
       matrix:
         language: [ 'java' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+        # Learn more about GitHub language support at https://aka.ms/codeql-docs/language-support
 
     steps:
-    - name: Set up Maven
-      uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
-      with:
-        maven-version: 3.9.9
     - name: Checkout repository
       uses: actions/checkout@v6
 
@@ -58,6 +55,9 @@ jobs:
         java-version: '21'
         distribution: 'temurin'
         cache: maven
+
+    - name: Use runner Maven
+      uses: ./.github/actions/use-runner-maven
 
     - name: Cache Maven dependencies
       uses: actions/cache@v5
@@ -72,7 +72,7 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified queries in a config file.
+        # By default, queries listed here will override any specified queries in the config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
 
     # Build with the versions declared by the reactor. Hard-coding Tycho here can

--- a/.github/workflows/distribution-smoke.yml
+++ b/.github/workflows/distribution-smoke.yml
@@ -12,6 +12,7 @@ on:
       - 'org/**'
       - '*.xml'
       - '*.properties'
+      - '.github/actions/use-runner-maven/**'
       - '.github/scripts/smoke_test_distribution.sh'
       - '.github/workflows/distribution-smoke.yml'
   push:
@@ -25,6 +26,7 @@ on:
       - 'org/**'
       - '*.xml'
       - '*.properties'
+      - '.github/actions/use-runner-maven/**'
       - '.github/scripts/smoke_test_distribution.sh'
       - '.github/workflows/distribution-smoke.yml'
   schedule:
@@ -51,9 +53,8 @@ jobs:
           distribution: temurin
           java-version: '21'
           cache: maven
-      - uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1
-        with:
-          maven-version: 3.9.14
+      - name: Use runner Maven
+        uses: ./.github/actions/use-runner-maven
       - name: Install Linux desktop runtime
         run: |
           sudo apt-get update

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,6 +13,7 @@ on:
       - '*.xml'
       - '*.properties'
       - '.github/actions/cleanup-action/**'
+      - '.github/actions/use-runner-maven/**'
       - '.github/workflows/maven.yml'
   pull_request:
     branches: [ main ]
@@ -26,6 +27,7 @@ on:
       - '*.xml'
       - '*.properties'
       - '.github/actions/cleanup-action/**'
+      - '.github/actions/use-runner-maven/**'
       - '.github/workflows/maven.yml'
   workflow_dispatch:
 
@@ -58,10 +60,8 @@ jobs:
           distribution: temurin
           cache: maven
 
-      - name: Set up Maven 3.9.14
-        uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1
-        with:
-          maven-version: 3.9.14
+      - name: Use runner Maven
+        uses: ./.github/actions/use-runner-maven
 
       - name: Set up Node.js for CSS tests
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary

Remove the network-dependent Maven bootstrap from the four authoritative pull-request gates.

- add one repository-local composite action that verifies the runner supplies Maven 3.9 or newer and records the exact version;
- use that action in Java CI, Distribution Smoke Test, CodeQL and Codacy;
- move Codacy and CodeQL checkout before the local action, as required for repository-local actions;
- include the shared action path in each workflow's pull-request path filter;
- leave every Maven goal, profile, Tycho option, timeout and publication/reporting step unchanged.

## Root cause

The pinned `stCarolas/setup-maven` action downloads Maven from Maven Central on every job. Current PR runs repeatedly failed before checkout/build because the Maven 3.9.14 archive request returned HTTP 429. The pinned Ubuntu 24.04 runner image already supplies Maven 3.9.16, so downloading an older patch release adds a failure mode without improving reproducibility.

## Safety boundary

This changes Maven provisioning only. Project versions, Maven goals, release ordering, p2 verification and security gates are unchanged.