### PR TITLE
Use runner Maven in the release workflow

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -73,10 +73,8 @@ jobs:
           java-version: '21'
           distribution: temurin
 
-      - name: Set up Maven
-        uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1
-        with:
-          maven-version: 3.9.14
+      - name: Use runner Maven
+        uses: ./.github/actions/use-runner-maven
 
       - name: Cache Maven dependencies
         uses: actions/cache@v5


### PR DESCRIPTION
## Summary

Apply the already validated #1358 Maven setup to the release workflow as well.

- remove the external exact-version Maven download from `deploy-release.yml`;
- use the repository-local `use-runner-maven` action after checkout and JDK setup;
- leave release version planning, dry-run behavior, Maven goals, publication safeguards, artifacts and rollback logic unchanged.

This closes the remaining path where a repository rate limit could fail a release before the actual Maven/Tycho build starts.

Refs #1285