### PR TITLE
Enable or retire all disabled JUnit tests

### DIFF
--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/internal/common/ASTProcessor.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/internal/common/ASTProcessor.java
@@ -2767,8 +2767,10 @@ public class ASTProcessor<E extends HelperVisitorProvider<V, T, E>, V, T> {
 		BiPredicate<ASTNode, E> biPredicate= nodeHolder.callee;
 		BiConsumer<ASTNode, E> bcConsumer= nodeHolder.callee_end;
 		HelperVisitor<E, V, T> hv= new HelperVisitor<>(nodesprocessed, dataholder);
+		boolean[] matched= { false };
 		if(bcConsumer!=null) {
 			hv.addEnd(next, (node, holder) -> {
+				matched[0]= true;
 				bcConsumer.accept(node, holder);
 				if (nodeHolder.navigate != null) {
 					process(nodeHolder.navigate.apply(node), i + 1);
@@ -2778,6 +2780,7 @@ public class ASTProcessor<E extends HelperVisitorProvider<V, T, E>, V, T> {
 			});
 		} else if (nodeHolder.object != null) {
 			hv.add(nodeHolder.object, next, (node, holder) -> {
+				matched[0]= true;
 				boolean test= biPredicate.test(node, holder);
 				if (nodeHolder.navigate != null) {
 					process(nodeHolder.navigate.apply(node), i + 1);
@@ -2788,6 +2791,7 @@ public class ASTProcessor<E extends HelperVisitorProvider<V, T, E>, V, T> {
 			});
 		} else  {
 			hv.add(next, (node, holder) -> {
+				matched[0]= true;
 				boolean test= biPredicate.test(node, holder);
 				if (nodeHolder.navigate != null) {
 					process(nodeHolder.navigate.apply(node), i + 1);
@@ -2798,6 +2802,9 @@ public class ASTProcessor<E extends HelperVisitorProvider<V, T, E>, V, T> {
 			});
 		}
 		hv.build(localnode);
+		if (!matched[0]) {
+			process(localnode, i + 1);
+		}
 	}
 
 }

--- a/sandbox_common_test/src/org/sandbox/jdt/ui/tests/quickfix/ClassInstanceCreationVisitorTest.java
+++ b/sandbox_common_test/src/org/sandbox/jdt/ui/tests/quickfix/ClassInstanceCreationVisitorTest.java
@@ -30,7 +30,6 @@ import org.eclipse.jdt.core.dom.ClassInstanceCreation;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.sandbox.jdt.internal.common.AstProcessorBuilder;
 import org.sandbox.jdt.internal.common.HelperVisitor;
@@ -529,7 +528,7 @@ public class ClassInstanceCreationVisitorTest {
 	}
 	
 	/**
-	 * Reproduces the AstProcessorBuilder chained visitor bug from PR #678.
+	 * Regression coverage for the AstProcessorBuilder chained visitor bug from PR #678.
 	 * 
 	 * <p>When using chained visitors (MethodInvocation → ClassInstanceCreation), 
 	 * if the first visitor (beginTask) does NOT match anything, the second visitor 
@@ -539,12 +538,11 @@ public class ClassInstanceCreationVisitorTest {
 	 * <p>This means standalone ClassInstanceCreation nodes (without a preceding 
 	 * beginTask) are never detected by the chained visitor.</p>
 	 * 
-	 * <p>The workaround used in JFacePlugin.java is to use a direct ASTVisitor for 
-	 * the second pass instead of relying on chained visitors.</p>
+	 * <p>The processor must advance to the next registered visitor even when a prior
+	 * visitor has no matches in the selected scope.</p>
 	 * 
 	 * @see <a href="https://github.com/carstenartur/sandbox/pull/678">PR #678</a>
 	 */
-	@Disabled("AstProcessorBuilder bug: chained ClassInstanceCreation visitor not called when first MethodInvocation visitor has no match (PR #678)")
 	@Test
 	public void testChainedVisitorWithoutFirstMatchBug() {
 		// Code WITHOUT beginTask() - only standalone ClassInstanceCreation nodes
@@ -570,8 +568,7 @@ public class ClassInstanceCreationVisitorTest {
 		
 		// Use the same chained pattern as JFacePlugin: MethodInvocation -> ClassInstanceCreation
 		// Since there's no beginTask(), the first visitor will have ZERO matches.
-		// BUG: The second visitor should still be able to find ClassInstanceCreation nodes,
-		// but due to the chaining architecture, it is never called.
+		// The second visitor must still inspect the original scope.
 		AstProcessorBuilder.with(dataholder, nodesprocessed)
 			.processor()
 			.callMethodInvocationVisitor(MockProgressMonitor.class, "beginTask", (node, holder) -> {
@@ -584,9 +581,7 @@ public class ClassInstanceCreationVisitorTest {
 			})
 			.build(cu);
 		
-		// This assertion FAILS because the chained ClassInstanceCreation visitor
-		// is never called when the MethodInvocation visitor has no matches.
-		// The workaround is to use a separate ASTVisitor for standalone detection.
+		// A missing first-stage match must not suppress later independent visitors.
 		assertEquals(2, cicNodes.size(), 
 			"Chained ClassInstanceCreation visitor should find nodes even when " +
 			"the first MethodInvocation visitor has no matches");

--- a/sandbox_encoding_quickfix/src/org/sandbox/jdt/internal/corext/fix/helper/AbstractExplicitEncoding.java
+++ b/sandbox_encoding_quickfix/src/org/sandbox/jdt/internal/corext/fix/helper/AbstractExplicitEncoding.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.sandbox.jdt.internal.corext.fix.helper;
 
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -23,6 +25,7 @@ import java.util.regex.Pattern;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.Block;
 import org.eclipse.jdt.core.dom.CatchClause;
 import org.eclipse.jdt.core.dom.CompilationUnit;
@@ -30,6 +33,7 @@ import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.FieldAccess;
 import org.eclipse.jdt.core.dom.FieldDeclaration;
 import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.ImportDeclaration;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.core.dom.Name;
@@ -63,6 +67,8 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 
 	private static final String JAVA_IO_UNSUPPORTED_ENCODING_EXCEPTION = "java.io.UnsupportedEncodingException"; //$NON-NLS-1$
 	private static final String UNSUPPORTED_ENCODING_EXCEPTION = "UnsupportedEncodingException"; //$NON-NLS-1$
+	private static final String REMOVED_UNSUPPORTED_ENCODING_CATCHES_PROPERTY =
+			AbstractExplicitEncoding.class.getName() + ".removedUnsupportedEncodingCatches"; //$NON-NLS-1$
 
 	public static final Map<String, String> ENCODING_MAP = Map.of(
 			"UTF-8", "UTF_8", //$NON-NLS-1$ //$NON-NLS-2$
@@ -239,8 +245,9 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 			CompilationUnit root = (CompilationUnit) statement.getRoot();
 			int start = root.getExtendedStartPosition(statement);
 			String source = buffer.substring(start, start + root.getExtendedLength(statement));
-			source = stripBaseIndent(source, lineDelimiter(buffer));
 			source = LAST_NLS_COMMENT.matcher(source).replaceFirst(""); //$NON-NLS-1$
+			source = Pattern.compile("^[ \\t]*").matcher(source).replaceAll(""); //$NON-NLS-1$ //$NON-NLS-2$
+			source = Pattern.compile("\n[ \\t]*").matcher(source).replaceAll("\n"); //$NON-NLS-1$ //$NON-NLS-2$
 			String visitedSource = buffer.substring(visited.getStartPosition(),
 					visited.getStartPosition() + visited.getLength());
 			String replacementSource = replacement.toString().replaceAll(",", ", "); //$NON-NLS-1$ //$NON-NLS-2$
@@ -288,13 +295,59 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 			}
 
 			CatchClause removedCatch = (CatchClause) tryStatement.catchClauses().get(0);
+			Set<CatchClause> removedCatches = removedUnsupportedEncodingCatches(root);
+			removedCatches.add(removedCatch);
 			cuRewrite.getImportRemover().registerRemovedNode(removedCatch);
+			if (!hasSurvivingUnsupportedEncodingExceptionReference(root, removedCatches)) {
+				cuRewrite.getImportRewrite().removeImport(JAVA_IO_UNSUPPORTED_ENCODING_EXCEPTION);
+			}
 			rewrite.remove(tryStatement, group);
 			return true;
 		} catch (JavaModelException exception) {
 			rewrite.replace(visited, replacement, group);
 			return false;
 		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Set<CatchClause> removedUnsupportedEncodingCatches(CompilationUnit root) {
+		Object stored = root.getProperty(REMOVED_UNSUPPORTED_ENCODING_CATCHES_PROPERTY);
+		if (stored instanceof Set<?>) {
+			return (Set<CatchClause>) stored;
+		}
+		Set<CatchClause> removedCatches = Collections.newSetFromMap(new IdentityHashMap<>());
+		root.setProperty(REMOVED_UNSUPPORTED_ENCODING_CATCHES_PROPERTY, removedCatches);
+		return removedCatches;
+	}
+
+	private static boolean hasSurvivingUnsupportedEncodingExceptionReference(CompilationUnit root,
+			Set<CatchClause> removedCatches) {
+		boolean[] found = { false };
+		root.accept(new ASTVisitor() {
+			@Override
+			public boolean visit(SimpleName node) {
+				if (found[0]) {
+					return false;
+				}
+				if (!UNSUPPORTED_ENCODING_EXCEPTION.equals(node.getIdentifier())
+						|| ASTNodes.getFirstAncestorOrNull(node, ImportDeclaration.class) != null
+						|| isDescendantOfAny(node, removedCatches)) {
+					return true;
+				}
+				found[0] = true;
+				return false;
+			}
+		});
+		return found[0];
+	}
+
+	private static boolean isDescendantOfAny(ASTNode node, Set<CatchClause> ancestors) {
+		for (ASTNode current = node; current != null; current = current.getParent()) {
+			if (ancestors.contains(current)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private static String stripBaseIndent(String source, String delimiter) {

--- a/sandbox_encoding_quickfix/src/org/sandbox/jdt/internal/corext/fix/helper/AbstractExplicitEncoding.java
+++ b/sandbox_encoding_quickfix/src/org/sandbox/jdt/internal/corext/fix/helper/AbstractExplicitEncoding.java
@@ -245,9 +245,7 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 			CompilationUnit root = (CompilationUnit) statement.getRoot();
 			int start = root.getExtendedStartPosition(statement);
 			String source = buffer.substring(start, start + root.getExtendedLength(statement));
-			source = LAST_NLS_COMMENT.matcher(source).replaceFirst(""); //$NON-NLS-1$
-			source = Pattern.compile("^[ \\t]*").matcher(source).replaceAll(""); //$NON-NLS-1$ //$NON-NLS-2$
-			source = Pattern.compile("\n[ \\t]*").matcher(source).replaceAll("\n"); //$NON-NLS-1$ //$NON-NLS-2$
+			source = normalizeReplacementSource(source);
 			String visitedSource = buffer.substring(visited.getStartPosition(),
 					visited.getStartPosition() + visited.getLength());
 			String replacementSource = replacement.toString().replaceAll(",", ", "); //$NON-NLS-1$ //$NON-NLS-2$
@@ -271,7 +269,6 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 		try {
 			String buffer = cuRewrite.getCu().getBuffer().getContents();
 			CompilationUnit root = (CompilationUnit) statement.getRoot();
-			String delimiter = lineDelimiter(buffer);
 			String visitedSource = buffer.substring(visited.getStartPosition(),
 					visited.getStartPosition() + visited.getLength());
 			String replacementSource = replacement.toString().replaceAll(",", ", "); //$NON-NLS-1$ //$NON-NLS-2$
@@ -284,9 +281,7 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 				if (bodyStatement == statement) {
 					int start = root.getExtendedStartPosition(bodyStatement);
 					String source = buffer.substring(start, start + root.getExtendedLength(bodyStatement));
-					source = stripBaseIndent(source, delimiter);
-					source = LAST_NLS_COMMENT.matcher(source).replaceFirst(""); //$NON-NLS-1$
-					source = source.replace(visitedSource, replacementSource);
+					source = normalizeReplacementSource(source).replace(visitedSource, replacementSource);
 					inlinedStatement = rewrite.createStringPlaceholder(source, bodyStatement.getNodeType());
 				} else {
 					inlinedStatement = rewrite.createMoveTarget(bodyStatement);
@@ -307,6 +302,12 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 			rewrite.replace(visited, replacement, group);
 			return false;
 		}
+	}
+
+	private static String normalizeReplacementSource(String source) {
+		String normalized = LAST_NLS_COMMENT.matcher(source).replaceFirst(""); //$NON-NLS-1$
+		normalized = Pattern.compile("^[ \\t]*").matcher(normalized).replaceAll(""); //$NON-NLS-1$ //$NON-NLS-2$
+		return Pattern.compile("\n[ \\t]*").matcher(normalized).replaceAll("\n"); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
 	@SuppressWarnings("unchecked")
@@ -330,7 +331,7 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 					return false;
 				}
 				if (!UNSUPPORTED_ENCODING_EXCEPTION.equals(node.getIdentifier())
-						|| ASTNodes.getFirstAncestorOrNull(node, ImportDeclaration.class) != null
+						|| hasAncestor(node, ImportDeclaration.class)
 						|| isDescendantOfAny(node, removedCatches)) {
 					return true;
 				}
@@ -341,6 +342,15 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 		return found[0];
 	}
 
+	private static boolean hasAncestor(ASTNode node, Class<? extends ASTNode> ancestorType) {
+		for (ASTNode current = node.getParent(); current != null; current = current.getParent()) {
+			if (ancestorType.isInstance(current)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	private static boolean isDescendantOfAny(ASTNode node, Set<CatchClause> ancestors) {
 		for (ASTNode current = node; current != null; current = current.getParent()) {
 			if (ancestors.contains(current)) {
@@ -348,50 +358,6 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 			}
 		}
 		return false;
-	}
-
-	private static String stripBaseIndent(String source, String delimiter) {
-		String[] lines = source.replace("\r\n", "\n").replace('\r', '\n').split("\n", -1); //$NON-NLS-1$ //$NON-NLS-2$
-		int first = 0;
-		while (first < lines.length && lines[first].isBlank()) {
-			first++;
-		}
-		int last = lines.length - 1;
-		while (last >= first && lines[last].isBlank()) {
-			last--;
-		}
-		if (first > last) {
-			return ""; //$NON-NLS-1$
-		}
-		String baseIndent = leadingWhitespace(lines[first]);
-		StringBuilder result = new StringBuilder();
-		for (int index = first; index <= last; index++) {
-			if (index > first) {
-				result.append(delimiter);
-			}
-			String line = lines[index];
-			if (!baseIndent.isEmpty() && line.startsWith(baseIndent)) {
-				line = line.substring(baseIndent.length());
-			}
-			result.append(line.isBlank() ? "" : line); //$NON-NLS-1$
-		}
-		return result.toString();
-	}
-
-	private static String leadingWhitespace(String line) {
-		int index = 0;
-		while (index < line.length()) {
-			char character = line.charAt(index);
-			if (character != ' ' && character != '\t') {
-				break;
-			}
-			index++;
-		}
-		return line.substring(0, index);
-	}
-
-	private static String lineDelimiter(String source) {
-		return source.contains("\r\n") ? "\r\n" : "\n"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 	}
 
 	private static boolean isInsideTryBodyWithOnlyUnsupportedEncodingCatch(ASTNode statement) {

--- a/sandbox_encoding_quickfix/src/org/sandbox/jdt/internal/corext/fix/helper/AbstractExplicitEncoding.java
+++ b/sandbox_encoding_quickfix/src/org/sandbox/jdt/internal/corext/fix/helper/AbstractExplicitEncoding.java
@@ -23,11 +23,15 @@ import java.util.regex.Pattern;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.Block;
+import org.eclipse.jdt.core.dom.CatchClause;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.FieldAccess;
 import org.eclipse.jdt.core.dom.FieldDeclaration;
+import org.eclipse.jdt.core.dom.ImportDeclaration;
+import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.core.dom.Name;
@@ -35,11 +39,11 @@ import org.eclipse.jdt.core.dom.QualifiedName;
 import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.Statement;
 import org.eclipse.jdt.core.dom.StringLiteral;
+import org.eclipse.jdt.core.dom.TryStatement;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
-import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
 import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperation;
@@ -50,7 +54,6 @@ import org.sandbox.jdt.internal.common.ReferenceHolder;
 import org.sandbox.jdt.internal.corext.fix.UseExplicitEncodingFixCore;
 import org.sandbox.jdt.internal.corext.util.ImportUtils;
 import org.sandbox.jdt.triggerpattern.cleanup.ExceptionCleanupHelper;
-
 
 /**
  * Abstract base class for encoding-related quick fixes. Provides common functionality
@@ -119,7 +122,7 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 	/**
 	 * Immutable record to hold node data for encoding transformations.
 	 * Replaces the mutable Nodedata class for better thread safety and immutability.
-	 * 
+	 *
 	 * @param replace Whether to replace an existing encoding parameter (true) or appended (false)
 	 * @param visited The AST node that was visited and needs modification
 	 * @param encoding The encoding constant name (e.g., "UTF_8"), or null for default charset
@@ -135,7 +138,7 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 
 	/**
 	 * Returns the charset constants map for use in encoding transformations.
-	 * 
+	 *
 	 * @return thread-safe map of charset constants
 	 */
 	protected static Map<String, QualifiedName> getCharsetConstants() {
@@ -291,11 +294,7 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 		}
 		ASTNode methodDecl = ASTNodes.getFirstAncestorOrNull(node, MethodDeclaration.class);
 		ASTNode typeDecl = ASTNodes.getFirstAncestorOrNull(node, TypeDeclaration.class);
-		
-		// Return the closest ancestor. In Java, methods are always declared inside types,
-		// so if a MethodDeclaration exists, it is guaranteed to be closer than any TypeDeclaration.
-		// getFirstAncestorOrNull returns the nearest ancestor of each type, so we just need to
-		// prefer the more specific (nested) one.
+
 		if (methodDecl != null) {
 			return methodDecl;
 		}
@@ -457,30 +456,21 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 			ASTNode replacement, TextEditGroup group, CompilationUnitRewrite cuRewrite) {
 		ASTNode st = ASTNodes.getFirstAncestorOrNull(visited, Statement.class, FieldDeclaration.class);
 		if (st != null && isInsideTryBodyWithOnlyUnsupportedEncodingCatch(st)) {
-			// Statement is in a try body that will be unwrapped.
-			// Handle BOTH the argument replacement AND the try-catch unwrapping
-			// in a single text-based operation to avoid conflicts between
-			// rewrite.replace() and createMoveTarget().
 			return replaceTryBodyAndUnwrap(rewrite, visited, replacement, st, group, cuRewrite);
 		}
 		if (st == null) {
 			rewrite.replace(visited, replacement, group);
 			return false;
 		}
-		// Safe to use the full statement replacement with NLS removal
-		// (same approach as ASTNodes.replaceAndRemoveNLS)
 		try {
 			String buffer = cuRewrite.getCu().getBuffer().getContents();
 			CompilationUnit cu = (CompilationUnit) st.getRoot();
 			int origStart = cu.getExtendedStartPosition(st);
 			int origLength = cu.getExtendedLength(st);
 			String original = buffer.substring(origStart, origStart + origLength);
-			// Remove last NLS comment (the one for the replaced encoding string literal)
 			original = LAST_NLS_COMMENT.matcher(original).replaceFirst(""); //$NON-NLS-1$
-			// Remove leading whitespace
 			original = Pattern.compile("^[ \\t]*").matcher(original).replaceAll(""); //$NON-NLS-1$ //$NON-NLS-2$
 			original = Pattern.compile("\n[ \\t]*").matcher(original).replaceAll("\n"); //$NON-NLS-1$ //$NON-NLS-2$
-			// Replace visited text with replacement text
 			String visitedString = buffer.substring(visited.getStartPosition(),
 					visited.getStartPosition() + visited.getLength());
 			String replacementString = replacement.toString().replaceAll(",", ", "); //$NON-NLS-1$ //$NON-NLS-2$
@@ -488,7 +478,6 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 			ASTNode placeholder = rewrite.createStringPlaceholder(modified, st.getNodeType());
 			rewrite.replace(st, placeholder, group);
 		} catch (JavaModelException e) {
-			// Fall back to simple replacement without NLS removal
 			rewrite.replace(visited, replacement, group);
 		}
 		return false;
@@ -509,10 +498,9 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 	private static boolean replaceTryBodyAndUnwrap(ASTRewrite rewrite, ASTNode visited,
 			ASTNode replacement, ASTNode statement, TextEditGroup group, CompilationUnitRewrite cuRewrite) {
 		Block block = (Block) statement.getParent();
-		org.eclipse.jdt.core.dom.TryStatement tryStatement = (org.eclipse.jdt.core.dom.TryStatement) block.getParent();
+		TryStatement tryStatement = (TryStatement) block.getParent();
 		ASTNode tryParent = tryStatement.getParent();
 		if (!(tryParent instanceof Block parentBlock)) {
-			// Cannot inline statements if the try's parent is not a block
 			rewrite.replace(visited, replacement, group);
 			return false;
 		}
@@ -523,7 +511,6 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 					visited.getStartPosition() + visited.getLength());
 			String replacementString = replacement.toString().replaceAll(",", ", "); //$NON-NLS-1$ //$NON-NLS-2$
 
-			// Create string placeholders for each statement in the try body
 			ListRewrite parentListRewrite = rewrite.getListRewrite(parentBlock, Block.STATEMENTS_PROPERTY);
 			List<?> tryStatements = block.statements();
 			for (int i = tryStatements.size() - 1; i >= 0; i--) {
@@ -531,12 +518,9 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 				int stmtStart = cu.getExtendedStartPosition(stmt);
 				int stmtLength = cu.getExtendedLength(stmt);
 				String stmtSource = buffer.substring(stmtStart, stmtStart + stmtLength);
-				// Remove leading whitespace
 				stmtSource = Pattern.compile("^[ \\t]*").matcher(stmtSource).replaceAll(""); //$NON-NLS-1$ //$NON-NLS-2$
 				stmtSource = Pattern.compile("\n[ \\t]*").matcher(stmtSource).replaceAll("\n"); //$NON-NLS-1$ //$NON-NLS-2$
-				// Apply the argument replacement if this statement contains the visited node
 				if (stmt == statement) {
-					// Remove last NLS comment (the one for the replaced encoding string literal)
 					stmtSource = LAST_NLS_COMMENT.matcher(stmtSource).replaceFirst(""); //$NON-NLS-1$
 					stmtSource = stmtSource.replace(visitedString, replacementString);
 				}
@@ -544,25 +528,64 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 				parentListRewrite.insertAfter(placeholder, tryStatement, group);
 			}
 			rewrite.remove(tryStatement, group);
+			registerUnwrappedTryForImportRemoval(tryStatement, cuRewrite);
 			return true;
 		} catch (JavaModelException e) {
-			// Fall back to simple replacement without NLS removal
 			rewrite.replace(visited, replacement, group);
 			return false;
 		}
 	}
 
 	/**
+	 * Registers the removed try/catch while retaining its inlined body. Placeholder
+	 * rewrites do not provide {@link ImportRemover} with a reliable reference balance,
+	 * so the obsolete exception import is removed explicitly only when no bound type
+	 * reference survives outside the deleted catch clause.
+	 */
+	private static void registerUnwrappedTryForImportRemoval(TryStatement tryStatement,
+			CompilationUnitRewrite cuRewrite) {
+		cuRewrite.getImportRemover().registerRemovedNode(tryStatement);
+		cuRewrite.getImportRemover().registerRetainedNode(tryStatement.getBody());
+		CatchClause removedCatch = (CatchClause) tryStatement.catchClauses().get(0);
+		CompilationUnit root = (CompilationUnit) tryStatement.getRoot();
+		if (!hasSurvivingUnsupportedEncodingExceptionReference(root, removedCatch)) {
+			cuRewrite.getImportRewrite().removeImport(JAVA_IO_UNSUPPORTED_ENCODING_EXCEPTION);
+		}
+	}
+
+	private static boolean hasSurvivingUnsupportedEncodingExceptionReference(CompilationUnit root,
+			CatchClause removedCatch) {
+		boolean[] found = { false };
+		root.accept(new ASTVisitor() {
+			@Override
+			public boolean visit(SimpleName node) {
+				if (found[0] || isDescendantOf(node, removedCatch)
+						|| ASTNodes.getFirstAncestorOrNull(node, ImportDeclaration.class) != null) {
+					return !found[0];
+				}
+				ITypeBinding typeBinding = node.resolveTypeBinding();
+				if (typeBinding != null
+						&& JAVA_IO_UNSUPPORTED_ENCODING_EXCEPTION.equals(typeBinding.getErasure().getQualifiedName())) {
+					found[0] = true;
+				}
+				return !found[0];
+			}
+		});
+		return found[0];
+	}
+
+	private static boolean isDescendantOf(ASTNode node, ASTNode ancestor) {
+		for (ASTNode current = node; current != null; current = current.getParent()) {
+			if (current == ancestor) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
 	 * Checks whether the given statement is directly inside the body of a try statement
-	 * that will be fully unwrapped by removeUnsupportedEncodingException. This happens when:
-	 * <ul>
-	 *   <li>The statement is in the try body (not a catch/finally block)</li>
-	 *   <li>The try has no resources (not try-with-resources)</li>
-	 *   <li>The try has no finally block</li>
-	 *   <li>The try has exactly one catch clause catching only UnsupportedEncodingException</li>
-	 * </ul>
-	 * In this case, simplifyEmptyTryStatement will use createMoveTarget to move
-	 * statements out of the try body, so we must not use statement-level replacement.
+	 * that will be fully unwrapped by removeUnsupportedEncodingException.
 	 */
 	private static boolean isInsideTryBodyWithOnlyUnsupportedEncodingCatch(ASTNode statement) {
 		ASTNode parent = statement.getParent();
@@ -570,14 +593,12 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 			return false;
 		}
 		ASTNode grandParent = block.getParent();
-		if (!(grandParent instanceof org.eclipse.jdt.core.dom.TryStatement tryStatement)) {
+		if (!(grandParent instanceof TryStatement tryStatement)) {
 			return false;
 		}
-		// Check if the block is the try body (not a catch or finally block)
 		if (tryStatement.getBody() != block) {
 			return false;
 		}
-		// Try-with-resources won't be unwrapped even if catch is removed
 		if (!tryStatement.resources().isEmpty()) {
 			return false;
 		}
@@ -585,18 +606,15 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 			return false;
 		}
 		@SuppressWarnings("unchecked")
-		List<org.eclipse.jdt.core.dom.CatchClause> catchClauses = tryStatement.catchClauses();
+		List<CatchClause> catchClauses = tryStatement.catchClauses();
 		if (catchClauses.size() != 1) {
 			return false;
 		}
-		org.eclipse.jdt.core.dom.CatchClause catchClause = catchClauses.get(0);
+		CatchClause catchClause = catchClauses.get(0);
 		org.eclipse.jdt.core.dom.Type exType = catchClause.getException().getType();
 		if (exType instanceof org.eclipse.jdt.core.dom.SimpleType simpleType) {
 			return UNSUPPORTED_ENCODING_EXCEPTION.equals(simpleType.getName().toString());
 		}
-		// Union type (e.g., FileNotFoundException | UnsupportedEncodingException):
-		// After removing UnsupportedEncodingException, another catch type remains,
-		// so the try won't be unwrapped → no conflict with createMoveTarget.
 		return false;
 	}
 

--- a/sandbox_encoding_quickfix/src/org/sandbox/jdt/internal/corext/fix/helper/AbstractExplicitEncoding.java
+++ b/sandbox_encoding_quickfix/src/org/sandbox/jdt/internal/corext/fix/helper/AbstractExplicitEncoding.java
@@ -487,11 +487,9 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 	 * Handles the case where a string literal replacement is needed inside a try body
 	 * that will be unwrapped (single catch clause for UnsupportedEncodingException only).
 	 *
-	 * <p>This method creates string placeholders for each statement in the try body
-	 * with the argument replacement already baked in, then replaces the entire try
-	 * statement with these inlined statements. This avoids the conflict between
-	 * {@code rewrite.replace()} on child nodes and {@code createMoveTarget()} on
-	 * parent statements.
+	 * <p>Unchanged statements remain AST move targets so their source formatting and
+	 * attached comments are preserved. Only the statement containing the replaced
+	 * encoding literal is recreated as a placeholder.
 	 *
 	 * @return {@code true} if the try-catch was successfully unwrapped
 	 */
@@ -515,17 +513,20 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 			List<?> tryStatements = block.statements();
 			for (int i = tryStatements.size() - 1; i >= 0; i--) {
 				ASTNode stmt = (ASTNode) tryStatements.get(i);
-				int stmtStart = cu.getExtendedStartPosition(stmt);
-				int stmtLength = cu.getExtendedLength(stmt);
-				String stmtSource = buffer.substring(stmtStart, stmtStart + stmtLength);
-				stmtSource = Pattern.compile("^[ \\t]*").matcher(stmtSource).replaceAll(""); //$NON-NLS-1$ //$NON-NLS-2$
-				stmtSource = Pattern.compile("\n[ \\t]*").matcher(stmtSource).replaceAll("\n"); //$NON-NLS-1$ //$NON-NLS-2$
+				ASTNode inlinedStatement;
 				if (stmt == statement) {
+					int stmtStart = cu.getExtendedStartPosition(stmt);
+					int stmtLength = cu.getExtendedLength(stmt);
+					String stmtSource = buffer.substring(stmtStart, stmtStart + stmtLength);
+					stmtSource = Pattern.compile("^[ \\t]*").matcher(stmtSource).replaceAll(""); //$NON-NLS-1$ //$NON-NLS-2$
+					stmtSource = Pattern.compile("\n[ \\t]*").matcher(stmtSource).replaceAll("\n"); //$NON-NLS-1$ //$NON-NLS-2$
 					stmtSource = LAST_NLS_COMMENT.matcher(stmtSource).replaceFirst(""); //$NON-NLS-1$
 					stmtSource = stmtSource.replace(visitedString, replacementString);
+					inlinedStatement = rewrite.createStringPlaceholder(stmtSource, stmt.getNodeType());
+				} else {
+					inlinedStatement = rewrite.createMoveTarget(stmt);
 				}
-				ASTNode placeholder = rewrite.createStringPlaceholder(stmtSource, stmt.getNodeType());
-				parentListRewrite.insertAfter(placeholder, tryStatement, group);
+				parentListRewrite.insertAfter(inlinedStatement, tryStatement, group);
 			}
 			rewrite.remove(tryStatement, group);
 			registerUnwrappedTryForImportRemoval(tryStatement, cuRewrite);
@@ -539,8 +540,8 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 	/**
 	 * Registers the removed try/catch while retaining its inlined body. Placeholder
 	 * rewrites do not provide {@link ImportRemover} with a reliable reference balance,
-	 * so the obsolete exception import is removed explicitly only when no bound type
-	 * reference survives outside the deleted catch clause.
+	 * so the obsolete exception import is removed explicitly only when no type reference
+	 * survives outside the deleted catch clause.
 	 */
 	private static void registerUnwrappedTryForImportRemoval(TryStatement tryStatement,
 			CompilationUnitRewrite cuRewrite) {
@@ -564,8 +565,12 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 					return !found[0];
 				}
 				ITypeBinding typeBinding = node.resolveTypeBinding();
-				if (typeBinding != null
-						&& JAVA_IO_UNSUPPORTED_ENCODING_EXCEPTION.equals(typeBinding.getErasure().getQualifiedName())) {
+				if (typeBinding != null) {
+					if (JAVA_IO_UNSUPPORTED_ENCODING_EXCEPTION.equals(typeBinding.getErasure().getQualifiedName())) {
+						found[0] = true;
+					}
+				} else if (UNSUPPORTED_ENCODING_EXCEPTION.equals(node.getIdentifier())) {
+					// Fail closed for incomplete or recovered bindings.
 					found[0] = true;
 				}
 				return !found[0];

--- a/sandbox_encoding_quickfix/src/org/sandbox/jdt/internal/corext/fix/helper/AbstractExplicitEncoding.java
+++ b/sandbox_encoding_quickfix/src/org/sandbox/jdt/internal/corext/fix/helper/AbstractExplicitEncoding.java
@@ -32,7 +32,6 @@ import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.FieldAccess;
 import org.eclipse.jdt.core.dom.FieldDeclaration;
-import org.eclipse.jdt.core.dom.ImportDeclaration;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
@@ -42,11 +41,11 @@ import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.Statement;
 import org.eclipse.jdt.core.dom.StringLiteral;
 import org.eclipse.jdt.core.dom.TryStatement;
+import org.eclipse.jdt.core.dom.Type;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
-import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperation;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
@@ -58,284 +57,127 @@ import org.sandbox.jdt.internal.corext.util.ImportUtils;
 import org.sandbox.jdt.triggerpattern.cleanup.ExceptionCleanupHelper;
 
 /**
- * Abstract base class for encoding-related quick fixes. Provides common functionality
- * for finding and rewriting code patterns that use implicit or string-based encoding
- * specifications.
+ * Shared support for cleanups that replace implicit or string-based encodings.
  *
- * <p>Subclasses must implement:
- * <ul>
- *   <li>{@link #find} - to locate code patterns that need to be fixed</li>
- *   <li>{@link #rewrite} - to apply the encoding-related transformation</li>
- *   <li>{@link #getPreview} - to generate preview text for the fix</li>
- * </ul>
- *
- * @param <T> The type of AST node that this encoding handler processes
+ * @param <T> AST node handled by the concrete cleanup
  */
 public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 
-	/** Fully qualified name of java.io.UnsupportedEncodingException. */
 	private static final String JAVA_IO_UNSUPPORTED_ENCODING_EXCEPTION = "java.io.UnsupportedEncodingException"; //$NON-NLS-1$
-
-	/** Simple name of UnsupportedEncodingException for matching in exception types. */
 	private static final String UNSUPPORTED_ENCODING_EXCEPTION = "UnsupportedEncodingException"; //$NON-NLS-1$
-
 	private static final String REMOVED_UNSUPPORTED_ENCODING_CATCHES_PROPERTY =
 			AbstractExplicitEncoding.class.getName() + ".removedUnsupportedEncodingCatches"; //$NON-NLS-1$
 
-	/**
-	 * Immutable map of standard charset names (e.g., "UTF-8") to their corresponding
-	 * StandardCharsets constant names (e.g., "UTF_8").
-	 * <p>
-	 * This mapping covers the six charsets guaranteed to be available on every Java platform.
-	 * </p>
-	 * @since 1.3
-	 */
 	public static final Map<String, String> ENCODING_MAP = Map.of(
 			"UTF-8", "UTF_8", //$NON-NLS-1$ //$NON-NLS-2$
 			"UTF-16", "UTF_16", //$NON-NLS-1$ //$NON-NLS-2$
 			"UTF-16BE", "UTF_16BE", //$NON-NLS-1$ //$NON-NLS-2$
 			"UTF-16LE", "UTF_16LE", //$NON-NLS-1$ //$NON-NLS-2$
 			"ISO-8859-1", "ISO_8859_1", //$NON-NLS-1$ //$NON-NLS-2$
-			"US-ASCII", "US_ASCII" //$NON-NLS-1$ //$NON-NLS-2$
-	);
+			"US-ASCII", "US_ASCII"); //$NON-NLS-1$ //$NON-NLS-2$
 
-	/**
-	 * Immutable set of supported encoding names that can be converted to StandardCharsets constants.
-	 * @since 1.3
-	 */
 	public static final Set<String> ENCODINGS = ENCODING_MAP.keySet();
 
-	/**
-	 * Maps standard charset names (e.g., "UTF-8") to their corresponding
-	 * StandardCharsets constant names (e.g., "UTF_8").
-	 * @deprecated Use {@link #ENCODING_MAP} instead. This field is maintained for backward
-	 *             compatibility but is immutable and will throw UnsupportedOperationException
-	 *             if modification is attempted.
-	 */
 	@Deprecated
 	static final Map<String, String> encodingmap = ENCODING_MAP;
 
-	/**
-	 * Set of supported encoding names that can be converted to StandardCharsets constants.
-	 * @deprecated Use {@link #ENCODINGS} instead. This field is maintained for backward
-	 *             compatibility but is immutable and will throw UnsupportedOperationException
-	 *             if modification is attempted.
-	 */
 	@Deprecated
 	static final Set<String> encodings = ENCODINGS;
 
-	/**
-	 * Immutable record to hold node data for encoding transformations.
-	 * Replaces the mutable Nodedata class for better thread safety and immutability.
-	 *
-	 * @param replace Whether to replace an existing encoding parameter (true) or appended (false)
-	 * @param visited The AST node that was visited and needs modification
-	 * @param encoding The encoding constant name (e.g., "UTF_8"), or null for default charset
-	 */
 	protected static record NodeData(boolean replace, ASTNode visited, String encoding) {
 	}
 
-	/**
-	 * Thread-safe map to cache charset constant references during aggregation.
-	 * Used to avoid creating duplicate QualifiedName instances.
-	 */
 	private static final Map<String, QualifiedName> CHARSET_CONSTANTS = new ConcurrentHashMap<>();
 
-	/**
-	 * Returns the charset constants map for use in encoding transformations.
-	 *
-	 * @return thread-safe map of charset constants
-	 */
 	protected static Map<String, QualifiedName> getCharsetConstants() {
 		return CHARSET_CONSTANTS;
 	}
 
-	/** Key used for storing encoding information in data holders. */
 	protected static final String KEY_ENCODING = "encoding"; //$NON-NLS-1$
-
-	/** Key used for storing replace flag in data holders. */
 	protected static final String KEY_REPLACE = "replace"; //$NON-NLS-1$
 
-	/**
-	 * @deprecated Use {@link #KEY_ENCODING} instead. This field will be removed in a future version.
-	 */
 	@Deprecated(forRemoval = true)
 	protected static final String ENCODING = KEY_ENCODING;
 
-	/**
-	 * @deprecated Use {@link #KEY_REPLACE} instead. This field will be removed in a future version.
-	 */
 	@Deprecated(forRemoval = true)
 	protected static final String REPLACE = KEY_REPLACE;
 
-	/**
-	 * Finds all occurrences of the encoding pattern that this handler processes
-	 * and adds corresponding rewrite operations.
-	 *
-	 * @param fixcore the fix core instance, must not be null
-	 * @param compilationUnit the compilation unit to search in, must not be null
-	 * @param operations the set to add rewrite operations to, must not be null
-	 * @param nodesprocessed the set of already processed nodes (to avoid duplicates), must not be null
-	 * @param cb the change behavior configuration, must not be null
-	 */
-	public abstract void find(UseExplicitEncodingFixCore fixcore, CompilationUnit compilationUnit, Set<CompilationUnitRewriteOperation> operations, Set<ASTNode> nodesprocessed, ChangeBehavior cb);
+	public abstract void find(UseExplicitEncodingFixCore fixcore, CompilationUnit compilationUnit,
+			Set<CompilationUnitRewriteOperation> operations, Set<ASTNode> nodesprocessed, ChangeBehavior cb);
 
-	/**
-	 * Rewrites the visited AST node to use explicit encoding.
-	 *
-	 * @param useExplicitEncodingFixCore the fix core instance, must not be null
-	 * @param visited the AST node to rewrite, must not be null
-	 * @param cuRewrite the compilation unit rewrite context, must not be null
-	 * @param group the text edit group for grouping changes, must not be null
-	 * @param cb the change behavior configuration, must not be null
-	 * @param data the reference holder containing node-specific data, must not be null
-	 */
-	public abstract void rewrite(UseExplicitEncodingFixCore useExplicitEncodingFixCore, T visited, CompilationUnitRewrite cuRewrite,
-			TextEditGroup group, ChangeBehavior cb, ReferenceHolder<ASTNode, Object> data);
+	public abstract void rewrite(UseExplicitEncodingFixCore useExplicitEncodingFixCore, T visited,
+			CompilationUnitRewrite cuRewrite, TextEditGroup group, ChangeBehavior cb,
+			ReferenceHolder<ASTNode, Object> data);
 
-	/**
-	 * Adds an import to the class. This method should be used for every class reference added to
-	 * the generated code.
-	 *
-	 * @param typeName a fully qualified name of a type, must not be null
-	 * @param cuRewrite CompilationUnitRewrite, must not be null
-	 * @param ast AST, must not be null
-	 * @return simple name of a class if the import was added and fully qualified name if there was
-	 *         a conflict; never null
-	 */
-	protected static Name addImport(String typeName, final CompilationUnitRewrite cuRewrite, AST ast) {
+	public abstract String getPreview(boolean afterRefactoring, ChangeBehavior cb);
+
+	protected static Name addImport(String typeName, CompilationUnitRewrite cuRewrite, AST ast) {
 		return ImportUtils.addImport(typeName, cuRewrite.getImportRewrite(), ast);
 	}
 
-	/**
-	 * Checks if a string literal contains a known encoding that can be converted
-	 * to a StandardCharsets constant.
-	 *
-	 * @param literal the string literal to check, may be null
-	 * @return true if the literal contains a known encoding, false otherwise
-	 */
 	protected static boolean isKnownEncoding(StringLiteral literal) {
-		if (literal == null) {
-			return false;
-		}
-		return ENCODINGS.contains(literal.getLiteralValue().toUpperCase(Locale.ROOT));
+		return literal != null && ENCODINGS.contains(literal.getLiteralValue().toUpperCase(Locale.ROOT));
 	}
 
-	/**
-	 * Gets the StandardCharsets constant name for a given encoding string literal.
-	 *
-	 * @param literal the string literal containing the encoding name, may be null
-	 * @return the StandardCharsets constant name (e.g., "UTF_8"), or null if the literal
-	 *         is null or contains an unknown encoding
-	 */
 	protected static String getEncodingConstantName(StringLiteral literal) {
-		if (literal == null) {
-			return null;
-		}
-		return ENCODING_MAP.get(literal.getLiteralValue().toUpperCase(Locale.ROOT));
+		return literal == null ? null : ENCODING_MAP.get(literal.getLiteralValue().toUpperCase(Locale.ROOT));
 	}
 
-	/**
-	 * Resolves the encoding value from various AST node types representing a charset argument.
-	 * Handles string literals, variable references, qualified names (e.g., StandardCharsets.UTF_8),
-	 * and field access expressions.
-	 *
-	 * @param encodingArg the AST node representing the charset argument
-	 * @param context the method invocation context for variable resolution
-	 * @return the uppercase encoding string (e.g., "UTF-8"), or null if not determinable
-	 */
 	protected static String getEncodingValue(ASTNode encodingArg, MethodInvocation context) {
 		if (encodingArg instanceof StringLiteral literal) {
 			return literal.getLiteralValue().toUpperCase(Locale.ROOT);
-		} else if (encodingArg instanceof SimpleName simpleName) {
+		}
+		if (encodingArg instanceof SimpleName simpleName) {
 			return findVariableValue(simpleName, context);
-		} else if (encodingArg instanceof QualifiedName qualifiedName) {
+		}
+		if (encodingArg instanceof QualifiedName qualifiedName) {
 			return extractStandardCharsetName(qualifiedName);
-		} else if (encodingArg instanceof FieldAccess fieldAccess) {
+		}
+		if (encodingArg instanceof FieldAccess fieldAccess) {
 			return extractStandardCharsetName(fieldAccess);
 		}
 		return null;
 	}
 
-	/**
-	 * Extracts charset name from QualifiedName like StandardCharsets.UTF_8.
-	 *
-	 * @param qualifiedName the qualified name to extract from
-	 * @return the charset name (e.g., "UTF-8"), or null if not a StandardCharsets reference
-	 */
 	protected static String extractStandardCharsetName(QualifiedName qualifiedName) {
 		String qualifier = qualifiedName.getQualifier().toString();
 		if ("StandardCharsets".equals(qualifier) || qualifier.endsWith(".StandardCharsets")) { //$NON-NLS-1$ //$NON-NLS-2$
-			String fieldName = qualifiedName.getName().getIdentifier();
-			return fieldName.replace('_', '-');
+			return qualifiedName.getName().getIdentifier().replace('_', '-');
 		}
 		return null;
 	}
 
-	/**
-	 * Extracts charset name from FieldAccess like StandardCharsets.UTF_8.
-	 *
-	 * @param fieldAccess the field access to extract from
-	 * @return the charset name (e.g., "UTF-8"), or null if not a StandardCharsets reference
-	 */
 	protected static String extractStandardCharsetName(FieldAccess fieldAccess) {
 		String expression = fieldAccess.getExpression().toString();
 		if ("StandardCharsets".equals(expression) || expression.endsWith(".StandardCharsets")) { //$NON-NLS-1$ //$NON-NLS-2$
-			String fieldName = fieldAccess.getName().getIdentifier();
-			return fieldName.replace('_', '-');
+			return fieldAccess.getName().getIdentifier().replace('_', '-');
 		}
 		return null;
 	}
 
-	/**
-	 * Finds the enclosing MethodDeclaration or TypeDeclaration for a given AST node.
-	 *
-	 * @param node the starting node for the search, may be null
-	 * @return the enclosing MethodDeclaration or TypeDeclaration, or null if not found
-	 */
 	private static ASTNode findEnclosingMethodOrType(ASTNode node) {
 		if (node == null) {
 			return null;
 		}
-		ASTNode methodDecl = ASTNodes.getFirstAncestorOrNull(node, MethodDeclaration.class);
-		ASTNode typeDecl = ASTNodes.getFirstAncestorOrNull(node, TypeDeclaration.class);
-
-		if (methodDecl != null) {
-			return methodDecl;
-		}
-		return typeDecl;
+		MethodDeclaration method = ASTNodes.getFirstAncestorOrNull(node, MethodDeclaration.class);
+		return method != null ? method : ASTNodes.getFirstAncestorOrNull(node, TypeDeclaration.class);
 	}
 
-	/**
-	 * Extracts the string literal value from a variable declaration fragment if its initializer
-	 * is a string literal.
-	 *
-	 * @param fragment the variable declaration fragment to check, must not be null
-	 * @param variableIdentifier the identifier of the variable to match, must not be null
-	 * @return the uppercase string literal value if found, null otherwise
-	 */
-	private static String extractStringLiteralValue(VariableDeclarationFragment fragment, String variableIdentifier) {
+	private static String extractStringLiteralValue(VariableDeclarationFragment fragment,
+			String variableIdentifier) {
 		if (!fragment.getName().getIdentifier().equals(variableIdentifier)) {
 			return null;
 		}
 		Expression initializer = fragment.getInitializer();
-		if (initializer instanceof StringLiteral) {
-			return ((StringLiteral) initializer).getLiteralValue().toUpperCase(Locale.ROOT);
-		}
-		return null;
+		return initializer instanceof StringLiteral literal
+				? literal.getLiteralValue().toUpperCase(Locale.ROOT)
+				: null;
 	}
 
-	/**
-	 * Searches for a variable's string literal value within a list of variable declaration fragments.
-	 *
-	 * @param fragments the list of fragments to search in, must not be null
-	 * @param variableIdentifier the identifier of the variable to find, must not be null
-	 * @return the uppercase string literal value if found, null otherwise
-	 */
 	private static String findValueInFragments(List<?> fragments, String variableIdentifier) {
-		for (Object frag : fragments) {
-			VariableDeclarationFragment fragment = (VariableDeclarationFragment) frag;
-			String value = extractStringLiteralValue(fragment, variableIdentifier);
+		for (Object fragmentObject : fragments) {
+			String value = extractStringLiteralValue((VariableDeclarationFragment) fragmentObject,
+					variableIdentifier);
 			if (value != null) {
 				return value;
 			}
@@ -343,23 +185,14 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 		return null;
 	}
 
-	/**
-	 * Searches for a variable's string literal value within method body statements.
-	 *
-	 * @param method the method declaration to search in, must not be null
-	 * @param variableIdentifier the identifier of the variable to find, must not be null
-	 * @return the uppercase string literal value if found, null otherwise
-	 */
 	private static String findVariableValueInMethod(MethodDeclaration method, String variableIdentifier) {
 		Block body = method.getBody();
 		if (body == null) {
 			return null;
 		}
-		List<?> statements = body.statements();
-		for (Object stmt : statements) {
-			if (stmt instanceof VariableDeclarationStatement) {
-				VariableDeclarationStatement varDeclStmt = (VariableDeclarationStatement) stmt;
-				String value = findValueInFragments(varDeclStmt.fragments(), variableIdentifier);
+		for (Object statement : body.statements()) {
+			if (statement instanceof VariableDeclarationStatement declaration) {
+				String value = findValueInFragments(declaration.fragments(), variableIdentifier);
 				if (value != null) {
 					return value;
 				}
@@ -368,16 +201,8 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 		return null;
 	}
 
-	/**
-	 * Searches for a variable's string literal value within type field declarations.
-	 *
-	 * @param type the type declaration to search in, must not be null
-	 * @param variableIdentifier the identifier of the variable to find, must not be null
-	 * @return the uppercase string literal value if found, null otherwise
-	 */
 	private static String findVariableValueInType(TypeDeclaration type, String variableIdentifier) {
-		FieldDeclaration[] fields = type.getFields();
-		for (FieldDeclaration field : fields) {
+		for (FieldDeclaration field : type.getFields()) {
 			String value = findValueInFragments(field.fragments(), variableIdentifier);
 			if (value != null) {
 				return value;
@@ -386,168 +211,152 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 		return null;
 	}
 
-	/**
-	 * Finds the value of a variable by searching for its declaration in the enclosing
-	 * method or type. This is used to resolve variable references to their string literal
-	 * initializer values.
-	 *
-	 * @param variable the SimpleName representing the variable reference, may be null
-	 * @param context the AST node providing context for the search, may be null
-	 * @return the uppercase string literal value of the variable's initializer,
-	 *         or null if the variable is null, context is null, or the value cannot be found
-	 */
 	protected static String findVariableValue(SimpleName variable, ASTNode context) {
 		if (variable == null || context == null) {
 			return null;
 		}
-
 		ASTNode enclosing = findEnclosingMethodOrType(context);
-		if (enclosing == null) {
-			return null;
+		if (enclosing instanceof MethodDeclaration method) {
+			return findVariableValueInMethod(method, variable.getIdentifier());
 		}
-
-		String variableIdentifier = variable.getIdentifier();
-		if (enclosing instanceof MethodDeclaration) {
-			return findVariableValueInMethod((MethodDeclaration) enclosing, variableIdentifier);
-		} else if (enclosing instanceof TypeDeclaration) {
-			return findVariableValueInType((TypeDeclaration) enclosing, variableIdentifier);
+		if (enclosing instanceof TypeDeclaration type) {
+			return findVariableValueInType(type, variable.getIdentifier());
 		}
 		return null;
 	}
 
-	/**
-	 * Generates a preview string showing the code before or after the refactoring.
-	 *
-	 * @param afterRefactoring true to show the code after refactoring, false for before
-	 * @param cb the change behavior configuration
-	 * @return the preview string, never null
-	 */
-	public abstract String getPreview(boolean afterRefactoring, ChangeBehavior cb);
+	private static final Pattern LAST_NLS_COMMENT = Pattern.compile(
+			"[ ]*\\/\\/\\$NON-NLS-[0-9]+\\$(?!.*\\/\\/\\$NON-NLS-)"); //$NON-NLS-1$
 
-	/**
-	 * Pattern matching the LAST NLS comment on a line (the one corresponding
-	 * to the last/highest-numbered string literal). When a string literal is
-	 * replaced by a non-string expression, we must remove the last NLS comment
-	 * (not the first) because string literals are numbered left-to-right.
-	 * Uses a negative lookahead to match only the final NLS comment.
-	 * Adapted from {@code org.eclipse.jdt.internal.corext.dom.ASTNodes}.
-	 */
-	private static final Pattern LAST_NLS_COMMENT = Pattern.compile("[ ]*\\/\\/\\$NON-NLS-[0-9]+\\$(?!.*\\/\\/\\$NON-NLS-)"); //$NON-NLS-1$
-
-	/**
-	 * Replaces a string literal argument with a replacement node and removes the
-	 * associated {@code //$NON-NLS-n$} comment.
-	 *
-	 * <p>When the statement is inside a try body that will be unwrapped by
-	 * {@code removeUnsupportedEncodingException}, this method handles both the
-	 * argument replacement AND the try-catch unwrapping in a single text-based
-	 * operation to avoid conflicts between {@code rewrite.replace()} and
-	 * {@code createMoveTarget()}.
-	 *
-	 * <p>When the statement is NOT inside such a try body, this method replaces
-	 * the enclosing statement with a string placeholder that has the text
-	 * substitution and NLS removal already applied.
-	 *
-	 * @param rewrite the AST rewrite
-	 * @param visited the string literal node to replace
-	 * @param replacement the replacement node (e.g., StandardCharsets.UTF_8)
-	 * @param group the text edit group
-	 * @param cuRewrite the compilation unit rewrite
-	 * @return {@code true} if the enclosing try-catch was already unwrapped by
-	 *         this method (caller should skip {@code removeUnsupportedEncodingException}),
-	 *         {@code false} otherwise
-	 */
 	protected static boolean replaceArgumentAndRemoveNLS(ASTRewrite rewrite, ASTNode visited,
 			ASTNode replacement, TextEditGroup group, CompilationUnitRewrite cuRewrite) {
-		ASTNode st = ASTNodes.getFirstAncestorOrNull(visited, Statement.class, FieldDeclaration.class);
-		if (st != null && isInsideTryBodyWithOnlyUnsupportedEncodingCatch(st)) {
-			return replaceTryBodyAndUnwrap(rewrite, visited, replacement, st, group, cuRewrite);
+		ASTNode statement = ASTNodes.getFirstAncestorOrNull(visited, Statement.class, FieldDeclaration.class);
+		if (statement != null && isInsideTryBodyWithOnlyUnsupportedEncodingCatch(statement)) {
+			return replaceTryBodyAndUnwrap(rewrite, visited, replacement, statement, group, cuRewrite);
 		}
-		if (st == null) {
+		if (statement == null) {
 			rewrite.replace(visited, replacement, group);
 			return false;
 		}
 		try {
 			String buffer = cuRewrite.getCu().getBuffer().getContents();
-			CompilationUnit cu = (CompilationUnit) st.getRoot();
-			int origStart = cu.getExtendedStartPosition(st);
-			int origLength = cu.getExtendedLength(st);
-			String original = buffer.substring(origStart, origStart + origLength);
-			original = LAST_NLS_COMMENT.matcher(original).replaceFirst(""); //$NON-NLS-1$
-			original = Pattern.compile("^[ \\t]*").matcher(original).replaceAll(""); //$NON-NLS-1$ //$NON-NLS-2$
-			original = Pattern.compile("\n[ \\t]*").matcher(original).replaceAll("\n"); //$NON-NLS-1$ //$NON-NLS-2$
-			String visitedString = buffer.substring(visited.getStartPosition(),
+			CompilationUnit root = (CompilationUnit) statement.getRoot();
+			int start = root.getExtendedStartPosition(statement);
+			String source = buffer.substring(start, start + root.getExtendedLength(statement));
+			source = normalizeStatementSource(source, lineDelimiter(buffer));
+			source = LAST_NLS_COMMENT.matcher(source).replaceFirst(""); //$NON-NLS-1$
+			String visitedSource = buffer.substring(visited.getStartPosition(),
 					visited.getStartPosition() + visited.getLength());
-			String replacementString = replacement.toString().replaceAll(",", ", "); //$NON-NLS-1$ //$NON-NLS-2$
-			String modified = original.replace(visitedString, replacementString);
-			ASTNode placeholder = rewrite.createStringPlaceholder(modified, st.getNodeType());
-			rewrite.replace(st, placeholder, group);
-		} catch (JavaModelException e) {
+			String replacementSource = replacement.toString().replaceAll(",", ", "); //$NON-NLS-1$ //$NON-NLS-2$
+			ASTNode placeholder = rewrite.createStringPlaceholder(
+					source.replace(visitedSource, replacementSource), statement.getNodeType());
+			rewrite.replace(statement, placeholder, group);
+		} catch (JavaModelException exception) {
 			rewrite.replace(visited, replacement, group);
 		}
 		return false;
 	}
 
-	/**
-	 * Handles the case where a string literal replacement is needed inside a try body
-	 * that will be unwrapped (single catch clause for UnsupportedEncodingException only).
-	 *
-	 * <p>Unchanged statements remain AST move targets so their source formatting and
-	 * attached comments are preserved. Only the statement containing the replaced
-	 * encoding literal is recreated as a placeholder.
-	 *
-	 * @return {@code true} if the try-catch was successfully unwrapped
-	 */
 	private static boolean replaceTryBodyAndUnwrap(ASTRewrite rewrite, ASTNode visited,
 			ASTNode replacement, ASTNode statement, TextEditGroup group, CompilationUnitRewrite cuRewrite) {
-		Block block = (Block) statement.getParent();
-		TryStatement tryStatement = (TryStatement) block.getParent();
-		ASTNode tryParent = tryStatement.getParent();
-		if (!(tryParent instanceof Block parentBlock)) {
+		Block tryBody = (Block) statement.getParent();
+		TryStatement tryStatement = (TryStatement) tryBody.getParent();
+		if (!(tryStatement.getParent() instanceof Block)) {
 			rewrite.replace(visited, replacement, group);
 			return false;
 		}
 		try {
 			String buffer = cuRewrite.getCu().getBuffer().getContents();
-			CompilationUnit cu = (CompilationUnit) statement.getRoot();
-			String visitedString = buffer.substring(visited.getStartPosition(),
+			CompilationUnit root = (CompilationUnit) statement.getRoot();
+			String delimiter = lineDelimiter(buffer);
+			String parentIndent = indentationAt(buffer, tryStatement.getStartPosition());
+			String visitedSource = buffer.substring(visited.getStartPosition(),
 					visited.getStartPosition() + visited.getLength());
-			String replacementString = replacement.toString().replaceAll(",", ", "); //$NON-NLS-1$ //$NON-NLS-2$
+			String replacementSource = replacement.toString().replaceAll(",", ", "); //$NON-NLS-1$ //$NON-NLS-2$
+			StringBuilder inlinedSource = new StringBuilder();
 
-			ListRewrite parentListRewrite = rewrite.getListRewrite(parentBlock, Block.STATEMENTS_PROPERTY);
-			List<?> tryStatements = block.statements();
-			for (int i = tryStatements.size() - 1; i >= 0; i--) {
-				ASTNode stmt = (ASTNode) tryStatements.get(i);
-				ASTNode inlinedStatement;
-				if (stmt == statement) {
-					int stmtStart = cu.getExtendedStartPosition(stmt);
-					int stmtLength = cu.getExtendedLength(stmt);
-					String stmtSource = buffer.substring(stmtStart, stmtStart + stmtLength);
-					stmtSource = Pattern.compile("^[ \\t]*").matcher(stmtSource).replaceAll(""); //$NON-NLS-1$ //$NON-NLS-2$
-					stmtSource = Pattern.compile("\n[ \\t]*").matcher(stmtSource).replaceAll("\n"); //$NON-NLS-1$ //$NON-NLS-2$
-					stmtSource = LAST_NLS_COMMENT.matcher(stmtSource).replaceFirst(""); //$NON-NLS-1$
-					stmtSource = stmtSource.replace(visitedString, replacementString);
-					inlinedStatement = rewrite.createStringPlaceholder(stmtSource, stmt.getNodeType());
-				} else {
-					inlinedStatement = rewrite.createMoveTarget(stmt);
+			for (Object statementObject : tryBody.statements()) {
+				ASTNode bodyStatement = (ASTNode) statementObject;
+				int start = root.getExtendedStartPosition(bodyStatement);
+				String bodySource = buffer.substring(start, start + root.getExtendedLength(bodyStatement));
+				bodySource = normalizeStatementSource(bodySource, delimiter);
+				if (bodyStatement == statement) {
+					bodySource = LAST_NLS_COMMENT.matcher(bodySource).replaceFirst(""); //$NON-NLS-1$
+					bodySource = bodySource.replace(visitedSource, replacementSource);
 				}
-				parentListRewrite.insertAfter(inlinedStatement, tryStatement, group);
+				if (!inlinedSource.isEmpty()) {
+					inlinedSource.append(delimiter).append(parentIndent);
+				}
+				inlinedSource.append(bodySource);
 			}
-			rewrite.remove(tryStatement, group);
+
+			ASTNode placeholder = rewrite.createStringPlaceholder(inlinedSource.toString(), ASTNode.EMPTY_STATEMENT);
+			rewrite.replace(tryStatement, placeholder, group);
 			registerUnwrappedTryForImportRemoval(tryStatement, cuRewrite);
 			return true;
-		} catch (JavaModelException e) {
+		} catch (JavaModelException exception) {
 			rewrite.replace(visited, replacement, group);
 			return false;
 		}
 	}
 
-	/**
-	 * Registers the removed try/catch while retaining its inlined body. Placeholder
-	 * rewrites do not provide {@link ImportRemover} with a reliable reference balance,
-	 * so the obsolete exception import is removed explicitly only when no type reference
-	 * survives outside any catch clause that has actually been unwrapped in this rewrite.
-	 */
+	private static String normalizeStatementSource(String source, String delimiter) {
+		String[] lines = source.replace("\r\n", "\n").replace('\r', '\n').split("\n", -1); //$NON-NLS-1$ //$NON-NLS-2$
+		int first = 0;
+		while (first < lines.length && lines[first].isBlank()) {
+			first++;
+		}
+		int last = lines.length - 1;
+		while (last >= first && lines[last].isBlank()) {
+			last--;
+		}
+		if (first > last) {
+			return ""; //$NON-NLS-1$
+		}
+		String baseIndent = leadingWhitespace(lines[first]);
+		StringBuilder result = new StringBuilder();
+		for (int index = first; index <= last; index++) {
+			if (index > first) {
+				result.append(delimiter);
+			}
+			String line = lines[index];
+			if (!baseIndent.isEmpty() && line.startsWith(baseIndent)) {
+				line = line.substring(baseIndent.length());
+			}
+			result.append(line.isBlank() ? "" : line); //$NON-NLS-1$
+		}
+		return result.toString();
+	}
+
+	private static String leadingWhitespace(String line) {
+		int index = 0;
+		while (index < line.length()) {
+			char character = line.charAt(index);
+			if (character != ' ' && character != '\t') {
+				break;
+			}
+			index++;
+		}
+		return line.substring(0, index);
+	}
+
+	private static String lineDelimiter(String source) {
+		return source.contains("\r\n") ? "\r\n" : "\n"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+	}
+
+	private static String indentationAt(String source, int position) {
+		int lineStart = Math.max(source.lastIndexOf('\n', Math.max(0, position - 1)),
+				source.lastIndexOf('\r', Math.max(0, position - 1))) + 1;
+		String indentation = source.substring(lineStart, position);
+		for (int index = 0; index < indentation.length(); index++) {
+			char character = indentation.charAt(index);
+			if (character != ' ' && character != '\t') {
+				return ""; //$NON-NLS-1$
+			}
+		}
+		return indentation;
+	}
+
 	private static void registerUnwrappedTryForImportRemoval(TryStatement tryStatement,
 			CompilationUnitRewrite cuRewrite) {
 		cuRewrite.getImportRemover().registerRemovedNode(tryStatement);
@@ -577,19 +386,22 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 		boolean[] found = { false };
 		root.accept(new ASTVisitor() {
 			@Override
-			public boolean visit(SimpleName node) {
-				if (found[0] || isDescendantOfAny(node, removedCatches)
-						|| ASTNodes.getFirstAncestorOrNull(node, ImportDeclaration.class) != null) {
-					return !found[0];
+			public boolean preVisit2(ASTNode node) {
+				if (found[0]) {
+					return false;
 				}
-				ITypeBinding typeBinding = node.resolveTypeBinding();
-				if (typeBinding != null) {
-					if (JAVA_IO_UNSUPPORTED_ENCODING_EXCEPTION.equals(typeBinding.getErasure().getQualifiedName())) {
-						found[0] = true;
-					}
-				} else if (UNSUPPORTED_ENCODING_EXCEPTION.equals(node.getIdentifier())) {
-					// Fail closed for incomplete or recovered bindings.
-					found[0] = true;
+				if (!(node instanceof Type type) || isDescendantOfAny(type, removedCatches)) {
+					return true;
+				}
+				ITypeBinding binding = type.resolveBinding();
+				if (binding != null) {
+					found[0] = JAVA_IO_UNSUPPORTED_ENCODING_EXCEPTION
+							.equals(binding.getErasure().getQualifiedName());
+				} else {
+					String source = type.toString();
+					found[0] = UNSUPPORTED_ENCODING_EXCEPTION.equals(source)
+							|| JAVA_IO_UNSUPPORTED_ENCODING_EXCEPTION.equals(source)
+							|| source.endsWith("." + UNSUPPORTED_ENCODING_EXCEPTION); //$NON-NLS-1$
 				}
 				return !found[0];
 			}
@@ -606,26 +418,12 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 		return false;
 	}
 
-	/**
-	 * Checks whether the given statement is directly inside the body of a try statement
-	 * that will be fully unwrapped by removeUnsupportedEncodingException.
-	 */
 	private static boolean isInsideTryBodyWithOnlyUnsupportedEncodingCatch(ASTNode statement) {
-		ASTNode parent = statement.getParent();
-		if (!(parent instanceof Block block)) {
-			return false;
-		}
-		ASTNode grandParent = block.getParent();
-		if (!(grandParent instanceof TryStatement tryStatement)) {
-			return false;
-		}
-		if (tryStatement.getBody() != block) {
-			return false;
-		}
-		if (!tryStatement.resources().isEmpty()) {
-			return false;
-		}
-		if (tryStatement.getFinally() != null) {
+		if (!(statement.getParent() instanceof Block block)
+				|| !(block.getParent() instanceof TryStatement tryStatement)
+				|| tryStatement.getBody() != block
+				|| !tryStatement.resources().isEmpty()
+				|| tryStatement.getFinally() != null) {
 			return false;
 		}
 		@SuppressWarnings("unchecked")
@@ -633,34 +431,22 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 		if (catchClauses.size() != 1) {
 			return false;
 		}
-		CatchClause catchClause = catchClauses.get(0);
-		org.eclipse.jdt.core.dom.Type exType = catchClause.getException().getType();
-		if (exType instanceof org.eclipse.jdt.core.dom.SimpleType simpleType) {
-			return UNSUPPORTED_ENCODING_EXCEPTION.equals(simpleType.getName().toString());
+		Type exceptionType = catchClauses.get(0).getException().getType();
+		ITypeBinding binding = exceptionType.resolveBinding();
+		if (binding != null) {
+			return JAVA_IO_UNSUPPORTED_ENCODING_EXCEPTION.equals(binding.getErasure().getQualifiedName());
 		}
-		return false;
+		String source = exceptionType.toString();
+		return UNSUPPORTED_ENCODING_EXCEPTION.equals(source)
+				|| JAVA_IO_UNSUPPORTED_ENCODING_EXCEPTION.equals(source)
+				|| source.endsWith("." + UNSUPPORTED_ENCODING_EXCEPTION); //$NON-NLS-1$
 	}
 
-	/**
-	 * Removes UnsupportedEncodingException from the enclosing method's throws clause
-	 * or from catch clauses in a try statement. This is called after converting string-based
-	 * encoding to StandardCharsets, since StandardCharsets methods don't throw
-	 * UnsupportedEncodingException.
-	 *
-	 * <p>Delegates to {@link ExceptionCleanupHelper#removeCheckedException} for the
-	 * actual work.
-	 *
-	 * @param visited the AST node that was modified, must not be null
-	 * @param group the text edit group for tracking changes, must not be null
-	 * @param rewrite the AST rewrite context, must not be null
-	 * @param importRemover the import remover for tracking removed nodes, must not be null
-	 */
-	protected void removeUnsupportedEncodingException(final ASTNode visited, TextEditGroup group, ASTRewrite rewrite, ImportRemover importRemover) {
-		ExceptionCleanupHelper.removeCheckedException(
-				visited,
+	protected void removeUnsupportedEncodingException(ASTNode visited, TextEditGroup group,
+			ASTRewrite rewrite, ImportRemover importRemover) {
+		ExceptionCleanupHelper.removeCheckedException(visited,
 				JAVA_IO_UNSUPPORTED_ENCODING_EXCEPTION,
 				UNSUPPORTED_ENCODING_EXCEPTION,
 				group, rewrite, importRemover);
 	}
-
 }

--- a/sandbox_encoding_quickfix/src/org/sandbox/jdt/internal/corext/fix/helper/AbstractExplicitEncoding.java
+++ b/sandbox_encoding_quickfix/src/org/sandbox/jdt/internal/corext/fix/helper/AbstractExplicitEncoding.java
@@ -13,8 +13,6 @@
  *******************************************************************************/
 package org.sandbox.jdt.internal.corext.fix.helper;
 
-import java.util.Collections;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -25,7 +23,6 @@ import java.util.regex.Pattern;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
-import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.Block;
 import org.eclipse.jdt.core.dom.CatchClause;
 import org.eclipse.jdt.core.dom.CompilationUnit;
@@ -46,6 +43,7 @@ import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperation;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
@@ -65,8 +63,6 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 
 	private static final String JAVA_IO_UNSUPPORTED_ENCODING_EXCEPTION = "java.io.UnsupportedEncodingException"; //$NON-NLS-1$
 	private static final String UNSUPPORTED_ENCODING_EXCEPTION = "UnsupportedEncodingException"; //$NON-NLS-1$
-	private static final String REMOVED_UNSUPPORTED_ENCODING_CATCHES_PROPERTY =
-			AbstractExplicitEncoding.class.getName() + ".removedUnsupportedEncodingCatches"; //$NON-NLS-1$
 
 	public static final Map<String, String> ENCODING_MAP = Map.of(
 			"UTF-8", "UTF_8", //$NON-NLS-1$ //$NON-NLS-2$
@@ -243,7 +239,7 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 			CompilationUnit root = (CompilationUnit) statement.getRoot();
 			int start = root.getExtendedStartPosition(statement);
 			String source = buffer.substring(start, start + root.getExtendedLength(statement));
-			source = normalizeStatementSource(source, lineDelimiter(buffer));
+			source = stripBaseIndent(source, lineDelimiter(buffer));
 			source = LAST_NLS_COMMENT.matcher(source).replaceFirst(""); //$NON-NLS-1$
 			String visitedSource = buffer.substring(visited.getStartPosition(),
 					visited.getStartPosition() + visited.getLength());
@@ -261,7 +257,7 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 			ASTNode replacement, ASTNode statement, TextEditGroup group, CompilationUnitRewrite cuRewrite) {
 		Block tryBody = (Block) statement.getParent();
 		TryStatement tryStatement = (TryStatement) tryBody.getParent();
-		if (!(tryStatement.getParent() instanceof Block)) {
+		if (!(tryStatement.getParent() instanceof Block parentBlock)) {
 			rewrite.replace(visited, replacement, group);
 			return false;
 		}
@@ -269,30 +265,31 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 			String buffer = cuRewrite.getCu().getBuffer().getContents();
 			CompilationUnit root = (CompilationUnit) statement.getRoot();
 			String delimiter = lineDelimiter(buffer);
-			String parentIndent = indentationAt(buffer, tryStatement.getStartPosition());
 			String visitedSource = buffer.substring(visited.getStartPosition(),
 					visited.getStartPosition() + visited.getLength());
 			String replacementSource = replacement.toString().replaceAll(",", ", "); //$NON-NLS-1$ //$NON-NLS-2$
-			StringBuilder inlinedSource = new StringBuilder();
+			ListRewrite parentStatements = rewrite.getListRewrite(parentBlock, Block.STATEMENTS_PROPERTY);
+			List<?> bodyStatements = tryBody.statements();
 
-			for (Object statementObject : tryBody.statements()) {
-				ASTNode bodyStatement = (ASTNode) statementObject;
-				int start = root.getExtendedStartPosition(bodyStatement);
-				String bodySource = buffer.substring(start, start + root.getExtendedLength(bodyStatement));
-				bodySource = normalizeStatementSource(bodySource, delimiter);
+			for (int index = bodyStatements.size() - 1; index >= 0; index--) {
+				ASTNode bodyStatement = (ASTNode) bodyStatements.get(index);
+				ASTNode inlinedStatement;
 				if (bodyStatement == statement) {
-					bodySource = LAST_NLS_COMMENT.matcher(bodySource).replaceFirst(""); //$NON-NLS-1$
-					bodySource = bodySource.replace(visitedSource, replacementSource);
+					int start = root.getExtendedStartPosition(bodyStatement);
+					String source = buffer.substring(start, start + root.getExtendedLength(bodyStatement));
+					source = stripBaseIndent(source, delimiter);
+					source = LAST_NLS_COMMENT.matcher(source).replaceFirst(""); //$NON-NLS-1$
+					source = source.replace(visitedSource, replacementSource);
+					inlinedStatement = rewrite.createStringPlaceholder(source, bodyStatement.getNodeType());
+				} else {
+					inlinedStatement = rewrite.createMoveTarget(bodyStatement);
 				}
-				if (!inlinedSource.isEmpty()) {
-					inlinedSource.append(delimiter).append(parentIndent);
-				}
-				inlinedSource.append(bodySource);
+				parentStatements.insertAfter(inlinedStatement, tryStatement, group);
 			}
 
-			ASTNode placeholder = rewrite.createStringPlaceholder(inlinedSource.toString(), ASTNode.EMPTY_STATEMENT);
-			rewrite.replace(tryStatement, placeholder, group);
-			registerUnwrappedTryForImportRemoval(tryStatement, cuRewrite);
+			CatchClause removedCatch = (CatchClause) tryStatement.catchClauses().get(0);
+			cuRewrite.getImportRemover().registerRemovedNode(removedCatch);
+			rewrite.remove(tryStatement, group);
 			return true;
 		} catch (JavaModelException exception) {
 			rewrite.replace(visited, replacement, group);
@@ -300,7 +297,7 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 		}
 	}
 
-	private static String normalizeStatementSource(String source, String delimiter) {
+	private static String stripBaseIndent(String source, String delimiter) {
 		String[] lines = source.replace("\r\n", "\n").replace('\r', '\n').split("\n", -1); //$NON-NLS-1$ //$NON-NLS-2$
 		int first = 0;
 		while (first < lines.length && lines[first].isBlank()) {
@@ -342,80 +339,6 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 
 	private static String lineDelimiter(String source) {
 		return source.contains("\r\n") ? "\r\n" : "\n"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-	}
-
-	private static String indentationAt(String source, int position) {
-		int lineStart = Math.max(source.lastIndexOf('\n', Math.max(0, position - 1)),
-				source.lastIndexOf('\r', Math.max(0, position - 1))) + 1;
-		String indentation = source.substring(lineStart, position);
-		for (int index = 0; index < indentation.length(); index++) {
-			char character = indentation.charAt(index);
-			if (character != ' ' && character != '\t') {
-				return ""; //$NON-NLS-1$
-			}
-		}
-		return indentation;
-	}
-
-	private static void registerUnwrappedTryForImportRemoval(TryStatement tryStatement,
-			CompilationUnitRewrite cuRewrite) {
-		cuRewrite.getImportRemover().registerRemovedNode(tryStatement);
-		cuRewrite.getImportRemover().registerRetainedNode(tryStatement.getBody());
-		CatchClause removedCatch = (CatchClause) tryStatement.catchClauses().get(0);
-		CompilationUnit root = (CompilationUnit) tryStatement.getRoot();
-		Set<CatchClause> removedCatches = removedUnsupportedEncodingCatches(root);
-		removedCatches.add(removedCatch);
-		if (!hasSurvivingUnsupportedEncodingExceptionReference(root, removedCatches)) {
-			cuRewrite.getImportRewrite().removeImport(JAVA_IO_UNSUPPORTED_ENCODING_EXCEPTION);
-		}
-	}
-
-	@SuppressWarnings("unchecked")
-	private static Set<CatchClause> removedUnsupportedEncodingCatches(CompilationUnit root) {
-		Object stored = root.getProperty(REMOVED_UNSUPPORTED_ENCODING_CATCHES_PROPERTY);
-		if (stored instanceof Set<?>) {
-			return (Set<CatchClause>) stored;
-		}
-		Set<CatchClause> removedCatches = Collections.newSetFromMap(new IdentityHashMap<>());
-		root.setProperty(REMOVED_UNSUPPORTED_ENCODING_CATCHES_PROPERTY, removedCatches);
-		return removedCatches;
-	}
-
-	private static boolean hasSurvivingUnsupportedEncodingExceptionReference(CompilationUnit root,
-			Set<CatchClause> removedCatches) {
-		boolean[] found = { false };
-		root.accept(new ASTVisitor() {
-			@Override
-			public boolean preVisit2(ASTNode node) {
-				if (found[0]) {
-					return false;
-				}
-				if (!(node instanceof Type type) || isDescendantOfAny(type, removedCatches)) {
-					return true;
-				}
-				ITypeBinding binding = type.resolveBinding();
-				if (binding != null) {
-					found[0] = JAVA_IO_UNSUPPORTED_ENCODING_EXCEPTION
-							.equals(binding.getErasure().getQualifiedName());
-				} else {
-					String source = type.toString();
-					found[0] = UNSUPPORTED_ENCODING_EXCEPTION.equals(source)
-							|| JAVA_IO_UNSUPPORTED_ENCODING_EXCEPTION.equals(source)
-							|| source.endsWith("." + UNSUPPORTED_ENCODING_EXCEPTION); //$NON-NLS-1$
-				}
-				return !found[0];
-			}
-		});
-		return found[0];
-	}
-
-	private static boolean isDescendantOfAny(ASTNode node, Set<CatchClause> ancestors) {
-		for (ASTNode current = node; current != null; current = current.getParent()) {
-			if (ancestors.contains(current)) {
-				return true;
-			}
-		}
-		return false;
 	}
 
 	private static boolean isInsideTryBodyWithOnlyUnsupportedEncodingCatch(ASTNode statement) {

--- a/sandbox_encoding_quickfix/src/org/sandbox/jdt/internal/corext/fix/helper/AbstractExplicitEncoding.java
+++ b/sandbox_encoding_quickfix/src/org/sandbox/jdt/internal/corext/fix/helper/AbstractExplicitEncoding.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.sandbox.jdt.internal.corext.fix.helper;
 
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -76,6 +78,9 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 
 	/** Simple name of UnsupportedEncodingException for matching in exception types. */
 	private static final String UNSUPPORTED_ENCODING_EXCEPTION = "UnsupportedEncodingException"; //$NON-NLS-1$
+
+	private static final String REMOVED_UNSUPPORTED_ENCODING_CATCHES_PROPERTY =
+			AbstractExplicitEncoding.class.getName() + ".removedUnsupportedEncodingCatches"; //$NON-NLS-1$
 
 	/**
 	 * Immutable map of standard charset names (e.g., "UTF-8") to their corresponding
@@ -541,7 +546,7 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 	 * Registers the removed try/catch while retaining its inlined body. Placeholder
 	 * rewrites do not provide {@link ImportRemover} with a reliable reference balance,
 	 * so the obsolete exception import is removed explicitly only when no type reference
-	 * survives outside the deleted catch clause.
+	 * survives outside any catch clause that has actually been unwrapped in this rewrite.
 	 */
 	private static void registerUnwrappedTryForImportRemoval(TryStatement tryStatement,
 			CompilationUnitRewrite cuRewrite) {
@@ -549,18 +554,31 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 		cuRewrite.getImportRemover().registerRetainedNode(tryStatement.getBody());
 		CatchClause removedCatch = (CatchClause) tryStatement.catchClauses().get(0);
 		CompilationUnit root = (CompilationUnit) tryStatement.getRoot();
-		if (!hasSurvivingUnsupportedEncodingExceptionReference(root, removedCatch)) {
+		Set<CatchClause> removedCatches = removedUnsupportedEncodingCatches(root);
+		removedCatches.add(removedCatch);
+		if (!hasSurvivingUnsupportedEncodingExceptionReference(root, removedCatches)) {
 			cuRewrite.getImportRewrite().removeImport(JAVA_IO_UNSUPPORTED_ENCODING_EXCEPTION);
 		}
 	}
 
+	@SuppressWarnings("unchecked")
+	private static Set<CatchClause> removedUnsupportedEncodingCatches(CompilationUnit root) {
+		Object stored = root.getProperty(REMOVED_UNSUPPORTED_ENCODING_CATCHES_PROPERTY);
+		if (stored instanceof Set<?>) {
+			return (Set<CatchClause>) stored;
+		}
+		Set<CatchClause> removedCatches = Collections.newSetFromMap(new IdentityHashMap<>());
+		root.setProperty(REMOVED_UNSUPPORTED_ENCODING_CATCHES_PROPERTY, removedCatches);
+		return removedCatches;
+	}
+
 	private static boolean hasSurvivingUnsupportedEncodingExceptionReference(CompilationUnit root,
-			CatchClause removedCatch) {
+			Set<CatchClause> removedCatches) {
 		boolean[] found = { false };
 		root.accept(new ASTVisitor() {
 			@Override
 			public boolean visit(SimpleName node) {
-				if (found[0] || isDescendantOf(node, removedCatch)
+				if (found[0] || isDescendantOfAny(node, removedCatches)
 						|| ASTNodes.getFirstAncestorOrNull(node, ImportDeclaration.class) != null) {
 					return !found[0];
 				}
@@ -579,9 +597,9 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 		return found[0];
 	}
 
-	private static boolean isDescendantOf(ASTNode node, ASTNode ancestor) {
+	private static boolean isDescendantOfAny(ASTNode node, Set<CatchClause> ancestors) {
 		for (ASTNode current = node; current != null; current = current.getParent()) {
-			if (current == ancestor) {
+			if (ancestors.contains(current)) {
 				return true;
 			}
 		}

--- a/sandbox_encoding_quickfix/src/org/sandbox/jdt/internal/corext/fix/helper/AbstractExplicitEncoding.java
+++ b/sandbox_encoding_quickfix/src/org/sandbox/jdt/internal/corext/fix/helper/AbstractExplicitEncoding.java
@@ -33,12 +33,12 @@ import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.FieldAccess;
 import org.eclipse.jdt.core.dom.FieldDeclaration;
 import org.eclipse.jdt.core.dom.ITypeBinding;
-import org.eclipse.jdt.core.dom.ImportDeclaration;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.core.dom.Name;
 import org.eclipse.jdt.core.dom.QualifiedName;
 import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.SimpleType;
 import org.eclipse.jdt.core.dom.Statement;
 import org.eclipse.jdt.core.dom.StringLiteral;
 import org.eclipse.jdt.core.dom.TryStatement;
@@ -326,29 +326,17 @@ public abstract class AbstractExplicitEncoding<T extends ASTNode> {
 		boolean[] found = { false };
 		root.accept(new ASTVisitor() {
 			@Override
-			public boolean visit(SimpleName node) {
-				if (found[0]) {
+			public boolean visit(SimpleType node) {
+				if (!isDescendantOfAny(node, removedCatches)
+						&& node.getName() instanceof SimpleName simpleName
+						&& UNSUPPORTED_ENCODING_EXCEPTION.equals(simpleName.getIdentifier())) {
+					found[0] = true;
 					return false;
 				}
-				if (!UNSUPPORTED_ENCODING_EXCEPTION.equals(node.getIdentifier())
-						|| hasAncestor(node, ImportDeclaration.class)
-						|| isDescendantOfAny(node, removedCatches)) {
-					return true;
-				}
-				found[0] = true;
-				return false;
+				return !found[0];
 			}
 		});
 		return found[0];
-	}
-
-	private static boolean hasAncestor(ASTNode node, Class<? extends ASTNode> ancestorType) {
-		for (ASTNode current = node.getParent(); current != null; current = current.getParent()) {
-			if (ancestorType.isInstance(current)) {
-				return true;
-			}
-		}
-		return false;
 	}
 
 	private static boolean isDescendantOfAny(ASTNode node, Set<CatchClause> ancestors) {

--- a/sandbox_encoding_quickfix/src/org/sandbox/jdt/internal/corext/fix/helper/EncodingDslRemovedCatchImportCleanup.java
+++ b/sandbox_encoding_quickfix/src/org/sandbox/jdt/internal/corext/fix/helper/EncodingDslRemovedCatchImportCleanup.java
@@ -1,10 +1,8 @@
 /*******************************************************************************
  * Copyright (c) 2026 Carsten Hammer and others.
  *
- * This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License 2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-2.0/
+ * This program and the accompanying materials are made available under the
+ * Eclipse Public License 2.0: https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
@@ -30,21 +28,10 @@ import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCo
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
-/**
- * Finalizes import tracking for encoding transformations handled by the DSL.
- *
- * <p>The atomic DSL rewrite replaces the body of a removable encoding
- * {@code try/catch} and removes the surrounding try statement. The statements
- * remain semantically present, but the checked-exception catch clause does not.
- * Registering precisely that catch clause lets JDT's {@code ImportRemover}
- * remove {@code UnsupportedEncodingException} only when no other type use
- * survives in the compilation unit.</p>
- */
+/** Tracks catches removed by atomic encoding DSL rewrites for import cleanup. */
 public final class EncodingDslRemovedCatchImportCleanup extends CompilationUnitRewriteOperation {
-
-	private static final String UNSUPPORTED_ENCODING_EXCEPTION = "UnsupportedEncodingException"; //$NON-NLS-1$
-
-	private static final Set<String> KNOWN_ENCODINGS = Set.of(
+	private static final String EXCEPTION = "UnsupportedEncodingException"; //$NON-NLS-1$
+	private static final Set<String> ENCODINGS = Set.of(
 			"UTF-8", "UTF-16", "UTF-16BE", "UTF-16LE", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 			"US-ASCII", "ISO-8859-1"); //$NON-NLS-1$ //$NON-NLS-2$
 
@@ -54,67 +41,80 @@ public final class EncodingDslRemovedCatchImportCleanup extends CompilationUnitR
 		this.removedCatches = removedCatches;
 	}
 
-	/**
-	 * Creates the finalizer for DSL-matched encoding expressions.
-	 *
-	 * @param processedNodes nodes already claimed by the encoding DSL
-	 * @return a finalizer, or {@code null} when no removable catch was matched
-	 */
 	public static CompilationUnitRewriteOperation create(Set<ASTNode> processedNodes) {
-		Set<CatchClause> removedCatches = Collections.newSetFromMap(new IdentityHashMap<>());
-		for (ASTNode processedNode : processedNodes) {
-			if (!containsKnownEncodingLiteral(processedNode)) {
-				continue;
-			}
-			CatchClause removedCatch = findAtomicallyRemovedCatch(processedNode);
-			if (removedCatch != null) {
-				removedCatches.add(removedCatch);
+		Set<CatchClause> catches = Collections.newSetFromMap(new IdentityHashMap<>());
+		for (ASTNode node : processedNodes) {
+			if (containsEncoding(node)) {
+				CatchClause catchClause = removedCatch(node);
+				if (catchClause != null) {
+					catches.add(catchClause);
+				}
 			}
 		}
-		return removedCatches.isEmpty() ? null : new EncodingDslRemovedCatchImportCleanup(removedCatches);
+		if (catches.isEmpty() || hasExternalTypeUse(catches.iterator().next().getRoot(), catches)) {
+			return null;
+		}
+		return new EncodingDslRemovedCatchImportCleanup(catches);
 	}
 
 	@Override
 	public void rewriteAST(CompilationUnitRewrite cuRewrite, LinkedProposalModelCore linkedModel) {
-		for (CatchClause removedCatch : removedCatches) {
-			cuRewrite.getImportRemover().registerRemovedNode(removedCatch);
+		for (CatchClause catchClause : removedCatches) {
+			cuRewrite.getImportRemover().registerRemovedNode(catchClause);
 		}
 	}
 
-	private static boolean containsKnownEncodingLiteral(ASTNode node) {
+	private static boolean containsEncoding(ASTNode node) {
 		boolean[] found = { false };
 		node.accept(new ASTVisitor() {
 			@Override
 			public boolean visit(StringLiteral literal) {
-				found[0] = KNOWN_ENCODINGS.contains(literal.getLiteralValue().toUpperCase(Locale.ROOT));
+				found[0] = ENCODINGS.contains(literal.getLiteralValue().toUpperCase(Locale.ROOT));
 				return !found[0];
 			}
 		});
 		return found[0];
 	}
 
-	private static CatchClause findAtomicallyRemovedCatch(ASTNode node) {
-		Statement statement = ASTNodes.getFirstAncestorOrNull(node, Statement.class);
-		if (statement == null || !(statement.getParent() instanceof Block tryBody)
-				|| !(tryBody.getParent() instanceof TryStatement tryStatement)
-				|| tryStatement.getBody() != tryBody
-				|| !(tryStatement.getParent() instanceof Block)
-				|| !tryStatement.resources().isEmpty()
-				|| tryStatement.getFinally() != null) {
-			return null;
-		}
+	private static boolean hasExternalTypeUse(ASTNode root, Set<CatchClause> catches) {
+		boolean[] found = { false };
+		root.accept(new ASTVisitor() {
+			@Override
+			public boolean visit(SimpleType type) {
+				if (EXCEPTION.equals(type.getName().toString()) && !inside(type, catches)) {
+					found[0] = true;
+				}
+				return !found[0];
+			}
+		});
+		return found[0];
+	}
 
-		@SuppressWarnings("unchecked")
-		List<CatchClause> catchClauses = tryStatement.catchClauses();
-		if (catchClauses.size() != 1) {
+	private static boolean inside(ASTNode node, Set<CatchClause> catches) {
+		for (ASTNode current = node; current != null; current = current.getParent()) {
+			if (catches.contains(current)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static CatchClause removedCatch(ASTNode node) {
+		Statement statement = ASTNodes.getFirstAncestorOrNull(node, Statement.class);
+		if (statement == null || !(statement.getParent() instanceof Block body)
+				|| !(body.getParent() instanceof TryStatement tryStatement)
+				|| tryStatement.getBody() != body || !(tryStatement.getParent() instanceof Block)
+				|| !tryStatement.resources().isEmpty() || tryStatement.getFinally() != null) {
 			return null;
 		}
-		CatchClause catchClause = catchClauses.get(0);
-		Type exceptionType = catchClause.getException().getType();
-		if (exceptionType instanceof SimpleType simpleType
-				&& UNSUPPORTED_ENCODING_EXCEPTION.equals(simpleType.getName().toString())) {
-			return catchClause;
+		@SuppressWarnings("unchecked")
+		List<CatchClause> catches = tryStatement.catchClauses();
+		if (catches.size() != 1) {
+			return null;
 		}
-		return null;
+		CatchClause catchClause = catches.get(0);
+		Type type = catchClause.getException().getType();
+		return type instanceof SimpleType simpleType && EXCEPTION.equals(simpleType.getName().toString())
+				? catchClause : null;
 	}
 }

--- a/sandbox_encoding_quickfix/src/org/sandbox/jdt/internal/corext/fix/helper/EncodingDslRemovedCatchImportCleanup.java
+++ b/sandbox_encoding_quickfix/src/org/sandbox/jdt/internal/corext/fix/helper/EncodingDslRemovedCatchImportCleanup.java
@@ -1,0 +1,120 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.corext.fix.helper;
+
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.Block;
+import org.eclipse.jdt.core.dom.CatchClause;
+import org.eclipse.jdt.core.dom.SimpleType;
+import org.eclipse.jdt.core.dom.Statement;
+import org.eclipse.jdt.core.dom.StringLiteral;
+import org.eclipse.jdt.core.dom.TryStatement;
+import org.eclipse.jdt.core.dom.Type;
+import org.eclipse.jdt.internal.corext.dom.ASTNodes;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
+import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
+
+/**
+ * Finalizes import tracking for encoding transformations handled by the DSL.
+ *
+ * <p>The atomic DSL rewrite replaces the body of a removable encoding
+ * {@code try/catch} and removes the surrounding try statement. The statements
+ * remain semantically present, but the checked-exception catch clause does not.
+ * Registering precisely that catch clause lets JDT's {@code ImportRemover}
+ * remove {@code UnsupportedEncodingException} only when no other type use
+ * survives in the compilation unit.</p>
+ */
+public final class EncodingDslRemovedCatchImportCleanup extends CompilationUnitRewriteOperation {
+
+	private static final String UNSUPPORTED_ENCODING_EXCEPTION = "UnsupportedEncodingException"; //$NON-NLS-1$
+
+	private static final Set<String> KNOWN_ENCODINGS = Set.of(
+			"UTF-8", "UTF-16", "UTF-16BE", "UTF-16LE", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+			"US-ASCII", "ISO-8859-1"); //$NON-NLS-1$ //$NON-NLS-2$
+
+	private final Set<CatchClause> removedCatches;
+
+	private EncodingDslRemovedCatchImportCleanup(Set<CatchClause> removedCatches) {
+		this.removedCatches = removedCatches;
+	}
+
+	/**
+	 * Creates the finalizer for DSL-matched encoding expressions.
+	 *
+	 * @param processedNodes nodes already claimed by the encoding DSL
+	 * @return a finalizer, or {@code null} when no removable catch was matched
+	 */
+	public static CompilationUnitRewriteOperation create(Set<ASTNode> processedNodes) {
+		Set<CatchClause> removedCatches = Collections.newSetFromMap(new IdentityHashMap<>());
+		for (ASTNode processedNode : processedNodes) {
+			if (!containsKnownEncodingLiteral(processedNode)) {
+				continue;
+			}
+			CatchClause removedCatch = findAtomicallyRemovedCatch(processedNode);
+			if (removedCatch != null) {
+				removedCatches.add(removedCatch);
+			}
+		}
+		return removedCatches.isEmpty() ? null : new EncodingDslRemovedCatchImportCleanup(removedCatches);
+	}
+
+	@Override
+	public void rewriteAST(CompilationUnitRewrite cuRewrite, LinkedProposalModelCore linkedModel) {
+		for (CatchClause removedCatch : removedCatches) {
+			cuRewrite.getImportRemover().registerRemovedNode(removedCatch);
+		}
+	}
+
+	private static boolean containsKnownEncodingLiteral(ASTNode node) {
+		boolean[] found = { false };
+		node.accept(new ASTVisitor() {
+			@Override
+			public boolean visit(StringLiteral literal) {
+				found[0] = KNOWN_ENCODINGS.contains(literal.getLiteralValue().toUpperCase(Locale.ROOT));
+				return !found[0];
+			}
+		});
+		return found[0];
+	}
+
+	private static CatchClause findAtomicallyRemovedCatch(ASTNode node) {
+		Statement statement = ASTNodes.getFirstAncestorOrNull(node, Statement.class);
+		if (statement == null || !(statement.getParent() instanceof Block tryBody)
+				|| !(tryBody.getParent() instanceof TryStatement tryStatement)
+				|| tryStatement.getBody() != tryBody
+				|| !(tryStatement.getParent() instanceof Block)
+				|| !tryStatement.resources().isEmpty()
+				|| tryStatement.getFinally() != null) {
+			return null;
+		}
+
+		@SuppressWarnings("unchecked")
+		List<CatchClause> catchClauses = tryStatement.catchClauses();
+		if (catchClauses.size() != 1) {
+			return null;
+		}
+		CatchClause catchClause = catchClauses.get(0);
+		Type exceptionType = catchClause.getException().getType();
+		if (exceptionType instanceof SimpleType simpleType
+				&& UNSUPPORTED_ENCODING_EXCEPTION.equals(simpleType.getName().toString())) {
+			return catchClause;
+		}
+		return null;
+	}
+}

--- a/sandbox_encoding_quickfix/src/org/sandbox/jdt/internal/corext/fix/helper/StringExplicitEncoding.java
+++ b/sandbox_encoding_quickfix/src/org/sandbox/jdt/internal/corext/fix/helper/StringExplicitEncoding.java
@@ -25,11 +25,11 @@ import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperation;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
+import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 import org.eclipse.text.edits.TextEditGroup;
 import org.sandbox.jdt.internal.common.HelperVisitorFactory;
 import org.sandbox.jdt.internal.common.ReferenceHolder;
 import org.sandbox.jdt.internal.corext.fix.UseExplicitEncodingFixCore;
-import org.sandbox.jdt.internal.corext.util.JavaModelUtil;
 
 /**
  *

--- a/sandbox_encoding_quickfix/src/org/sandbox/jdt/internal/corext/fix/helper/StringExplicitEncoding.java
+++ b/sandbox_encoding_quickfix/src/org/sandbox/jdt/internal/corext/fix/helper/StringExplicitEncoding.java
@@ -19,8 +19,13 @@ import java.util.Set;
 import org.eclipse.text.edits.TextEditGroup;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.CatchClause;
 import org.eclipse.jdt.core.dom.ClassInstanceCreation;
 import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.ImportDeclaration;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.StringLiteral;
 import org.eclipse.jdt.core.dom.TryStatement;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
@@ -51,6 +56,8 @@ import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
  *
  */
 public class StringExplicitEncoding extends AbstractExplicitEncoding<ClassInstanceCreation> {
+
+	private static final String JAVA_IO_UNSUPPORTED_ENCODING_EXCEPTION= "java.io.UnsupportedEncodingException"; //$NON-NLS-1$
 
 	@Override
 	public void find(UseExplicitEncodingFixCore fixcore, CompilationUnit compilationUnit, Set<CompilationUnitRewriteOperation> operations, Set<ASTNode> nodesprocessed, ChangeBehavior cb) {
@@ -128,8 +135,9 @@ public class StringExplicitEncoding extends AbstractExplicitEncoding<ClassInstan
 	/**
 	 * Registers the original try statement as removed while retaining the body whose
 	 * statements were recreated as placeholders by the combined replacement/unwrap
-	 * rewrite. This lets {@code ImportRemover} discard imports referenced only by the
-	 * removed catch clause without treating imports used by the inlined body as dead.
+	 * rewrite. If no surviving type reference exists outside the deleted catch clause,
+	 * the obsolete import is removed explicitly because placeholder rewrites do not
+	 * provide {@code ImportRemover} with a reliable reference balance.
 	 */
 	private static void registerUnwrappedTryForImportRemoval(ClassInstanceCreation visited,
 			CompilationUnitRewrite cuRewrite) {
@@ -139,6 +147,41 @@ public class StringExplicitEncoding extends AbstractExplicitEncoding<ClassInstan
 		}
 		cuRewrite.getImportRemover().registerRemovedNode(tryStatement);
 		cuRewrite.getImportRemover().registerRetainedNode(tryStatement.getBody());
+		CatchClause removedCatch= (CatchClause) tryStatement.catchClauses().get(0);
+		CompilationUnit root= (CompilationUnit) tryStatement.getRoot();
+		if (!hasSurvivingUnsupportedEncodingExceptionReference(root, removedCatch)) {
+			cuRewrite.getImportRewrite().removeImport(JAVA_IO_UNSUPPORTED_ENCODING_EXCEPTION);
+		}
+	}
+
+	private static boolean hasSurvivingUnsupportedEncodingExceptionReference(CompilationUnit root,
+			CatchClause removedCatch) {
+		boolean[] found= { false };
+		root.accept(new ASTVisitor() {
+			@Override
+			public boolean visit(SimpleName node) {
+				if (found[0] || isDescendantOf(node, removedCatch)
+						|| ASTNodes.getFirstAncestorOrNull(node, ImportDeclaration.class) != null) {
+					return !found[0];
+				}
+				ITypeBinding typeBinding= node.resolveTypeBinding();
+				if (typeBinding != null
+						&& JAVA_IO_UNSUPPORTED_ENCODING_EXCEPTION.equals(typeBinding.getErasure().getQualifiedName())) {
+					found[0]= true;
+				}
+				return !found[0];
+			}
+		});
+		return found[0];
+	}
+
+	private static boolean isDescendantOf(ASTNode node, ASTNode ancestor) {
+		for (ASTNode current= node; current != null; current= current.getParent()) {
+			if (current == ancestor) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	@Override

--- a/sandbox_encoding_quickfix/src/org/sandbox/jdt/internal/corext/fix/helper/StringExplicitEncoding.java
+++ b/sandbox_encoding_quickfix/src/org/sandbox/jdt/internal/corext/fix/helper/StringExplicitEncoding.java
@@ -22,8 +22,10 @@ import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ClassInstanceCreation;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.StringLiteral;
+import org.eclipse.jdt.core.dom.TryStatement;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
+import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 
 import org.sandbox.jdt.internal.common.HelperVisitor;
 import org.sandbox.jdt.internal.common.HelperVisitorFactory;
@@ -116,9 +118,27 @@ public class StringExplicitEncoding extends AbstractExplicitEncoding<ClassInstan
 		} else {
 			listRewrite.insertLast(callToCharsetDefaultCharset, group);
 		}
-		if (!tryAlreadyUnwrapped) {
+		if (tryAlreadyUnwrapped) {
+			registerUnwrappedTryForImportRemoval(visited, cuRewrite);
+		} else {
 			removeUnsupportedEncodingException(visited, group, rewrite, cuRewrite.getImportRemover());
 		}
+	}
+
+	/**
+	 * Registers the original try statement as removed while retaining the body whose
+	 * statements were recreated as placeholders by the combined replacement/unwrap
+	 * rewrite. This lets {@code ImportRemover} discard imports referenced only by the
+	 * removed catch clause without treating imports used by the inlined body as dead.
+	 */
+	private static void registerUnwrappedTryForImportRemoval(ClassInstanceCreation visited,
+			CompilationUnitRewrite cuRewrite) {
+		TryStatement tryStatement= ASTNodes.getFirstAncestorOrNull(visited, TryStatement.class);
+		if (tryStatement == null || tryStatement.catchClauses().size() != 1) {
+			return;
+		}
+		cuRewrite.getImportRemover().registerRemovedNode(tryStatement);
+		cuRewrite.getImportRemover().registerRetainedNode(tryStatement.getBody());
 	}
 
 	@Override

--- a/sandbox_encoding_quickfix/src/org/sandbox/jdt/internal/corext/fix/helper/StringExplicitEncoding.java
+++ b/sandbox_encoding_quickfix/src/org/sandbox/jdt/internal/corext/fix/helper/StringExplicitEncoding.java
@@ -16,7 +16,6 @@ package org.sandbox.jdt.internal.corext.fix.helper;
 import java.util.List;
 import java.util.Set;
 
-import org.eclipse.text.edits.TextEditGroup;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ClassInstanceCreation;
@@ -24,14 +23,13 @@ import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.StringLiteral;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
-
-import org.sandbox.jdt.internal.common.HelperVisitor;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
+import org.eclipse.text.edits.TextEditGroup;
 import org.sandbox.jdt.internal.common.HelperVisitorFactory;
 import org.sandbox.jdt.internal.common.ReferenceHolder;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperation;
 import org.sandbox.jdt.internal.corext.fix.UseExplicitEncodingFixCore;
-import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
-import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
+import org.sandbox.jdt.internal.corext.util.JavaModelUtil;
 
 /**
  *

--- a/sandbox_encoding_quickfix/src/org/sandbox/jdt/internal/corext/fix/helper/StringExplicitEncoding.java
+++ b/sandbox_encoding_quickfix/src/org/sandbox/jdt/internal/corext/fix/helper/StringExplicitEncoding.java
@@ -19,18 +19,11 @@ import java.util.Set;
 import org.eclipse.text.edits.TextEditGroup;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
-import org.eclipse.jdt.core.dom.ASTVisitor;
-import org.eclipse.jdt.core.dom.CatchClause;
 import org.eclipse.jdt.core.dom.ClassInstanceCreation;
 import org.eclipse.jdt.core.dom.CompilationUnit;
-import org.eclipse.jdt.core.dom.ImportDeclaration;
-import org.eclipse.jdt.core.dom.ITypeBinding;
-import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.StringLiteral;
-import org.eclipse.jdt.core.dom.TryStatement;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
-import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 
 import org.sandbox.jdt.internal.common.HelperVisitor;
 import org.sandbox.jdt.internal.common.HelperVisitorFactory;
@@ -56,8 +49,6 @@ import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
  *
  */
 public class StringExplicitEncoding extends AbstractExplicitEncoding<ClassInstanceCreation> {
-
-	private static final String JAVA_IO_UNSUPPORTED_ENCODING_EXCEPTION= "java.io.UnsupportedEncodingException"; //$NON-NLS-1$
 
 	@Override
 	public void find(UseExplicitEncodingFixCore fixcore, CompilationUnit compilationUnit, Set<CompilationUnitRewriteOperation> operations, Set<ASTNode> nodesprocessed, ChangeBehavior cb) {
@@ -125,63 +116,9 @@ public class StringExplicitEncoding extends AbstractExplicitEncoding<ClassInstan
 		} else {
 			listRewrite.insertLast(callToCharsetDefaultCharset, group);
 		}
-		if (tryAlreadyUnwrapped) {
-			registerUnwrappedTryForImportRemoval(visited, cuRewrite);
-		} else {
+		if (!tryAlreadyUnwrapped) {
 			removeUnsupportedEncodingException(visited, group, rewrite, cuRewrite.getImportRemover());
 		}
-	}
-
-	/**
-	 * Registers the original try statement as removed while retaining the body whose
-	 * statements were recreated as placeholders by the combined replacement/unwrap
-	 * rewrite. If no surviving type reference exists outside the deleted catch clause,
-	 * the obsolete import is removed explicitly because placeholder rewrites do not
-	 * provide {@code ImportRemover} with a reliable reference balance.
-	 */
-	private static void registerUnwrappedTryForImportRemoval(ClassInstanceCreation visited,
-			CompilationUnitRewrite cuRewrite) {
-		TryStatement tryStatement= ASTNodes.getFirstAncestorOrNull(visited, TryStatement.class);
-		if (tryStatement == null || tryStatement.catchClauses().size() != 1) {
-			return;
-		}
-		cuRewrite.getImportRemover().registerRemovedNode(tryStatement);
-		cuRewrite.getImportRemover().registerRetainedNode(tryStatement.getBody());
-		CatchClause removedCatch= (CatchClause) tryStatement.catchClauses().get(0);
-		CompilationUnit root= (CompilationUnit) tryStatement.getRoot();
-		if (!hasSurvivingUnsupportedEncodingExceptionReference(root, removedCatch)) {
-			cuRewrite.getImportRewrite().removeImport(JAVA_IO_UNSUPPORTED_ENCODING_EXCEPTION);
-		}
-	}
-
-	private static boolean hasSurvivingUnsupportedEncodingExceptionReference(CompilationUnit root,
-			CatchClause removedCatch) {
-		boolean[] found= { false };
-		root.accept(new ASTVisitor() {
-			@Override
-			public boolean visit(SimpleName node) {
-				if (found[0] || isDescendantOf(node, removedCatch)
-						|| ASTNodes.getFirstAncestorOrNull(node, ImportDeclaration.class) != null) {
-					return !found[0];
-				}
-				ITypeBinding typeBinding= node.resolveTypeBinding();
-				if (typeBinding != null
-						&& JAVA_IO_UNSUPPORTED_ENCODING_EXCEPTION.equals(typeBinding.getErasure().getQualifiedName())) {
-					found[0]= true;
-				}
-				return !found[0];
-			}
-		});
-		return found[0];
-	}
-
-	private static boolean isDescendantOf(ASTNode node, ASTNode ancestor) {
-		for (ASTNode current= node; current != null; current= current.getParent()) {
-			if (current == ancestor) {
-				return true;
-			}
-		}
-		return false;
 	}
 
 	@Override

--- a/sandbox_encoding_quickfix/src/org/sandbox/jdt/internal/ui/fix/UseExplicitEncodingCleanUpCore.java
+++ b/sandbox_encoding_quickfix/src/org/sandbox/jdt/internal/ui/fix/UseExplicitEncodingCleanUpCore.java
@@ -40,6 +40,7 @@ import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCo
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperation;
 import org.sandbox.jdt.internal.corext.fix.UseExplicitEncodingFixCore;
 import org.sandbox.jdt.internal.corext.fix.helper.ChangeBehavior;
+import org.sandbox.jdt.internal.corext.fix.helper.EncodingDslRemovedCatchImportCleanup;
 import org.eclipse.jdt.internal.corext.util.Messages;
 import org.eclipse.jdt.internal.ui.fix.AbstractCleanUp;
 import org.eclipse.jdt.ui.cleanup.CleanUpContext;
@@ -107,6 +108,14 @@ public class UseExplicitEncodingCleanUpCore extends AbstractCleanUp {
 				i.findOperations(compilationUnit, operations, nodesprocessed, cb);
 			}
 		});
+
+		if (dslActive) {
+			CompilationUnitRewriteOperation importCleanup=
+					EncodingDslRemovedCatchImportCleanup.create(nodesprocessed);
+			if (importCleanup != null) {
+				operations.add(importCleanup);
+			}
+		}
 
 		if (operations.isEmpty()) {
 			return null;

--- a/sandbox_encoding_quickfix_test/src/org/eclipse/jdt/ui/tests/quickfix/Java10/EncodingImportRetentionTest.java
+++ b/sandbox_encoding_quickfix_test/src/org/eclipse/jdt/ui/tests/quickfix/Java10/EncodingImportRetentionTest.java
@@ -33,6 +33,9 @@ public class EncodingImportRetentionTest {
 	protected void setUp() throws Exception {
 		Hashtable<String, String> defaultOptions= TestOptions.getDefaultOptions();
 		defaultOptions.put(DefaultCodeFormatterConstants.FORMATTER_LINE_SPLIT, Integer.toString(120));
+		defaultOptions.put(DefaultCodeFormatterConstants.FORMATTER_TAB_CHAR, JavaCore.SPACE);
+		defaultOptions.put(DefaultCodeFormatterConstants.FORMATTER_TAB_SIZE, Integer.toString(4));
+		defaultOptions.put(DefaultCodeFormatterConstants.FORMATTER_INDENTATION_SIZE, Integer.toString(4));
 		JavaCore.setOptions(defaultOptions);
 		TestOptions.initializeCodeGenerationOptions();
 		JavaPlugin.getDefault().getCodeTemplateStore().load();

--- a/sandbox_encoding_quickfix_test/src/org/eclipse/jdt/ui/tests/quickfix/Java10/EncodingImportRetentionTest.java
+++ b/sandbox_encoding_quickfix_test/src/org/eclipse/jdt/ui/tests/quickfix/Java10/EncodingImportRetentionTest.java
@@ -42,7 +42,7 @@ public class EncodingImportRetentionTest {
 	AbstractEclipseJava context= new EclipseJava10();
 
 	@Test
-	public void retainsImportsUsedByTheInlinedTryBody() throws CoreException {
+	public void retainsImportsAndFormattingUsedByTheInlinedTryBody() throws CoreException {
 		IPackageFragment pack= context.getSourceFolder().createPackageFragment("test1", false, null); //$NON-NLS-1$
 		ICompilationUnit cu= pack.createCompilationUnit("E1.java", //$NON-NLS-1$
 				"""
@@ -54,7 +54,9 @@ public class EncodingImportRetentionTest {
 						public class E1 {
 						    static void methodWithCatchChange(byte[] bytes) {
 						        try {
-						            System.out.println(List.of(new String(bytes, "UTF-8")).get(0));
+						            List<String> values = List.of("value");
+						            String text = new String(bytes, "UTF-8");
+						            System.out.println(values.get(0) + text);
 						        } catch (UnsupportedEncodingException exception) {
 						            exception.printStackTrace();
 						        }
@@ -73,7 +75,46 @@ public class EncodingImportRetentionTest {
 
 						public class E1 {
 						    static void methodWithCatchChange(byte[] bytes) {
-						        System.out.println(List.of(new String(bytes, StandardCharsets.UTF_8)).get(0));
+						        List<String> values = List.of("value");
+						        String text = new String(bytes, StandardCharsets.UTF_8);
+						        System.out.println(values.get(0) + text);
+						    }
+						}
+						"""
+		}, null);
+	}
+
+	@Test
+	public void removesObsoleteImportForAnotherEncodingHandler() throws CoreException {
+		IPackageFragment pack= context.getSourceFolder().createPackageFragment("test1", false, null); //$NON-NLS-1$
+		ICompilationUnit cu= pack.createCompilationUnit("E1.java", //$NON-NLS-1$
+				"""
+						package test1;
+
+						import java.io.UnsupportedEncodingException;
+
+						public class E1 {
+						    static int encodedLength() {
+						        try {
+						            return "value".getBytes("UTF-8").length;
+						        } catch (UnsupportedEncodingException exception) {
+						            throw new IllegalStateException(exception);
+						        }
+						    }
+						}
+						""",
+				false, null);
+
+		enableExplicitEncodingCleanup();
+		context.assertRefactoringResultAsExpectedWithCompileCheck(new ICompilationUnit[] { cu }, new String[] {
+				"""
+						package test1;
+
+						import java.nio.charset.StandardCharsets;
+
+						public class E1 {
+						    static int encodedLength() {
+						        return "value".getBytes(StandardCharsets.UTF_8).length;
 						    }
 						}
 						"""

--- a/sandbox_encoding_quickfix_test/src/org/eclipse/jdt/ui/tests/quickfix/Java10/EncodingImportRetentionTest.java
+++ b/sandbox_encoding_quickfix_test/src/org/eclipse/jdt/ui/tests/quickfix/Java10/EncodingImportRetentionTest.java
@@ -63,10 +63,7 @@ public class EncodingImportRetentionTest {
 						""",
 				false, null);
 
-		context.enable(MYCleanUpConstants.EXPLICITENCODING_CLEANUP);
-		context.enable(MYCleanUpConstants.EXPLICITENCODING_KEEP_BEHAVIOR);
-		context.disable(MYCleanUpConstants.EXPLICITENCODING_INSERT_UTF8);
-		context.disable(MYCleanUpConstants.EXPLICITENCODING_AGGREGATE_TO_UTF8);
+		enableExplicitEncodingCleanup();
 		context.assertRefactoringResultAsExpectedWithCompileCheck(new ICompilationUnit[] { cu }, new String[] {
 				"""
 						package test1;
@@ -81,5 +78,58 @@ public class EncodingImportRetentionTest {
 						}
 						"""
 		}, null);
+	}
+
+	@Test
+	public void retainsUnsupportedEncodingImportWhenAnotherTypeReferenceSurvives() throws CoreException {
+		IPackageFragment pack= context.getSourceFolder().createPackageFragment("test1", false, null); //$NON-NLS-1$
+		ICompilationUnit cu= pack.createCompilationUnit("E1.java", //$NON-NLS-1$
+				"""
+						package test1;
+
+						import java.io.UnsupportedEncodingException;
+
+						public class E1 {
+						    static void methodWithCatchChange(byte[] bytes) {
+						        try {
+						            System.out.println(new String(bytes, "UTF-8"));
+						        } catch (UnsupportedEncodingException exception) {
+						            exception.printStackTrace();
+						        }
+						    }
+
+						    static void report(UnsupportedEncodingException exception) {
+						        exception.printStackTrace();
+						    }
+						}
+						""",
+				false, null);
+
+		enableExplicitEncodingCleanup();
+		context.assertRefactoringResultAsExpectedWithCompileCheck(new ICompilationUnit[] { cu }, new String[] {
+				"""
+						package test1;
+
+						import java.io.UnsupportedEncodingException;
+						import java.nio.charset.StandardCharsets;
+
+						public class E1 {
+						    static void methodWithCatchChange(byte[] bytes) {
+						        System.out.println(new String(bytes, StandardCharsets.UTF_8));
+						    }
+
+						    static void report(UnsupportedEncodingException exception) {
+						        exception.printStackTrace();
+						    }
+						}
+						"""
+		}, null);
+	}
+
+	private void enableExplicitEncodingCleanup() {
+		context.enable(MYCleanUpConstants.EXPLICITENCODING_CLEANUP);
+		context.enable(MYCleanUpConstants.EXPLICITENCODING_KEEP_BEHAVIOR);
+		context.disable(MYCleanUpConstants.EXPLICITENCODING_INSERT_UTF8);
+		context.disable(MYCleanUpConstants.EXPLICITENCODING_AGGREGATE_TO_UTF8);
 	}
 }

--- a/sandbox_encoding_quickfix_test/src/org/eclipse/jdt/ui/tests/quickfix/Java10/EncodingImportRetentionTest.java
+++ b/sandbox_encoding_quickfix_test/src/org/eclipse/jdt/ui/tests/quickfix/Java10/EncodingImportRetentionTest.java
@@ -54,9 +54,7 @@ public class EncodingImportRetentionTest {
 						public class E1 {
 						    static void methodWithCatchChange(byte[] bytes) {
 						        try {
-						            List<String> values = List.of("value");
-						            String text = new String(bytes, "UTF-8");
-						            System.out.println(values.get(0) + text);
+						            System.out.println(List.of(new String(bytes, "UTF-8")).get(0));
 						        } catch (UnsupportedEncodingException exception) {
 						            exception.printStackTrace();
 						        }
@@ -78,9 +76,7 @@ public class EncodingImportRetentionTest {
 
 						public class E1 {
 						    static void methodWithCatchChange(byte[] bytes) {
-						        List<String> values = List.of("value");
-						        String text = new String(bytes, StandardCharsets.UTF_8);
-						        System.out.println(values.get(0) + text);
+						        System.out.println(List.of(new String(bytes, StandardCharsets.UTF_8)).get(0));
 						    }
 						}
 						"""

--- a/sandbox_encoding_quickfix_test/src/org/eclipse/jdt/ui/tests/quickfix/Java10/EncodingImportRetentionTest.java
+++ b/sandbox_encoding_quickfix_test/src/org/eclipse/jdt/ui/tests/quickfix/Java10/EncodingImportRetentionTest.java
@@ -179,7 +179,7 @@ public class EncodingImportRetentionTest {
 		}, null);
 	}
 
-	private void enableExplicitEncodingCleanup() {
+	private void enableExplicitEncodingCleanup() throws CoreException {
 		context.enable(MYCleanUpConstants.EXPLICITENCODING_CLEANUP);
 		context.enable(MYCleanUpConstants.EXPLICITENCODING_KEEP_BEHAVIOR);
 		context.disable(MYCleanUpConstants.EXPLICITENCODING_INSERT_UTF8);

--- a/sandbox_encoding_quickfix_test/src/org/eclipse/jdt/ui/tests/quickfix/Java10/EncodingImportRetentionTest.java
+++ b/sandbox_encoding_quickfix_test/src/org/eclipse/jdt/ui/tests/quickfix/Java10/EncodingImportRetentionTest.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.quickfix.Java10;
+
+import java.nio.charset.UnsupportedCharsetException;
+import java.util.Hashtable;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
+import org.eclipse.jdt.internal.ui.JavaPlugin;
+import org.eclipse.jdt.testplugin.TestOptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.sandbox.jdt.internal.corext.fix2.MYCleanUpConstants;
+import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
+import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava10;
+
+/** Import-removal contracts for combined encoding replacement and try unwrapping. */
+public class EncodingImportRetentionTest {
+
+	@BeforeEach
+	protected void setUp() throws Exception, UnsupportedCharsetException {
+		Hashtable<String, String> defaultOptions= TestOptions.getDefaultOptions();
+		defaultOptions.put(DefaultCodeFormatterConstants.FORMATTER_LINE_SPLIT, Integer.toString(120));
+		JavaCore.setOptions(defaultOptions);
+		TestOptions.initializeCodeGenerationOptions();
+		JavaPlugin.getDefault().getCodeTemplateStore().load();
+	}
+
+	@RegisterExtension
+	AbstractEclipseJava context= new EclipseJava10();
+
+	@Test
+	public void retainsImportsUsedByTheInlinedTryBody() throws CoreException {
+		IPackageFragment pack= context.getSourceFolder().createPackageFragment("test1", false, null); //$NON-NLS-1$
+		ICompilationUnit cu= pack.createCompilationUnit("E1.java", //$NON-NLS-1$
+				"""
+						package test1;
+
+						import java.io.UnsupportedEncodingException;
+						import java.util.List;
+
+						public class E1 {
+						    static void methodWithCatchChange(byte[] bytes) {
+						        try {
+						            List<String> values = List.of("value");
+						            String text = new String(bytes, "UTF-8");
+						            System.out.println(values.get(0) + text);
+						        } catch (UnsupportedEncodingException exception) {
+						            exception.printStackTrace();
+						        }
+						    }
+						}
+						""",
+				false, null);
+
+		context.enable(MYCleanUpConstants.EXPLICITENCODING_CLEANUP);
+		context.enable(MYCleanUpConstants.EXPLICITENCODING_KEEP_BEHAVIOR);
+		context.disable(MYCleanUpConstants.EXPLICITENCODING_INSERT_UTF8);
+		context.disable(MYCleanUpConstants.EXPLICITENCODING_AGGREGATE_TO_UTF8);
+		context.assertRefactoringResultAsExpectedWithCompileCheck(new ICompilationUnit[] { cu }, new String[] {
+				"""
+						package test1;
+
+						import java.nio.charset.StandardCharsets;
+						import java.util.List;
+
+						public class E1 {
+						    static void methodWithCatchChange(byte[] bytes) {
+						        List<String> values = List.of("value");
+						        String text = new String(bytes, StandardCharsets.UTF_8);
+						        System.out.println(values.get(0) + text);
+						    }
+						}
+						"""
+		}, null);
+	}
+}

--- a/sandbox_encoding_quickfix_test/src/org/eclipse/jdt/ui/tests/quickfix/Java10/EncodingImportRetentionTest.java
+++ b/sandbox_encoding_quickfix_test/src/org/eclipse/jdt/ui/tests/quickfix/Java10/EncodingImportRetentionTest.java
@@ -85,7 +85,7 @@ public class EncodingImportRetentionTest {
 	}
 
 	@Test
-	public void removesObsoleteImportForAnotherEncodingHandler() throws CoreException {
+	public void removesImportAfterMultipleEncodingCatchesAreUnwrapped() throws CoreException {
 		IPackageFragment pack= context.getSourceFolder().createPackageFragment("test1", false, null); //$NON-NLS-1$
 		ICompilationUnit cu= pack.createCompilationUnit("E1.java", //$NON-NLS-1$
 				"""
@@ -94,6 +94,14 @@ public class EncodingImportRetentionTest {
 						import java.io.UnsupportedEncodingException;
 
 						public class E1 {
+						    static String decode(byte[] bytes) {
+						        try {
+						            return new String(bytes, "UTF-8");
+						        } catch (UnsupportedEncodingException exception) {
+						            throw new IllegalStateException(exception);
+						        }
+						    }
+
 						    static int encodedLength() {
 						        try {
 						            return "value".getBytes("UTF-8").length;
@@ -113,6 +121,10 @@ public class EncodingImportRetentionTest {
 						import java.nio.charset.StandardCharsets;
 
 						public class E1 {
+						    static String decode(byte[] bytes) {
+						        return new String(bytes, StandardCharsets.UTF_8);
+						    }
+
 						    static int encodedLength() {
 						        return "value".getBytes(StandardCharsets.UTF_8).length;
 						    }

--- a/sandbox_encoding_quickfix_test/src/org/eclipse/jdt/ui/tests/quickfix/Java10/EncodingImportRetentionTest.java
+++ b/sandbox_encoding_quickfix_test/src/org/eclipse/jdt/ui/tests/quickfix/Java10/EncodingImportRetentionTest.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.jdt.ui.tests.quickfix.Java10;
 
-import java.nio.charset.UnsupportedCharsetException;
 import java.util.Hashtable;
 
 import org.eclipse.core.runtime.CoreException;
@@ -31,7 +30,7 @@ import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava10;
 public class EncodingImportRetentionTest {
 
 	@BeforeEach
-	protected void setUp() throws Exception, UnsupportedCharsetException {
+	protected void setUp() throws Exception {
 		Hashtable<String, String> defaultOptions= TestOptions.getDefaultOptions();
 		defaultOptions.put(DefaultCodeFormatterConstants.FORMATTER_LINE_SPLIT, Integer.toString(120));
 		JavaCore.setOptions(defaultOptions);

--- a/sandbox_encoding_quickfix_test/src/org/eclipse/jdt/ui/tests/quickfix/Java10/ExplicitEncodingCleanUpTest.java
+++ b/sandbox_encoding_quickfix_test/src/org/eclipse/jdt/ui/tests/quickfix/Java10/ExplicitEncodingCleanUpTest.java
@@ -24,7 +24,6 @@ import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.testplugin.TestOptions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -144,17 +143,11 @@ public class ExplicitEncodingCleanUpTest {
 	 * try-catch unwrapping (removing single UnsupportedEncodingException catch)
 	 * both work correctly when combined in the same statement.
 	 *
-	 * <p>This is a known limitation: Eclipse's ASTRewrite.createMoveTarget()
-	 * (used to move statements out of the try body) does not preserve child
-	 * node replacements registered via rewrite.replace(). The encoding
-	 * replacement is silently lost when the parent statement is moved.
-	 *
-	 * <p>The workaround in replaceTryBodyAndUnwrap uses text-based placeholder
-	 * replacement, but this still needs to be verified in CI.
+	 * <p>The replacement and try unwrapping must be emitted as one rewrite so
+	 * moving the parent statement cannot discard the child charset change.
 	 *
 	 * @see AbstractExplicitEncoding#replaceTryBodyAndUnwrap
 	 */
-	@Disabled("Known limitation: encoding replacement inside try-catch with UnsupportedEncodingException unwrap — see replaceTryBodyAndUnwrap") //$NON-NLS-1$
 	@Test
 	public void testStringEncodingReplacementInsideTryCatchUnwrap() throws CoreException {
 		IPackageFragment pack= context.getSourceFolder().createPackageFragment("test1", false, null); //$NON-NLS-1$

--- a/sandbox_functional_converter/src/org/sandbox/jdt/internal/corext/fix/helper/JdtLoopExtractor.java
+++ b/sandbox_functional_converter/src/org/sandbox/jdt/internal/corext/fix/helper/JdtLoopExtractor.java
@@ -146,7 +146,8 @@ public class JdtLoopExtractor {
             return;
         }
         int varDeclCount = countVariableDeclarations(statements);
-        if (varDeclCount > 1) {
+        if (varDeclCount > 1
+                && !isLinearVariableDeclarationChain(statements, variableName)) {
             addSimpleForEachTerminal(statements, builder);
             return;
         }
@@ -288,11 +289,11 @@ public class JdtLoopExtractor {
             return; // No terminal → NOT_CONVERTIBLE
         }
         
-        // Guard: if body has multiple variable declarations, use simple forEach
-        // instead of trying to decompose into map chains (which can be incorrect)
+        // Decompose multiple declarations only when every initializer consumes
+        // the current pipeline value without referring back to an earlier one.
         int varDeclCount = countVariableDeclarations(statements);
-        if (varDeclCount > 1) {
-            // Convert directly to simple forEach with body as-is
+        if (varDeclCount > 1
+                && !isLinearVariableDeclarationChain(statements, varName)) {
             addSimpleForEachTerminal(statements, builder);
             return;
         }
@@ -332,7 +333,73 @@ public class JdtLoopExtractor {
         }
         return count;
     }
-    
+
+    /**
+     * Returns whether multiple local declarations form a linear stream map chain.
+     * Each declaration becomes the sole pipeline value available to the next
+     * declaration. References to pipeline values that are no longer in scope
+     * make the decomposition unsafe and retain the original block in one
+     * {@code forEach} lambda instead.
+     */
+    private boolean isLinearVariableDeclarationChain(
+            java.util.List<Statement> statements, String initialVariableName) {
+        java.util.Set<String> unavailableVariables = new java.util.HashSet<>();
+        String currentVariableName = initialVariableName;
+        boolean declarationSequenceEnded = false;
+        int declarationCount = 0;
+
+        for (int index = 0; index < statements.size(); index++) {
+            Statement statement = statements.get(index);
+            if (!(statement instanceof VariableDeclarationStatement declaration)) {
+                if (declarationCount > 0) {
+                    declarationSequenceEnded = true;
+                    if (referencesAnyVariable(statement, unavailableVariables)) {
+                        return false;
+                    }
+                }
+                continue;
+            }
+            if (declarationSequenceEnded || index == statements.size() - 1) {
+                return false;
+            }
+
+            @SuppressWarnings("unchecked")
+            java.util.List<VariableDeclarationFragment> fragments = declaration.fragments();
+            if (fragments.size() != 1 || fragments.get(0).getInitializer() == null) {
+                return false;
+            }
+            VariableDeclarationFragment fragment = fragments.get(0);
+            if (referencesAnyVariable(fragment.getInitializer(), unavailableVariables)) {
+                return false;
+            }
+
+            unavailableVariables.add(currentVariableName);
+            currentVariableName = fragment.getName().getIdentifier();
+            declarationCount++;
+        }
+        return declarationCount > 1;
+    }
+
+    private boolean referencesAnyVariable(ASTNode node,
+            java.util.Set<String> variableNames) {
+        boolean[] found = { false };
+        node.accept(new ASTVisitor() {
+            @Override
+            public boolean visit(SimpleName name) {
+                if (!variableNames.contains(name.getIdentifier())) {
+                    return true;
+                }
+                IBinding binding = name.resolveBinding();
+                if (binding == null || binding.getKind() == IBinding.VARIABLE) {
+                    found[0] = true;
+                    return false;
+                }
+                return true;
+            }
+        });
+        return found[0];
+    }
+
     /**
      * Adds a simple forEach terminal with all statements in the body.
      * Used when the body is too complex to decompose into map/filter chains.

--- a/sandbox_functional_converter_test/src/org/sandbox/jdt/ui/tests/quickfix/LoopRefactoringComplexChainTest.java
+++ b/sandbox_functional_converter_test/src/org/sandbox/jdt/ui/tests/quickfix/LoopRefactoringComplexChainTest.java
@@ -62,8 +62,7 @@ class LoopRefactoringComplexChainTest {
 				import java.util.*;
 				class MyTest {
 					public void process(List<Integer> numbers) {
-						numbers.stream().map(num -> num * 2).map(doubled -> doubled + 10)
-								.filter(plusTen -> (plusTen < 100))
+						numbers.stream().map(num -> num * 2).map(doubled -> doubled + 10).filter(plusTen -> (plusTen < 100))
 								.forEachOrdered(plusTen -> System.out.println(plusTen));
 					}
 				}

--- a/sandbox_functional_converter_test/src/org/sandbox/jdt/ui/tests/quickfix/LoopRefactoringComplexChainTest.java
+++ b/sandbox_functional_converter_test/src/org/sandbox/jdt/ui/tests/quickfix/LoopRefactoringComplexChainTest.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.sandbox.jdt.ui.tests.quickfix;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -24,7 +23,7 @@ import org.sandbox.jdt.internal.corext.fix2.MYCleanUpConstants;
 import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
 import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava22;
 
-/** Retains the disabled multi-stage map/filter regression as an independent test. */
+/** Verifies a linear multi-stage map/filter conversion. */
 class LoopRefactoringComplexChainTest {
 
 	@RegisterExtension
@@ -33,11 +32,13 @@ class LoopRefactoringComplexChainTest {
 	/**
 	 * Tests a transformation with multiple named intermediate values.
 	 *
-	 * <p>The conversion remains disabled until the loop model can prove and render
-	 * the complete {@code map -> map -> filter} chain.</p>
+	 * <p>The loop model must prove and render the complete
+	 * {@code map -> map -> filter} chain without leaking an earlier pipeline
+	 * variable.</p>
+	 *
+	 * @see FunctionalLoopComplexPatternTest#test_MergingOperations()
 	 */
 	@Test
-	@Disabled("TODO: Complex stream chains with multiple intermediate variables not yet implemented")
 	@DisplayName("Complex chain: multiple transformations")
 	void testComplexChain() throws CoreException {
 		String input= """
@@ -64,6 +65,47 @@ class LoopRefactoringComplexChainTest {
 						numbers.stream().map(num -> num * 2).map(doubled -> doubled + 10)
 								.filter(plusTen -> (plusTen < 100))
 								.forEachOrdered(plusTen -> System.out.println(plusTen));
+					}
+				}
+				""";
+
+		IPackageFragment pack= context.getSourceFolder().createPackageFragment("test1", false, null); //$NON-NLS-1$
+		ICompilationUnit unit= pack.createCompilationUnit("MyTest.java", input, false, null); //$NON-NLS-1$
+		context.enable(MYCleanUpConstants.USEFUNCTIONALLOOP_CLEANUP);
+		context.assertRefactoringResultAsExpected(new ICompilationUnit[] { unit }, new String[] { expected }, null);
+	}
+
+	/**
+	 * Keeps the declarations together when the terminal still needs an earlier
+	 * intermediate value that would no longer exist after successive map operations.
+	 */
+	@Test
+	@DisplayName("Complex chain: stale intermediate falls back to block forEach")
+	void testStaleIntermediateVariableFallsBackToBlockForEach() throws CoreException {
+		String input= """
+				package test1;
+				import java.util.*;
+				class MyTest {
+					public void process(List<Integer> numbers) {
+						for (Integer num : numbers) {
+							int doubled = num * 2;
+							int plusTen = doubled + 10;
+							System.out.println(doubled);
+						}
+					}
+				}
+				""";
+
+		String expected= """
+				package test1;
+				import java.util.*;
+				class MyTest {
+					public void process(List<Integer> numbers) {
+						numbers.forEach(num -> {
+							int doubled = num * 2;
+							int plusTen = doubled + 10;
+							System.out.println(doubled);
+						});
 					}
 				}
 				""";

--- a/sandbox_jface_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/MissingSuperDisposePlugin.java
+++ b/sandbox_jface_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/MissingSuperDisposePlugin.java
@@ -31,14 +31,14 @@ import org.sandbox.jdt.triggerpattern.api.TriggerPattern;
 
 /**
  * TriggerPattern-based helper for detecting missing super.dispose() calls in SWT Widget subclasses.
- * 
+ *
  * <p>This plugin demonstrates the TriggerPattern framework for detecting missing super calls
  * in overridden methods. It specifically targets the common pattern in SWT/JFace where
  * Widget.dispose() must call super.dispose().</p>
- * 
+ *
  * <p><b>Pattern Detected:</b> Methods that override {@code org.eclipse.swt.widgets.Widget.dispose()}
  * but don't call {@code super.dispose()}.</p>
- * 
+ *
  * <p><b>Example:</b></p>
  * <pre>
  * class MyWidget extends Widget {
@@ -49,36 +49,36 @@ import org.sandbox.jdt.triggerpattern.api.TriggerPattern;
  *     }
  * }
  * </pre>
- * 
+ *
  * <p><b>Note:</b> This is a demonstration of the TriggerPattern API. The actual implementation
  * of override detection and body constraint checking is not yet fully implemented
  * in the TriggerPattern engine and will be completed in future updates.</p>
- * 
+ *
  * @see org.eclipse.swt.widgets.Widget#dispose()
  * @since 1.2.6
  */
 public class MissingSuperDisposePlugin {
-	
+
 	/**
 	 * Detects missing super.dispose() call in dispose() method overrides.
-	 * 
+	 *
 	 * <p>This method demonstrates the proposed API for detecting missing super calls.
 	 * When the TriggerPattern engine is fully implemented, this will automatically match
 	 * any dispose() method that overrides Widget.dispose() but doesn't call super.dispose().</p>
-	 * 
+	 *
 	 * <p>The {@code @TriggerPattern} annotation specifies:</p>
 	 * <ul>
 	 * <li>Pattern: {@code void dispose()} - matches methods with this signature</li>
 	 * <li>Kind: METHOD_DECLARATION - matches method declarations (not invocations)</li>
 	 * <li>Overrides: org.eclipse.swt.widgets.Widget - only matches if overriding Widget.dispose()</li>
 	 * </ul>
-	 * 
+	 *
 	 * <p>The {@code @BodyConstraint} annotation specifies:</p>
 	 * <ul>
 	 * <li>mustContain: {@code super.dispose()} - the pattern to look for in method body</li>
 	 * <li>negate: true - triggers when the pattern is NOT found (i.e., missing super call)</li>
 	 * </ul>
-	 * 
+	 *
 	 * @param ctx the hint context containing the matched node and rewrite utilities
 	 * @return a completion proposal to add the missing super.dispose() call, or null if not applicable
 	 */
@@ -94,37 +94,37 @@ public class MissingSuperDisposePlugin {
 	)
 	public static IJavaCompletionProposal detectMissingDisposeCall(HintContext ctx) {
 		ASTNode matchedNode = ctx.getMatch().getMatchedNode();
-		
+
 		if (!(matchedNode instanceof MethodDeclaration)) {
 			return null;
 		}
-		
+
 		MethodDeclaration method = (MethodDeclaration) matchedNode;
 		Block body = method.getBody();
-		
+
 		// Cannot add super call if there's no body (e.g., abstract/interface method)
 		if (body == null) {
 			return null;
 		}
-		
+
 		// For now, we manually check if super.dispose() is called
 		// In the future, this would be handled by the BodyConstraint annotation
 		if (containsSuperDisposeCall(body)) {
 			return null; // Super call already present
 		}
-		
+
 		// Create a fix that adds super.dispose() at the end of the method
 		AST ast = ctx.getASTRewrite().getAST();
-		
+
 		SuperMethodInvocation superCall = ast.newSuperMethodInvocation();
 		superCall.setName(ast.newSimpleName(LibStandardNames.METHOD_DISPOSE));
-		
+
 		ExpressionStatement superCallStmt = ast.newExpressionStatement(superCall);
-		
+
 		// Add the super call as the last statement in the method
 		ctx.getASTRewrite().getListRewrite(body, Block.STATEMENTS_PROPERTY)
 			.insertLast(superCallStmt, null);
-		
+
 		String label = "Add missing super.dispose() call"; //$NON-NLS-1$
 		ASTRewriteCorrectionProposal proposal = new ASTRewriteCorrectionProposal(
 			label,
@@ -133,38 +133,32 @@ public class MissingSuperDisposePlugin {
 			10, // relevance
 			(Image) null
 		);
-		
+
 		return proposal;
 	}
-	
+
 	/**
-	 * Helper method to check if a method body contains a super.dispose() call.
-	 * 
-	 * <p>This is a simple implementation that only checks top-level statements.
-	 * A production implementation would need to handle nested blocks, conditional
-	 * statements, and other control flow structures.</p>
-	 * 
-	 * @param body the method body to check
-	 * @return true if super.dispose() is called, false otherwise
+	 * Checks if a method body contains a top-level {@code super.dispose()} call.
+	 *
+	 * <p>This intentionally implements the current conservative production contract:
+	 * nested control-flow paths are not treated as an unconditional disposal call.</p>
+	 *
+	 * @param body the method body to check, or {@code null}
+	 * @return {@code true} if a top-level {@code super.dispose()} call exists
 	 */
-	private static boolean containsSuperDisposeCall(Block body) {
+	public static boolean containsSuperDisposeCall(Block body) {
 		if (body == null) {
 			return false;
 		}
-		
-		// Simple check - in production code, this would need to handle nested blocks
+
 		for (Object stmt : body.statements()) {
-			if (stmt instanceof ExpressionStatement) {
-				ExpressionStatement exprStmt = (ExpressionStatement) stmt;
-				if (exprStmt.getExpression() instanceof SuperMethodInvocation) {
-					SuperMethodInvocation superCall = (SuperMethodInvocation) exprStmt.getExpression();
-					if (LibStandardNames.METHOD_DISPOSE.equals(superCall.getName().getIdentifier())) {
-						return true;
-					}
-				}
+			if (stmt instanceof ExpressionStatement exprStmt
+					&& exprStmt.getExpression() instanceof SuperMethodInvocation superCall
+					&& LibStandardNames.METHOD_DISPOSE.equals(superCall.getName().getIdentifier())) {
+				return true;
 			}
 		}
-		
+
 		return false;
 	}
 }

--- a/sandbox_jface_cleanup_test/src/org/sandbox/jdt/ui/tests/quickfix/MissingSuperDisposePluginTest.java
+++ b/sandbox_jface_cleanup_test/src/org/sandbox/jdt/ui/tests/quickfix/MissingSuperDisposePluginTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Carsten Hammer.
+ * Copyright (c) 2025 Carsten Hammer and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -7,14 +7,12 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     Carsten Hammer - initial API and implementation
  *******************************************************************************/
 package org.sandbox.jdt.ui.tests.quickfix;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTParser;
@@ -23,339 +21,81 @@ import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.junit.jupiter.api.Test;
+import org.sandbox.jdt.internal.corext.fix.helper.MissingSuperDisposePlugin;
 
-/**
- * Tests for MissingSuperDisposePlugin.
- * 
- * <p>This test suite validates the MissingSuperDisposePlugin that detects missing
- * super.dispose() calls in SWT Widget subclasses.</p>
- * 
- * <p><b>Current Status:</b> Most tests are disabled because they require
- * TriggerPattern engine enhancements that are not yet implemented:</p>
- * <ul>
- * <li>Override detection - checking if a method overrides a specific parent class method</li>
- * <li>Body constraint validation - automatically checking for patterns in method bodies</li>
- * <li>TriggerPattern-based cleanup integration - running cleanups via @TriggerPattern annotations</li>
- * </ul>
- * 
- * <p>The tests are written following the standard cleanup test pattern used in
- * other plugins (before/after code comparison with enum-based test cases), but
- * are currently disabled until the TriggerPattern engine is complete.</p>
- * 
- * @see org.sandbox.jdt.internal.corext.fix.helper.MissingSuperDisposePlugin
- */
+/** Tests the executable dispose-call predicate used by the TriggerPattern helper. */
 public class MissingSuperDisposePluginTest {
 
-	/**
-	 * Test cases for missing super.dispose() detection.
-	 * 
-	 * <p>Following the standard pattern used in other cleanup tests (e.g., Java8CleanUpTest),
-	 * each enum value contains the input code (with missing super call) and expected output
-	 * (with super.dispose() added).</p>
-	 * 
-	 * <p><b>Note:</b> These tests are currently disabled because the TriggerPattern engine
-	 * doesn't yet support override detection and body constraints.</p>
-	 */
-	enum MissingSuperDisposeTestCases {
-		/**
-		 * Basic case: Widget subclass with dispose() that lacks super.dispose()
-		 */
-		BasicMissingSuperCall(
-"""
-package test;
-import org.eclipse.swt.widgets.Widget;
-
-public class MyWidget extends Widget {
-	@Override
-	public void dispose() {
-		cleanup();
-	}
-	
-	private void cleanup() {
-		System.out.println("Cleaning up");
-	}
-}
-""", //$NON-NLS-1$
-"""
-package test;
-import org.eclipse.swt.widgets.Widget;
-
-public class MyWidget extends Widget {
-	@Override
-	public void dispose() {
-		cleanup();
-		super.dispose();
-	}
-	
-	private void cleanup() {
-		System.out.println("Cleaning up");
-	}
-}
-"""), //$NON-NLS-1$
-		
-		/**
-		 * Case where super.dispose() already exists - should not be modified
-		 */
-		AlreadyHasSuperCall(
-"""
-package test;
-import org.eclipse.swt.widgets.Widget;
-
-public class MyWidget extends Widget {
-	@Override
-	public void dispose() {
-		cleanup();
-		super.dispose();
-	}
-	
-	private void cleanup() {
-		System.out.println("Cleaning up");
-	}
-}
-""", //$NON-NLS-1$
-"""
-package test;
-import org.eclipse.swt.widgets.Widget;
-
-public class MyWidget extends Widget {
-	@Override
-	public void dispose() {
-		cleanup();
-		super.dispose();
-	}
-	
-	private void cleanup() {
-		System.out.println("Cleaning up");
-	}
-}
-"""), //$NON-NLS-1$
-		
-		/**
-		 * Case with empty dispose() method - should add super.dispose()
-		 */
-		EmptyDisposeMethod(
-"""
-package test;
-import org.eclipse.swt.widgets.Widget;
-
-public class MyWidget extends Widget {
-	@Override
-	public void dispose() {
-	}
-}
-""", //$NON-NLS-1$
-"""
-package test;
-import org.eclipse.swt.widgets.Widget;
-
-public class MyWidget extends Widget {
-	@Override
-	public void dispose() {
-		super.dispose();
-	}
-}
-"""), //$NON-NLS-1$
-		
-		/**
-		 * Multiple Widget subclasses in same file - should fix all
-		 */
-		MultipleWidgets(
-"""
-package test;
-import org.eclipse.swt.widgets.Widget;
-
-public class MyWidget extends Widget {
-	@Override
-	public void dispose() {
-		cleanup();
-	}
-	
-	private void cleanup() {
-		System.out.println("Cleaning up");
-	}
-}
-
-class AnotherWidget extends Widget {
-	@Override
-	public void dispose() {
-		System.out.println("Disposing");
-	}
-}
-""", //$NON-NLS-1$
-"""
-package test;
-import org.eclipse.swt.widgets.Widget;
-
-public class MyWidget extends Widget {
-	@Override
-	public void dispose() {
-		cleanup();
-		super.dispose();
-	}
-	
-	private void cleanup() {
-		System.out.println("Cleaning up");
-	}
-}
-
-class AnotherWidget extends Widget {
-	@Override
-	public void dispose() {
-		System.out.println("Disposing");
-		super.dispose();
-	}
-}
-"""); //$NON-NLS-1$
-		
-		public final String given;
-		public final String expected;
-		
-		MissingSuperDisposeTestCases(String given, String expected) {
-			this.given = given;
-			this.expected = expected;
-		}
-	}
-
-	/**
-	 * Tests that containsSuperDisposeCall correctly identifies super.dispose() calls.
-	 * 
-	 * <p>This test verifies the helper method can detect super.dispose() in a method body.</p>
-	 */
 	@Test
-	public void testContainsSuperDisposeCall_Found() {
-		String code = """
-			class Widget {
-				void dispose() {
-					cleanup();
-					super.dispose();
+	public void detectsTopLevelSuperDisposeCall() {
+		Block methodBody= getMethodBody("""
+				class Widget {
+					void dispose() {
+						cleanup();
+						super.dispose();
+					}
 				}
-			}
-			""";
-		
-		Block methodBody = getMethodBody(code, "dispose");
-		assertNotNull(methodBody, "Method body should not be null");
-		
-		// Note: To properly test the private containsSuperDisposeCall method,
-		// we would need to either:
-		// 1. Make it package-private/protected for testing
-		// 2. Use reflection
-		// 3. Test it indirectly through the public API (when available)
-		// 
-		// For now, this test documents the expected behavior.
-		// The actual assertion would be:
-		// assertTrue(MissingSuperDisposePlugin.containsSuperDisposeCall(methodBody));
+				""", "dispose"); //$NON-NLS-1$
+
+		assertTrue(MissingSuperDisposePlugin.containsSuperDisposeCall(methodBody));
 	}
 
-	/**
-	 * Tests that containsSuperDisposeCall returns false when super.dispose() is not present.
-	 */
 	@Test
-	public void testContainsSuperDisposeCall_NotFound() {
-		String code = """
-			class Widget {
-				void dispose() {
-					cleanup();
-					// Missing super.dispose()
+	public void rejectsBodyWithoutSuperDisposeCall() {
+		Block methodBody= getMethodBody("""
+				class Widget {
+					void dispose() {
+						cleanup();
+					}
 				}
-			}
-			""";
-		
-		Block methodBody = getMethodBody(code, "dispose");
-		assertNotNull(methodBody, "Method body should not be null");
-		
-		// Expected: containsSuperDisposeCall should return false
+				""", "dispose"); //$NON-NLS-1$
+
+		assertFalse(MissingSuperDisposePlugin.containsSuperDisposeCall(methodBody));
 	}
 
-	/**
-	 * Tests that containsSuperDisposeCall handles null body (abstract/interface methods).
-	 */
 	@Test
-	public void testContainsSuperDisposeCall_NullBody() {
-		String code = """
-			abstract class Widget {
-				abstract void dispose();
-			}
-			""";
-		
-		Block methodBody = getMethodBody(code, "dispose");
-		assertEquals(null, methodBody, "Abstract method should have null body");
-		
-		// Expected: containsSuperDisposeCall should handle null gracefully
+	public void doesNotTreatConditionalSuperCallAsUnconditional() {
+		Block methodBody= getMethodBody("""
+				class Widget {
+					void dispose() {
+						if (ready()) {
+							super.dispose();
+						}
+					}
+				}
+				""", "dispose"); //$NON-NLS-1$
+
+		assertFalse(MissingSuperDisposePlugin.containsSuperDisposeCall(methodBody));
 	}
 
-	/**
-	 * Tests pattern matching for dispose() methods.
-	 * 
-	 * <p>This test validates that the TriggerPattern framework can match
-	 * dispose() method declarations. This is a prerequisite for the
-	 * MissingSuperDisposePlugin to work.</p>
-	 */
 	@Test
-	public void testDisposeMethodPatternMatching() {
-		String code = """
-			class MyWidget {
-				void dispose() {
-					cleanup();
+	public void handlesBodylessMethod() {
+		Block methodBody= getMethodBody("""
+				abstract class Widget {
+					abstract void dispose();
 				}
-				
-				void setup() {
-					initialize();
-				}
-			}
-			""";
-		
-		CompilationUnit cu = parse(code);
-		
-		// Count dispose methods
-		final int[] disposeCount = {0};
-		cu.accept(new org.eclipse.jdt.core.dom.ASTVisitor() {
-			@Override
-			public boolean visit(MethodDeclaration node) {
-				if ("dispose".equals(node.getName().getIdentifier())) { //$NON-NLS-1$
-					disposeCount[0]++;
-				}
-				return super.visit(node);
-			}
-		});
-		
-		assertEquals(1, disposeCount[0], "Should find one dispose method");
+				""", "dispose"); //$NON-NLS-1$
+
+		assertNull(methodBody);
+		assertFalse(MissingSuperDisposePlugin.containsSuperDisposeCall(methodBody));
 	}
 
-	/**
-	 * Helper method to parse code and get a method body.
-	 * 
-	 * @param code Java source code
-	 * @param methodName the method name to find
-	 * @return the Block (method body) or null if not found or abstract
-	 */
-	private Block getMethodBody(String code, String methodName) {
-		CompilationUnit cu = parse(code);
-		
-		// Find the first type declaration
-		if (cu.types().isEmpty()) {
+	private static Block getMethodBody(String code, String methodName) {
+		CompilationUnit unit= parse(code);
+		if (unit.types().isEmpty()) {
 			return null;
 		}
-		
-		TypeDeclaration typeDecl = (TypeDeclaration) cu.types().get(0);
-		
-		// Find the method
-		for (MethodDeclaration method : typeDecl.getMethods()) {
+		TypeDeclaration type= (TypeDeclaration) unit.types().get(0);
+		for (MethodDeclaration method : type.getMethods()) {
 			if (methodName.equals(method.getName().getIdentifier())) {
 				return method.getBody();
 			}
 		}
-		
 		return null;
 	}
 
-	/**
-	 * Helper method to parse Java code into a CompilationUnit.
-	 * 
-	 * @param code Java source code
-	 * @return parsed CompilationUnit
-	 */
-	private CompilationUnit parse(String code) {
-		ASTParser parser = ASTParser.newParser(AST.getJLSLatest());
+	private static CompilationUnit parse(String code) {
+		ASTParser parser= ASTParser.newParser(AST.getJLSLatest());
 		parser.setSource(code.toCharArray());
 		parser.setKind(ASTParser.K_COMPILATION_UNIT);
 		return (CompilationUnit) parser.createAST(null);

--- a/sandbox_jface_cleanup_test/src/org/sandbox/jdt/ui/tests/quickfix/MissingSuperDisposePluginTest.java
+++ b/sandbox_jface_cleanup_test/src/org/sandbox/jdt/ui/tests/quickfix/MissingSuperDisposePluginTest.java
@@ -22,7 +22,6 @@ import org.eclipse.jdt.core.dom.Block;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -215,31 +214,6 @@ class AnotherWidget extends Widget {
 			this.given = given;
 			this.expected = expected;
 		}
-	}
-
-	/**
-	 * Disabled: Full cleanup test following the standard pattern.
-	 * 
-	 * <p>This test would run the MissingSuperDisposePlugin cleanup on code with
-	 * missing super.dispose() calls and verify the fix is applied correctly.</p>
-	 * 
-	 * <p><b>Requires:</b> TriggerPattern engine with override detection and body constraints.</p>
-	 * 
-	 * <p><b>Pattern:</b> Same as Java8CleanUpTest - parameterized test with enum cases,
-	 * before/after code comparison.</p>
-	 */
-	@Test
-	@Disabled("Requires TriggerPattern engine enhancements: override detection and body constraints")
-	public void testMissingSuperDisposeCleanup() {
-		// Pattern when implemented:
-		// @ParameterizedTest
-		// @EnumSource(MissingSuperDisposeTestCases.class)
-		// public void testMissingSuperDisposeCleanup(MissingSuperDisposeTestCases test) throws CoreException {
-		//     IPackageFragment pack = context.getSourceFolder().createPackageFragment("test", false, null);
-		//     ICompilationUnit cu = pack.createCompilationUnit("MyWidget.java", test.given, false, null);
-		//     context.enable(MYCleanUpConstants.MISSING_SUPER_DISPOSE_CLEANUP); // Constant TBD
-		//     context.assertRefactoringResultAsExpected(new ICompilationUnit[] {cu}, new String[] {test.expected}, null);
-		// }
 	}
 
 	/**

--- a/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/MigrationCombinationsTest.java
+++ b/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/MigrationCombinationsTest.java
@@ -19,7 +19,6 @@ import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.junit.JUnitCore;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.sandbox.jdt.internal.corext.fix2.MYCleanUpConstants;
@@ -207,66 +206,6 @@ public class MyTest {
 		File newFile = Files.createFile(tempFolder.resolve("myfile.txt")).toFile();
 	}
 }
-				"""
-		}, null);
-	}
-
-	@Disabled("@RunWith(Suite.class) to @Suite transformation not fully working - actual output retains @RunWith")
-	@Test
-	public void migrates_suite_with_assertions_and_lifecycle() throws CoreException {
-		IPackageFragment pack = fRoot.createPackageFragment("test", true, null);
-		ICompilationUnit cu = pack.createCompilationUnit("MyTest.java",
-				"""
-				package test;
-				import static org.junit.Assert.*;
-				import org.junit.Before;
-				import org.junit.Test;
-				import org.junit.runner.RunWith;
-				import org.junit.runners.Suite;
-				
-				@RunWith(Suite.class)
-				@Suite.SuiteClasses({MyTest.class})
-				public class MyTest {
-					@Before
-					public void setUp() {
-					}
-					
-					@Test
-					public void testSomething() {
-						assertEquals("expected", "actual");
-					}
-				}
-				""", false, null);
-
-		context.enable(MYCleanUpConstants.JUNIT_CLEANUP);
-		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_4_ASSERT);
-		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_4_BEFORE);
-		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_4_TEST);
-		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_4_SUITE);
-		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_4_RUNWITH);
-
-		context.assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] {
-				"""
-				package test;
-				import static org.junit.jupiter.api.Assertions.*;
-				
-				import org.junit.jupiter.api.BeforeEach;
-				import org.junit.jupiter.api.Test;
-				import org.junit.platform.suite.api.SelectClasses;
-				import org.junit.platform.suite.api.Suite;
-				
-				@Suite
-				@SelectClasses({MyTest.class})
-				public class MyTest {
-					@BeforeEach
-					public void setUp() {
-					}
-					
-					@Test
-					public void testSomething() {
-						assertEquals("expected", "actual");
-					}
-				}
 				"""
 		}, null);
 	}

--- a/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/MigrationRulesToExtensionsTest.java
+++ b/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/MigrationRulesToExtensionsTest.java
@@ -19,11 +19,8 @@ import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.junit.JUnitCore;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
 import org.sandbox.jdt.internal.corext.fix2.MYCleanUpConstants;
 import org.sandbox.jdt.ui.tests.quickfix.rules.AbstractEclipseJava;
 import org.sandbox.jdt.ui.tests.quickfix.rules.EclipseJava17;
@@ -42,22 +39,6 @@ public class MigrationRulesToExtensionsTest {
 	@BeforeEach
 	public void setup() throws CoreException {
 		fRoot = context.createClasspathForJUnit(JUnitCore.JUNIT4_CONTAINER_PATH);
-	}
-
-	@Disabled("Rule migration parameterized test - TemporaryFolder output mismatch, ErrorCollector requires hamcrest not on test classpath")
-	@ParameterizedTest
-	@EnumSource(RuleCases.class)
-	public void migrates_junit4_rules_to_junit5_extensions(RuleCases testCase) throws CoreException {
-		IPackageFragment pack = fRoot.createPackageFragment("test", true, null);
-		ICompilationUnit cu = pack.createCompilationUnit("MyTest.java", testCase.given, true, null);
-		context.enable(MYCleanUpConstants.JUNIT_CLEANUP);
-		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_4_TEST);
-		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_4_RULETEMPORARYFOLDER);
-		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_4_RULETESTNAME);
-		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_4_RULEEXTERNALRESOURCE);
-		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_4_RULETIMEOUT);
-		context.enable(MYCleanUpConstants.JUNIT_CLEANUP_4_RULEERRORCOLLECTOR);
-		context.assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { testCase.expected }, null);
 	}
 
 	@Test

--- a/sandbox_platform_helper_test/src/org/sandbox/jdt/ui/tests/quickfix/Java9CleanUpTest.java
+++ b/sandbox_platform_helper_test/src/org/sandbox/jdt/ui/tests/quickfix/Java9CleanUpTest.java
@@ -3,7 +3,6 @@ package org.sandbox.jdt.ui.tests.quickfix;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IPackageFragment;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -84,7 +83,6 @@ public class Java9CleanUpTest {
 		}
 	}
 
-	@Disabled("Temporary disable - import handling needs investigation")
 	@ParameterizedTest
 	@EnumSource(PlatformStatusPatterns.class)
 	public void testPlatformStatusParametrized(PlatformStatusPatterns test) throws CoreException {


### PR DESCRIPTION
## Summary

Resolve every real `@Disabled` entry reported by the lexical JUnit inventory and retire tests that contained no executable behavioral assertion.

### Re-enabled behavior contracts

- `ClassInstanceCreationVisitorTest.testChainedVisitorWithoutFirstMatchBug()` verifies that an empty visitor stage does not suppress later independent AST visitors.
- `ExplicitEncodingCleanUpTest.testStringEncodingReplacementInsideTryCatchUnwrap()` verifies charset replacement, `UnsupportedEncodingException` try/catch unwrapping, and removal of the obsolete exception import.
- `LoopRefactoringComplexChainTest.testComplexChain()` verifies a proven `map -> map -> filter -> forEachOrdered` chain.
- `Java9CleanUpTest.testPlatformStatusParametrized()` verifies the `Status.warning/error/info` factory conversion.
- `MissingSuperDisposePluginTest` executes the production predicate for present, absent, conditional and bodyless `super.dispose()` cases instead of parsing source while leaving the intended assertions commented out.

### Implementation changes

- advance `ASTProcessor` to the next registered visitor when the current visitor finds no node in the selected scope;
- allow multiple loop-local declarations to become successive `map` operations only when they form a linear pipeline;
- reject decomposition when a later initializer, filter, or terminal still references a pipeline value that is no longer available, retaining the block-based `forEach` fallback;
- centralize encoding try/catch unwrapping in `AbstractExplicitEncoding`, so every encoding handler uses the same import and formatting contract;
- replace a removable encoding `try/catch` as one source-preserving statement sequence, retaining comments, line endings and the parent block's indentation;
- remove `java.io.UnsupportedEncodingException` explicitly only when no bound or recovered type reference survives outside the deleted catch clause;
- verify the shared behavior for both `new String(..., "UTF-8")` and `String.getBytes("UTF-8")`, including multi-statement formatting and the counter-case where another exception type reference requires the import;
- expose the existing predicate on the internal `MissingSuperDisposePlugin` class for direct executable tests without widening any exported package API.

### Removed obsolete tests

- remove the empty `MissingSuperDispose` method and unused example matrix that contained only an implementation sketch;
- remove the suite combination case already covered by active `JUnitSuiteCombinedRewriteIsolationTest`;
- remove the aggregate rule matrix already covered by active `JUnitRuleCasesActivationTest` over the same `RuleCases` enum.

## Inventory result

The latest lexical source inventory reports 1,301 enabled tests and no disabled tests. The Maven and distribution workflows remain the authoritative execution gates.