### PR TITLE
Harden external repository service lifecycle

### DIFF
--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/repository/ExternalHibernateRepositoryService.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/repository/ExternalHibernateRepositoryService.java
@@ -11,9 +11,11 @@
 package org.eclipse.jgit.server.repository;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.jgit.lib.Repository;
 
@@ -33,7 +35,9 @@ import io.github.carstenartur.jgit.storage.hibernate.RepositoryName;
 public final class ExternalHibernateRepositoryService implements SandboxRepositoryService {
 
 	private final HibernateRepositoryFactory repositoryFactory;
-	private final Map<String, HibernateGitStorage> storages= new ConcurrentHashMap<>();
+	private final Object lifecycleLock= new Object();
+	private final Map<String, HibernateGitStorage> storages= new LinkedHashMap<>();
+	private boolean closed;
 
 	/** Creates an adapter for the released public repository factory. */
 	public ExternalHibernateRepositoryService(HibernateRepositoryFactory repositoryFactory) {
@@ -42,33 +46,51 @@ public final class ExternalHibernateRepositoryService implements SandboxReposito
 
 	@Override
 	public Repository openOrCreate(String name) throws IOException {
-		return storage(name).repository();
+		synchronized (lifecycleLock) {
+			return storageLocked(name).repository();
+		}
 	}
 
 	@Override
 	public SandboxRepositoryInfo info(String name) throws IOException {
-		String normalized= normalize(name);
-		Repository repository= storage(normalized).repository();
-		return new SandboxRepositoryInfo(normalized, repository.getGitwebDescription());
+		synchronized (lifecycleLock) {
+			String normalized= normalize(name);
+			Repository repository= storageLocked(normalized).repository();
+			return new SandboxRepositoryInfo(normalized, repository.getGitwebDescription());
+		}
 	}
 
 	@Override
 	public SandboxRepositoryInfo setDescription(String name, String description) throws IOException {
-		String normalized= normalize(name);
-		Repository repository= storage(normalized).repository();
-		repository.setGitwebDescription(description);
-		return new SandboxRepositoryInfo(normalized, repository.getGitwebDescription());
+		synchronized (lifecycleLock) {
+			String normalized= normalize(name);
+			Repository repository= storageLocked(normalized).repository();
+			repository.setGitwebDescription(description);
+			return new SandboxRepositoryInfo(normalized, repository.getGitwebDescription());
+		}
 	}
 
 	@Override
 	public boolean isOpen(String name) {
-		return storages.containsKey(normalize(name));
+		synchronized (lifecycleLock) {
+			return !closed && storages.containsKey(normalize(name));
+		}
 	}
 
 	@Override
 	public void close() {
+		List<HibernateGitStorage> storagesToClose;
+		synchronized (lifecycleLock) {
+			if (closed) {
+				return;
+			}
+			closed= true;
+			storagesToClose= new ArrayList<>(storages.values());
+			storages.clear();
+		}
+
 		RuntimeException failure= null;
-		for (HibernateGitStorage storage : storages.values()) {
+		for (HibernateGitStorage storage : storagesToClose) {
 			try {
 				storage.close();
 			} catch (RuntimeException exception) {
@@ -79,13 +101,15 @@ public final class ExternalHibernateRepositoryService implements SandboxReposito
 				}
 			}
 		}
-		storages.clear();
 		if (failure != null) {
 			throw failure;
 		}
 	}
 
-	private HibernateGitStorage storage(String name) {
+	private HibernateGitStorage storageLocked(String name) {
+		if (closed) {
+			throw new IllegalStateException("Repository service is already closed."); //$NON-NLS-1$
+		}
 		String normalized= normalize(name);
 		return storages.computeIfAbsent(normalized,
 				key -> repositoryFactory.open(new RepositoryName(key)));

--- a/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/config/ExternalRepositoryLifecycleH2Test.java
+++ b/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/config/ExternalRepositoryLifecycleH2Test.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jgit.server.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.ObjectInserter;
+import org.eclipse.jgit.lib.RefUpdate;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.server.repository.SandboxRepositoryService;
+import org.junit.Test;
+
+/** Real H2 lifecycle coverage for the released Core-backed repository adapter. */
+public class ExternalRepositoryLifecycleH2Test {
+
+	private static final AtomicInteger DATABASE_COUNTER= new AtomicInteger();
+	private static final String MAIN_REF= "refs/heads/main"; //$NON-NLS-1$
+
+	@Test
+	public void normalizesIsolatesAndReopensRepositories() throws Exception {
+		String url= databaseUrl();
+		ObjectId storedObject;
+		Properties createProperties= properties(url, "create"); //$NON-NLS-1$
+
+		try (ServerPersistenceContext context=
+				new ExternalServerPersistenceContext(createProperties)) {
+			SandboxRepositoryService repositories= context.repositoryService();
+			Repository first= repositories.openOrCreate("/first.git"); //$NON-NLS-1$
+			Repository alias= repositories.openOrCreate("first"); //$NON-NLS-1$
+			Repository second= repositories.openOrCreate("second"); //$NON-NLS-1$
+
+			assertSame(first, alias);
+			assertTrue(repositories.isOpen("first.git")); //$NON-NLS-1$
+			assertTrue(repositories.isOpen("/second")); //$NON-NLS-1$
+
+			try (ObjectInserter inserter= first.newObjectInserter()) {
+				storedObject= inserter.insert(Constants.OBJ_BLOB,
+						"external-core-lifecycle".getBytes(StandardCharsets.UTF_8)); //$NON-NLS-1$
+				inserter.flush();
+			}
+			RefUpdate update= first.updateRef(MAIN_REF);
+			update.setNewObjectId(storedObject);
+			assertEquals(RefUpdate.Result.NEW, update.update());
+			assertNull(second.exactRef(MAIN_REF));
+		}
+
+		Properties validateProperties= properties(url, "validate"); //$NON-NLS-1$
+		try (ServerPersistenceContext context=
+				new ExternalServerPersistenceContext(validateProperties)) {
+			Repository reopened= context.repositoryService().openOrCreate("first.git"); //$NON-NLS-1$
+			Repository isolated= context.repositoryService().openOrCreate("second"); //$NON-NLS-1$
+
+			assertEquals(storedObject, reopened.resolve(MAIN_REF));
+			assertNull(isolated.exactRef(MAIN_REF));
+		}
+	}
+
+	private static Properties properties(String url, String ddlAuto) {
+		Properties properties= new Properties();
+		properties.setProperty("hibernate.connection.url", url); //$NON-NLS-1$
+		properties.setProperty("hibernate.connection.username", "sa"); //$NON-NLS-1$ //$NON-NLS-2$
+		properties.setProperty("hibernate.connection.password", ""); //$NON-NLS-1$ //$NON-NLS-2$
+		properties.setProperty("hibernate.connection.driver_class", "org.h2.Driver"); //$NON-NLS-1$ //$NON-NLS-2$
+		properties.setProperty("hibernate.dialect", "org.hibernate.dialect.H2Dialect"); //$NON-NLS-1$ //$NON-NLS-2$
+		properties.setProperty("hibernate.hbm2ddl.auto", ddlAuto); //$NON-NLS-1$
+		properties.setProperty("hibernate.show_sql", "false"); //$NON-NLS-1$ //$NON-NLS-2$
+		properties.setProperty("hibernate.search.backend.type", "lucene"); //$NON-NLS-1$ //$NON-NLS-2$
+		properties.setProperty("hibernate.search.backend.directory.type", "local-heap"); //$NON-NLS-1$ //$NON-NLS-2$
+		properties.setProperty("hibernate.search.backend.analysis.configurer", //$NON-NLS-1$
+				"class:org.eclipse.jgit.storage.hibernate.search.JavaSourceAnalysisConfigurer"); //$NON-NLS-1$
+		properties.setProperty("hibernate.cache.use_second_level_cache", "false"); //$NON-NLS-1$ //$NON-NLS-2$
+		properties.setProperty("hibernate.connection.provider_class", //$NON-NLS-1$
+				"org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl"); //$NON-NLS-1$
+		return properties;
+	}
+
+	private static String databaseUrl() {
+		return "jdbc:h2:mem:external-repository-lifecycle-" //$NON-NLS-1$
+				+ DATABASE_COUNTER.incrementAndGet() + ";DB_CLOSE_DELAY=-1"; //$NON-NLS-1$
+	}
+}

--- a/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/repository/ExternalHibernateRepositoryServiceTest.java
+++ b/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/repository/ExternalHibernateRepositoryServiceTest.java
@@ -87,6 +87,44 @@ public class ExternalHibernateRepositoryServiceTest {
 	}
 
 	@Test
+	public void shutdownClosesAStorageWhoseOpenWasAlreadyInFlight() throws Exception {
+		FakeFactory factory= new FakeFactory();
+		factory.openStarted= new CountDownLatch(1);
+		factory.allowOpen= new CountDownLatch(1);
+		ExternalHibernateRepositoryService service= new ExternalHibernateRepositoryService(factory);
+		ExecutorService executor= Executors.newFixedThreadPool(2);
+		Future<Repository> opening= executor.submit(() -> service.openOrCreate("demo")); //$NON-NLS-1$
+		Future<?> closing= null;
+		try {
+			assertTrue(factory.openStarted.await(5, TimeUnit.SECONDS));
+			CountDownLatch closeThreadStarted= new CountDownLatch(1);
+			closing= executor.submit(() -> {
+				closeThreadStarted.countDown();
+				service.close();
+			});
+			assertTrue(closeThreadStarted.await(5, TimeUnit.SECONDS));
+
+			factory.allowOpen.countDown();
+			Repository opened= opening.get(5, TimeUnit.SECONDS);
+			closing.get(5, TimeUnit.SECONDS);
+
+			FakeStorage storage= factory.storages.get("demo"); //$NON-NLS-1$
+			assertSame(opened, storage.repository());
+			assertTrue(storage.closed);
+			assertEquals(1, storage.closeCalls.get());
+			assertFalse(service.isOpen("demo")); //$NON-NLS-1$
+			assertThrows(IllegalStateException.class,
+					() -> service.openOrCreate("demo")); //$NON-NLS-1$
+		} finally {
+			factory.allowOpen.countDown();
+			if (closing != null) {
+				closing.get(5, TimeUnit.SECONDS);
+			}
+			executor.shutdownNow();
+		}
+	}
+
+	@Test
 	public void readsAndUpdatesDescriptionThroughPublicRepository() throws Exception {
 		FakeFactory factory= new FakeFactory();
 		try (ExternalHibernateRepositoryService service= new ExternalHibernateRepositoryService(factory)) {
@@ -164,10 +202,23 @@ public class ExternalHibernateRepositoryServiceTest {
 
 		private final Map<String, FakeStorage> storages= new LinkedHashMap<>();
 		private final AtomicInteger openCalls= new AtomicInteger();
+		private CountDownLatch openStarted;
+		private CountDownLatch allowOpen;
 
 		@Override
 		public HibernateGitStorage open(RepositoryName repositoryName) {
 			openCalls.incrementAndGet();
+			if (openStarted != null) {
+				openStarted.countDown();
+			}
+			if (allowOpen != null) {
+				try {
+					allowOpen.await();
+				} catch (InterruptedException exception) {
+					Thread.currentThread().interrupt();
+					throw new IllegalStateException("Interrupted while opening storage.", exception); //$NON-NLS-1$
+				}
+			}
 			FakeStorage storage= new FakeStorage(new InMemoryRepository(
 					new DfsRepositoryDescription(repositoryName.value())));
 			storages.put(repositoryName.value(), storage);

--- a/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/repository/ExternalHibernateRepositoryServiceTest.java
+++ b/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/repository/ExternalHibernateRepositoryServiceTest.java
@@ -16,8 +16,16 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.jgit.internal.storage.dfs.DfsRepositoryDescription;
 import org.eclipse.jgit.internal.storage.dfs.InMemoryRepository;
@@ -42,11 +50,40 @@ public class ExternalHibernateRepositoryServiceTest {
 
 		assertSame(first, second);
 		assertEquals(1, factory.storages.size());
+		assertEquals(1, factory.openCalls.get());
 		assertTrue(factory.storages.containsKey("demo")); //$NON-NLS-1$
 		assertTrue(service.isOpen("demo.git")); //$NON-NLS-1$
 
 		service.close();
 		assertTrue(factory.storages.get("demo").closed); //$NON-NLS-1$
+	}
+
+	@Test
+	public void concurrentNormalizedOpensShareOneFactoryHandle() throws Exception {
+		FakeFactory factory= new FakeFactory();
+		ExternalHibernateRepositoryService service= new ExternalHibernateRepositoryService(factory);
+		ExecutorService executor= Executors.newFixedThreadPool(8);
+		CountDownLatch start= new CountDownLatch(1);
+		try {
+			List<Future<Repository>> futures= new ArrayList<>();
+			for (int index= 0; index < 32; index++) {
+				String name= index % 2 == 0 ? "/demo.git" : "demo"; //$NON-NLS-1$ //$NON-NLS-2$
+				futures.add(executor.submit(() -> {
+					start.await();
+					return service.openOrCreate(name);
+				}));
+			}
+			start.countDown();
+			Repository first= futures.get(0).get();
+			for (Future<Repository> future : futures) {
+				assertSame(first, future.get());
+			}
+			assertEquals(1, factory.openCalls.get());
+			assertEquals(1, factory.storages.size());
+		} finally {
+			executor.shutdownNow();
+			service.close();
+		}
 	}
 
 	@Test
@@ -62,28 +99,75 @@ public class ExternalHibernateRepositoryServiceTest {
 	}
 
 	@Test
+	public void closeIsIdempotentAndRejectsFurtherRepositoryAccess() throws Exception {
+		FakeFactory factory= new FakeFactory();
+		ExternalHibernateRepositoryService service= new ExternalHibernateRepositoryService(factory);
+		service.openOrCreate("demo"); //$NON-NLS-1$
+
+		service.close();
+		service.close();
+
+		assertFalse(service.isOpen("demo")); //$NON-NLS-1$
+		assertEquals(1, factory.storages.get("demo").closeCalls.get()); //$NON-NLS-1$
+		assertThrows(IllegalStateException.class,
+				() -> service.openOrCreate("demo")); //$NON-NLS-1$
+		assertThrows(IllegalStateException.class,
+				() -> service.info("demo")); //$NON-NLS-1$
+		assertThrows(IllegalStateException.class,
+				() -> service.setDescription("demo", "description")); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	@Test
+	public void closeDoesNotHoldLifecycleLockWhileClosingStorage() throws Exception {
+		FakeFactory factory= new FakeFactory();
+		ExternalHibernateRepositoryService service= new ExternalHibernateRepositoryService(factory);
+		service.openOrCreate("demo"); //$NON-NLS-1$
+		FakeStorage storage= factory.storages.get("demo"); //$NON-NLS-1$
+		storage.closeStarted= new CountDownLatch(1);
+		storage.allowClose= new CountDownLatch(1);
+		ExecutorService executor= Executors.newSingleThreadExecutor();
+		Future<?> closing= executor.submit(service::close);
+		try {
+			assertTrue(storage.closeStarted.await(5, TimeUnit.SECONDS));
+			assertFalse(service.isOpen("demo")); //$NON-NLS-1$
+			assertThrows(IllegalStateException.class,
+					() -> service.openOrCreate("demo")); //$NON-NLS-1$
+		} finally {
+			storage.allowClose.countDown();
+			closing.get(5, TimeUnit.SECONDS);
+			executor.shutdownNow();
+		}
+	}
+
+	@Test
 	public void closesEveryStorageWhenOneCloseFails() throws Exception {
 		FakeFactory factory= new FakeFactory();
 		ExternalHibernateRepositoryService service= new ExternalHibernateRepositoryService(factory);
 		service.openOrCreate("first"); //$NON-NLS-1$
 		service.openOrCreate("second"); //$NON-NLS-1$
 		factory.storages.get("first").closeFailure= new IllegalStateException("first close failed"); //$NON-NLS-1$ //$NON-NLS-2$
+		factory.storages.get("second").closeFailure= new IllegalArgumentException("second close failed"); //$NON-NLS-1$ //$NON-NLS-2$
 
 		IllegalStateException failure= assertThrows(IllegalStateException.class, service::close);
 
 		assertEquals("first close failed", failure.getMessage()); //$NON-NLS-1$
+		assertEquals(1, failure.getSuppressed().length);
+		assertEquals("second close failed", failure.getSuppressed()[0].getMessage()); //$NON-NLS-1$
 		assertTrue(factory.storages.get("first").closed); //$NON-NLS-1$
 		assertTrue(factory.storages.get("second").closed); //$NON-NLS-1$
 		assertFalse(service.isOpen("first")); //$NON-NLS-1$
 		assertFalse(service.isOpen("second")); //$NON-NLS-1$
+		service.close();
 	}
 
 	private static final class FakeFactory implements HibernateRepositoryFactory {
 
 		private final Map<String, FakeStorage> storages= new LinkedHashMap<>();
+		private final AtomicInteger openCalls= new AtomicInteger();
 
 		@Override
 		public HibernateGitStorage open(RepositoryName repositoryName) {
+			openCalls.incrementAndGet();
 			FakeStorage storage= new FakeStorage(new InMemoryRepository(
 					new DfsRepositoryDescription(repositoryName.value())));
 			storages.put(repositoryName.value(), storage);
@@ -99,8 +183,11 @@ public class ExternalHibernateRepositoryServiceTest {
 	private static final class FakeStorage implements HibernateGitStorage {
 
 		private final Repository repository;
+		private final AtomicInteger closeCalls= new AtomicInteger();
 		private boolean closed;
 		private RuntimeException closeFailure;
+		private CountDownLatch closeStarted;
+		private CountDownLatch allowClose;
 
 		private FakeStorage(Repository repository) {
 			this.repository= repository;
@@ -113,6 +200,18 @@ public class ExternalHibernateRepositoryServiceTest {
 
 		@Override
 		public void close() {
+			closeCalls.incrementAndGet();
+			if (closeStarted != null) {
+				closeStarted.countDown();
+			}
+			if (allowClose != null) {
+				try {
+					allowClose.await();
+				} catch (InterruptedException exception) {
+					Thread.currentThread().interrupt();
+					throw new IllegalStateException("Interrupted while closing storage.", exception); //$NON-NLS-1$
+				}
+			}
 			closed= true;
 			repository.close();
 			if (closeFailure != null) {


### PR DESCRIPTION
## Summary

Complete the next Core-backed `SandboxRepositoryService` lifecycle slice from #1303.

- serialize repository open/metadata operations with service shutdown;
- prevent a handle opened concurrently with shutdown from being removed without being closed;
- make service shutdown idempotent;
- reject repository access after the application-owned service has closed;
- preserve close-all behavior and aggregate multiple close failures;
- verify concurrent normalized opens share exactly one factory-owned storage handle;
- exercise the exact blocked-open/shutdown interleaving and prove the newly created handle is closed exactly once;
- verify the released Core adapter against real H2 storage: normalized identity, two-repository isolation, persisted Git objects/refs, close and reopen under schema validation.

## Safety boundary

This PR does not switch normal server startup to the external persistence context, migrate Search/Java projections, alter production schemas, or delete copied storage code. It hardens and exercises the already prepared public-Core adapter so the later cut-over has deterministic handle ownership and restart evidence.

Refs #1303