### PR TITLE
Verify JUnit 3 migration across JDT runtime loaders

### DIFF
--- a/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/JUnit3CoordinatedHierarchyMigrationTest.java
+++ b/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/JUnit3CoordinatedHierarchyMigrationTest.java
@@ -46,8 +46,8 @@ public class JUnit3CoordinatedHierarchyMigrationTest {
 
 	@BeforeEach
 	public void setup() throws CoreException {
-		// Keep Vintage and Jupiter on one classpath so the configured JDT finder and
-		// runtime launch kind are the same before and after the migration.
+		// Keep JUnit 3, Vintage and Jupiter on one classpath. The baseline is launched
+		// by JDT's JUnit 3 loader and the migrated code by JDT's JUnit 5 loader.
 		root= context.createClasspathForJUnit(JUnitCore.JUNIT5_CONTAINER_PATH);
 	}
 
@@ -85,7 +85,8 @@ public class JUnit3CoordinatedHierarchyMigrationTest {
 		IType launchTarget= concrete.findPrimaryType();
 		assertNotNull(launchTarget);
 		JUnitTestTypeInventory before= JUnitTestTypeInventory.capture(context.getJavaProject(), null);
-		ExecutionTreeSnapshot runtimeBefore= JUnitRuntimeTestTree.capture(launchTarget);
+		ExecutionTreeSnapshot runtimeBefore= JUnitRuntimeTestTree.capture(launchTarget,
+				JUnitRuntimeTestTree.TestKind.JUNIT3);
 		assertTrue(runtimeBefore.successful(), () -> "JUnit 3 baseline failed: " + runtimeBefore.roots()); //$NON-NLS-1$
 		enableMigration();
 		context.assertRefactoringResultAsExpectedNormalizingWhitespace(
@@ -130,7 +131,7 @@ public class JUnit3CoordinatedHierarchyMigrationTest {
 						"""
 				}, null);
 		assertFinderInventoryUnchanged(before);
-		assertRuntimeTreeUnchanged(runtimeBefore, launchTarget);
+		assertRuntimeTreePreservedAcrossLoaders(runtimeBefore, launchTarget);
 	}
 
 	@Test
@@ -168,7 +169,8 @@ public class JUnit3CoordinatedHierarchyMigrationTest {
 		IType launchTarget= concrete.findPrimaryType();
 		assertNotNull(launchTarget);
 		JUnitTestTypeInventory before= JUnitTestTypeInventory.capture(context.getJavaProject(), null);
-		ExecutionTreeSnapshot runtimeBefore= JUnitRuntimeTestTree.capture(launchTarget);
+		ExecutionTreeSnapshot runtimeBefore= JUnitRuntimeTestTree.capture(launchTarget,
+				JUnitRuntimeTestTree.TestKind.JUNIT3);
 		assertTrue(runtimeBefore.successful(), () -> "JUnit 3 baseline failed: " + runtimeBefore.roots()); //$NON-NLS-1$
 		enableMigration();
 		context.assertRefactoringResultAsExpectedNormalizingWhitespace(
@@ -216,7 +218,7 @@ public class JUnit3CoordinatedHierarchyMigrationTest {
 						"""
 				}, null);
 		assertFinderInventoryUnchanged(before);
-		assertRuntimeTreeUnchanged(runtimeBefore, launchTarget);
+		assertRuntimeTreePreservedAcrossLoaders(runtimeBefore, launchTarget);
 	}
 
 	private void enableMigration() throws CoreException {
@@ -230,10 +232,12 @@ public class JUnit3CoordinatedHierarchyMigrationTest {
 				"The configured JDT JUnit finder must expose the same test types after migration."); //$NON-NLS-1$
 	}
 
-	private void assertRuntimeTreeUnchanged(ExecutionTreeSnapshot before, IType launchTarget)
+	private void assertRuntimeTreePreservedAcrossLoaders(ExecutionTreeSnapshot before, IType launchTarget)
 			throws CoreException {
-		ExecutionTreeSnapshot after= JUnitRuntimeTestTree.capture(launchTarget);
-		Comparison comparison= ExecutionTreeComparator.compare(before, after, Policy.strict());
+		ExecutionTreeSnapshot after= JUnitRuntimeTestTree.capture(launchTarget,
+				JUnitRuntimeTestTree.TestKind.JUNIT5);
+		Policy crossLoaderPolicy= Policy.sameShape().withAttributes(false);
+		Comparison comparison= ExecutionTreeComparator.compare(before, after, crossLoaderPolicy);
 		assertTrue(comparison.equivalent(), comparison::difference);
 	}
 }

--- a/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/JUnitRuntimeTestTree.java
+++ b/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/JUnitRuntimeTestTree.java
@@ -13,6 +13,7 @@ package org.eclipse.jdt.ui.tests.quickfix.Java8;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -49,13 +50,30 @@ import org.sandbox.jdt.triggerpattern.api.ExecutionTreeSnapshot.NodeKind;
 final class JUnitRuntimeTestTree {
 
 	private static final String ATTR_TEST_RUNNER_KIND= "org.eclipse.jdt.junit.TEST_KIND"; //$NON-NLS-1$
-	private static final String JUNIT5_TEST_KIND_ID= "org.eclipse.jdt.junit.loader.junit5"; //$NON-NLS-1$
 	private static final long SESSION_TIMEOUT_SECONDS= 90;
+
+	/** JDT test kinds used as the authoritative migration oracle. */
+	enum TestKind {
+		JUNIT3("org.eclipse.jdt.junit.loader.junit3"), //$NON-NLS-1$
+		JUNIT5("org.eclipse.jdt.junit.loader.junit5"); //$NON-NLS-1$
+
+		private final String id;
+
+		TestKind(String id) {
+			this.id= id;
+		}
+
+		String id() {
+			return id;
+		}
+	}
 
 	private JUnitRuntimeTestTree() {
 	}
 
-	static ExecutionTreeSnapshot capture(IJavaElement launchTarget) throws CoreException {
+	static ExecutionTreeSnapshot capture(IJavaElement launchTarget, TestKind testKind) throws CoreException {
+		Objects.requireNonNull(launchTarget);
+		Objects.requireNonNull(testKind);
 		ResourcesPlugin.getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, null);
 		CountDownLatch completed= new CountDownLatch(1);
 		AtomicReference<ExecutionTreeSnapshot> captured= new AtomicReference<>();
@@ -78,25 +96,30 @@ final class JUnitRuntimeTestTree {
 		JUnitCore.addTestRunListener(listener);
 		try {
 			configuration= TestLaunchShortcut.createConfiguration(launchTarget);
-			configuration.setAttribute(ATTR_TEST_RUNNER_KIND, JUNIT5_TEST_KIND_ID);
+			configuration.setAttribute(ATTR_TEST_RUNNER_KIND, testKind.id());
 			launch= configuration.launch(ILaunchManager.RUN_MODE, null);
 			if (!completed.await(SESSION_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-				throw failure("Timed out waiting for the JDT JUnit runtime test tree", null); //$NON-NLS-1$
+				throw failure("Timed out waiting for the JDT " + testKind //$NON-NLS-1$
+						+ " runtime test tree", null); //$NON-NLS-1$
 			}
 			if (callbackFailure.get() != null) {
-				throw failure("Cannot snapshot the completed JDT JUnit runtime test tree", callbackFailure.get()); //$NON-NLS-1$
+				throw failure("Cannot snapshot the completed JDT " + testKind //$NON-NLS-1$
+						+ " runtime test tree", callbackFailure.get()); //$NON-NLS-1$
 			}
 			ExecutionTreeSnapshot result= captured.get();
 			if (result == null) {
-				throw failure("The JDT JUnit launch completed without a runtime test tree", null); //$NON-NLS-1$
+				throw failure("The JDT " + testKind //$NON-NLS-1$
+						+ " launch completed without a runtime test tree", null); //$NON-NLS-1$
 			}
 			if (result.isEmpty()) {
-				throw failure("The JDT JUnit runtime test tree contains no test elements", null); //$NON-NLS-1$
+				throw failure("The JDT " + testKind //$NON-NLS-1$
+						+ " runtime test tree contains no test elements", null); //$NON-NLS-1$
 			}
 			return result;
 		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
-			throw failure("Interrupted while waiting for the JDT JUnit runtime test tree", e); //$NON-NLS-1$
+			throw failure("Interrupted while waiting for the JDT " + testKind //$NON-NLS-1$
+					+ " runtime test tree", e); //$NON-NLS-1$
 		} finally {
 			JUnitCore.removeTestRunListener(listener);
 			cleanUp(launch, configuration);

--- a/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/JUnitRuntimeTestTree.java
+++ b/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/JUnitRuntimeTestTree.java
@@ -66,6 +66,11 @@ final class JUnitRuntimeTestTree {
 		String id() {
 			return id;
 		}
+
+		@Override
+		public String toString() {
+			return id;
+		}
 	}
 
 	private JUnitRuntimeTestTree() {


### PR DESCRIPTION
## Summary

Advance #1334 from finder-only and same-loader verification to the actual JDT runtime loader boundary.

- make the runtime-tree adapter select an explicit JDT JUnit test kind;
- capture the pre-migration execution tree with `org.eclipse.jdt.junit.loader.junit3`;
- capture the post-migration execution tree with `org.eclipse.jdt.junit.loader.junit5`;
- keep JUnit 3, Vintage and Jupiter on the same test classpath while changing only the authoritative JDT loader;
- compare complete tree shape, ordered test identity, exact multiplicity and results;
- ignore only loader-specific container identities and diagnostic attributes.

## Why this is safer

The previous tests launched both the JUnit 3 source and the migrated Jupiter source through the JDT JUnit 5/Vintage loader. That proved rewrite stability inside one compatibility loader, but it did not establish the issue's required JUnit 3 before-state. This PR uses JDT's dedicated JUnit 3 runtime loader as the baseline and its JUnit 5 loader as the post-migration oracle.

## Safety boundary

This PR does not widen the set of supported migrations. Custom constructors, suites, `runTest`, `runBare`, result/name contracts and runner integration remain fail-closed under the diagnostics merged in #1355. It strengthens acceptance evidence only for the already supported ordinary closed hierarchy.

Refs #1334
Refs #1217