### PR TITLE
Reject unsupported Parameterized provider shapes

### DIFF
--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/ParameterizedMigrationEligibility.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/ParameterizedMigrationEligibility.java
@@ -209,6 +209,7 @@ public final class ParameterizedMigrationEligibility {
 						&& "value".equals(pair.getName().getIdentifier())) { //$NON-NLS-1$
 					return pair.getValue();
 				}
+			}
 		}
 		return null;
 	}
@@ -233,6 +234,7 @@ public final class ParameterizedMigrationEligibility {
 								"Parameter")) { //$NON-NLS-1$
 					return true;
 				}
+			}
 		}
 		return false;
 	}

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/ParameterizedMigrationEligibility.java
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/helper/ParameterizedMigrationEligibility.java
@@ -17,13 +17,21 @@ import static org.sandbox.jdt.internal.corext.fix.helper.lib.JUnitConstants.ORG_
 import java.util.Objects;
 
 import org.eclipse.jdt.core.dom.Annotation;
+import org.eclipse.jdt.core.dom.ArrayCreation;
+import org.eclipse.jdt.core.dom.ArrayInitializer;
+import org.eclipse.jdt.core.dom.ArrayType;
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.FieldDeclaration;
+import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.MemberValuePair;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.Modifier;
 import org.eclipse.jdt.core.dom.NormalAnnotation;
+import org.eclipse.jdt.core.dom.ReturnStatement;
 import org.eclipse.jdt.core.dom.SingleMemberAnnotation;
+import org.eclipse.jdt.core.dom.Statement;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.TypeLiteral;
 
@@ -35,6 +43,8 @@ public final class ParameterizedMigrationEligibility {
 
 	private static final String PARAMETER_ANNOTATION=
 			"org.junit.runners.Parameterized.Parameter"; //$NON-NLS-1$
+	private static final String JAVA_LANG_OBJECT= "java.lang.Object"; //$NON-NLS-1$
+	private static final String JAVA_UTIL_ARRAYS= "java.util.Arrays"; //$NON-NLS-1$
 
 	/** Immutable eligibility decision with a stable diagnostic reason code. */
 	public record Assessment(boolean eligible, String reasonCode,
@@ -59,6 +69,66 @@ public final class ParameterizedMigrationEligibility {
 	 *         {@code @RunWith(Parameterized.class)}
 	 */
 	public static boolean hasParameterizedRunner(TypeDeclaration type) {
+		return parameterizedRunnerAnnotation(type) != null;
+	}
+
+	/**
+	 * Assess the exact local source contract understood by the existing rewrite.
+	 *
+	 * @param type
+	 *            Parameterized test type
+	 * @return eligibility or one stable fail-closed reason
+	 */
+	public static Assessment assess(TypeDeclaration type) {
+		Objects.requireNonNull(type);
+		int providers= 0;
+		int constructors= 0;
+		MethodDeclaration provider= null;
+		MethodDeclaration constructor= null;
+		for (MethodDeclaration method : type.getMethods()) {
+			if (method.isConstructor()) {
+				constructors++;
+				constructor= method;
+				continue;
+			}
+			if (hasParametersAnnotation(method)) {
+				providers++;
+				provider= method;
+			}
+		}
+		if (providers == 0) {
+			return rejected("PARAMETERIZED_PROVIDER_NOT_LOCAL", //$NON-NLS-1$
+					"No local @Parameters provider is declared; inherited or external providers require a coordinated migration."); //$NON-NLS-1$
+		}
+		if (providers > 1) {
+			return rejected("PARAMETERIZED_MULTIPLE_LOCAL_PROVIDERS", //$NON-NLS-1$
+					"More than one local @Parameters provider is declared, so a unique MethodSource cannot be selected safely."); //$NON-NLS-1$
+		}
+		if (usesFieldInjection(type)) {
+			return rejected("PARAMETERIZED_FIELD_INJECTION", //$NON-NLS-1$
+					"@Parameterized.Parameter field injection is not represented by the constructor-based local rewrite."); //$NON-NLS-1$
+		}
+		if (!(parameterizedRunnerAnnotation(type) instanceof SingleMemberAnnotation)) {
+			return rejected("PARAMETERIZED_RUNNER_SYNTAX_UNSUPPORTED", //$NON-NLS-1$
+					"The local rewrite currently supports only @RunWith(Parameterized.class), not the explicit value = syntax."); //$NON-NLS-1$
+		}
+		if (provider == null || !hasSupportedProviderShape(provider)) {
+			return rejected("PARAMETERIZED_PROVIDER_BODY_UNSUPPORTED", //$NON-NLS-1$
+					"The local @Parameters provider is not the supported static Arrays.asList(new Object[][] { ... }) form and cannot be rewritten safely."); //$NON-NLS-1$
+		}
+		if (constructors != 1) {
+			return rejected("PARAMETERIZED_CONSTRUCTOR_NOT_UNIQUE", //$NON-NLS-1$
+					"Exactly one explicit constructor is required before constructor parameters can become test-method parameters."); //$NON-NLS-1$
+		}
+		if (constructor == null || constructor.parameters().isEmpty()) {
+			return rejected("PARAMETERIZED_CONSTRUCTOR_HAS_NO_PARAMETERS", //$NON-NLS-1$
+					"The unique constructor has no parameters to propagate to ParameterizedTest methods."); //$NON-NLS-1$
+		}
+		return new Assessment(true, "PARAMETERIZED_LOCAL_CONTRACT", //$NON-NLS-1$
+				"One local provider with a supported body and one parameterized constructor form the supported local rewrite contract."); //$NON-NLS-1$
+	}
+
+	private static Annotation parameterizedRunnerAnnotation(TypeDeclaration type) {
 		Objects.requireNonNull(type);
 		for (Object modifier : type.modifiers()) {
 			if (!(modifier instanceof Annotation annotation)) {
@@ -74,56 +144,59 @@ public final class ParameterizedMigrationEligibility {
 			ITypeBinding runnerBinding= literal.getType().resolveBinding();
 			if (runnerBinding != null && ORG_JUNIT_RUNNERS_PARAMETERIZED
 					.equals(runnerBinding.getErasure().getQualifiedName())) {
-				return true;
+				return annotation;
 			}
 		}
-		return false;
+		return null;
 	}
 
-	/**
-	 * Assess the exact local source contract understood by the existing rewrite.
-	 *
-	 * @param type
-	 *            Parameterized test type
-	 * @return eligibility or one stable fail-closed reason
-	 */
-	public static Assessment assess(TypeDeclaration type) {
-		Objects.requireNonNull(type);
-		int providers= 0;
-		int constructors= 0;
-		MethodDeclaration constructor= null;
-		for (MethodDeclaration method : type.getMethods()) {
-			if (method.isConstructor()) {
-				constructors++;
-				constructor= method;
+	private static boolean hasSupportedProviderShape(MethodDeclaration provider) {
+		if (!Modifier.isStatic(provider.getModifiers())
+				|| !provider.parameters().isEmpty()
+				|| !provider.typeParameters().isEmpty()
+				|| !provider.thrownExceptionTypes().isEmpty()
+				|| provider.getBody() == null
+				|| provider.getBody().statements().size() != 1) {
+			return false;
+		}
+		Statement statement= (Statement) provider.getBody().statements().get(0);
+		if (!(statement instanceof ReturnStatement returnStatement)
+				|| !(returnStatement.getExpression() instanceof MethodInvocation invocation)
+				|| !"asList".equals(invocation.getName().getIdentifier()) //$NON-NLS-1$
+				|| invocation.arguments().size() != 1) {
+			return false;
+		}
+		IMethodBinding methodBinding= invocation.resolveMethodBinding();
+		ITypeBinding declaringType= methodBinding == null
+				? null : methodBinding.getDeclaringClass();
+		if (declaringType == null || !JAVA_UTIL_ARRAYS.equals(
+				declaringType.getErasure().getQualifiedName())) {
+			return false;
+		}
+		Expression argument= (Expression) invocation.arguments().get(0);
+		if (!(argument instanceof ArrayCreation arrayCreation)
+				|| arrayCreation.getInitializer() == null
+				|| arrayCreation.getInitializer().expressions().isEmpty()) {
+			return false;
+		}
+		ArrayType arrayType= arrayCreation.getType();
+		ITypeBinding elementType= arrayType.getElementType().resolveBinding();
+		if (arrayType.getDimensions() != 2 || elementType == null
+				|| !JAVA_LANG_OBJECT.equals(
+						elementType.getErasure().getQualifiedName())) {
+			return false;
+		}
+		for (Object row : arrayCreation.getInitializer().expressions()) {
+			if (row instanceof ArrayInitializer) {
 				continue;
 			}
-			if (hasParametersAnnotation(method)) {
-				providers++;
+			if (row instanceof ArrayCreation nested
+					&& nested.getInitializer() != null) {
+				continue;
 			}
+			return false;
 		}
-		if (providers == 0) {
-			return rejected("PARAMETERIZED_PROVIDER_NOT_LOCAL", //$NON-NLS-1$
-					"No local @Parameters provider is declared; inherited or external providers require a coordinated migration."); //$NON-NLS-1$
-		}
-		if (providers > 1) {
-			return rejected("PARAMETERIZED_MULTIPLE_LOCAL_PROVIDERS", //$NON-NLS-1$
-					"More than one local @Parameters provider is declared, so a unique MethodSource cannot be selected safely."); //$NON-NLS-1$
-		}
-		if (usesFieldInjection(type)) {
-			return rejected("PARAMETERIZED_FIELD_INJECTION", //$NON-NLS-1$
-					"@Parameterized.Parameter field injection is not represented by the constructor-based local rewrite."); //$NON-NLS-1$
-		}
-		if (constructors != 1) {
-			return rejected("PARAMETERIZED_CONSTRUCTOR_NOT_UNIQUE", //$NON-NLS-1$
-					"Exactly one explicit constructor is required before constructor parameters can become test-method parameters."); //$NON-NLS-1$
-		}
-		if (constructor == null || constructor.parameters().isEmpty()) {
-			return rejected("PARAMETERIZED_CONSTRUCTOR_HAS_NO_PARAMETERS", //$NON-NLS-1$
-					"The unique constructor has no parameters to propagate to ParameterizedTest methods."); //$NON-NLS-1$
-		}
-		return new Assessment(true, "PARAMETERIZED_LOCAL_CONTRACT", //$NON-NLS-1$
-				"One local provider and one parameterized constructor form the supported local rewrite contract."); //$NON-NLS-1$
+		return true;
 	}
 
 	private static Expression runnerValue(Annotation annotation) {
@@ -136,7 +209,6 @@ public final class ParameterizedMigrationEligibility {
 						&& "value".equals(pair.getName().getIdentifier())) { //$NON-NLS-1$
 					return pair.getValue();
 				}
-			}
 		}
 		return null;
 	}
@@ -161,7 +233,6 @@ public final class ParameterizedMigrationEligibility {
 								"Parameter")) { //$NON-NLS-1$
 					return true;
 				}
-			}
 		}
 		return false;
 	}

--- a/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/ParameterizedMigrationContractTest.java
+++ b/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/Java8/ParameterizedMigrationContractTest.java
@@ -136,6 +136,75 @@ public class ParameterizedMigrationContractTest {
 				""");
 	}
 
+	@Test
+	public void leavesExplicitRunWithValueSyntaxUntouched() throws CoreException {
+		assertNoChange("ExplicitRunnerTest.java", //$NON-NLS-1$
+				"""
+				package test;
+
+				import java.util.Arrays;
+				import java.util.Collection;
+
+				import org.junit.Test;
+				import org.junit.runner.RunWith;
+				import org.junit.runners.Parameterized;
+				import org.junit.runners.Parameterized.Parameters;
+
+				@RunWith(value = Parameterized.class)
+				public class ExplicitRunnerTest {
+					private final int value;
+
+					public ExplicitRunnerTest(int value) {
+						this.value = value;
+					}
+
+					@Parameters
+					public static Collection<Object[]> data() {
+						return Arrays.asList(new Object[][] { { 1 }, { 2 } });
+					}
+
+					@Test
+					public void verifiesValue() {
+						System.out.println(value);
+					}
+				}
+				""");
+	}
+
+	@Test
+	public void leavesUnsupportedProviderBodyUntouched() throws CoreException {
+		assertNoChange("UnsupportedProviderTest.java", //$NON-NLS-1$
+				"""
+				package test;
+
+				import java.util.List;
+
+				import org.junit.Test;
+				import org.junit.runner.RunWith;
+				import org.junit.runners.Parameterized;
+				import org.junit.runners.Parameterized.Parameters;
+
+				@RunWith(Parameterized.class)
+				public class UnsupportedProviderTest {
+					private final int value;
+
+					public UnsupportedProviderTest(int value) {
+						this.value = value;
+					}
+
+					@Parameters
+					public static List<Object[]> data() {
+						return List.<Object[]>of(new Object[] { 1 });
+					}
+
+					@Test
+					public void verifiesValue() {
+						System.out.println(value);
+					}
+				}
+				""");
+	}
+
 	private void assertNoChange(String fileName, String source) throws CoreException {
 		IPackageFragment pack= root.createPackageFragment("test", true, null); //$NON-NLS-1$
 		ICompilationUnit unit= pack.createCompilationUnit(fileName, source, false, null);

--- a/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/ParameterizedMigrationDiagnosticsTest.java
+++ b/sandbox_junit_cleanup_test/src/org/sandbox/jdt/internal/corext/fix/multifile/ParameterizedMigrationDiagnosticsTest.java
@@ -152,21 +152,58 @@ public class ParameterizedMigrationDiagnosticsTest {
 	}
 
 	@Test
-	public void recognizesExplicitRunWithValueSyntax() throws CoreException {
+	public void reportsUnsupportedExplicitRunWithValueSyntax() throws CoreException {
 		ICompilationUnit unit= compilationUnit("explicitrunner", //$NON-NLS-1$
 				"ExplicitRunnerTest", //$NON-NLS-1$
+				"""
+				import java.util.Arrays;
+				import java.util.List;
+				import org.junit.Test;
+				import org.junit.runner.RunWith;
+				import org.junit.runners.Parameterized;
+				import org.junit.runners.Parameterized.Parameters;
+
+				@RunWith(value = Parameterized.class)
+				public class ExplicitRunnerTest {
+					private final int value;
+
+					public ExplicitRunnerTest(int value) {
+						this.value = value;
+					}
+
+					@Parameters
+					public static List<Object[]> data() {
+						return Arrays.asList(new Object[][] { { 1 } });
+					}
+
+					@Test
+					public void testValue() {
+					}
+				}
+				"""); //$NON-NLS-1$
+
+		assertReason(planClosed(unit),
+				"PARAMETERIZED_RUNNER_SYNTAX_UNSUPPORTED"); //$NON-NLS-1$
+	}
+
+	@Test
+	public void reportsUnsupportedLocalProviderBody() throws CoreException {
+		ICompilationUnit unit= compilationUnit("unsupportedprovider", //$NON-NLS-1$
+				"UnsupportedProviderTest", //$NON-NLS-1$
 				"""
 				import java.util.List;
 				import org.junit.Test;
 				import org.junit.runner.RunWith;
 				import org.junit.runners.Parameterized;
-				import org.junit.runners.Parameterized.Parameter;
 				import org.junit.runners.Parameterized.Parameters;
 
-				@RunWith(value = Parameterized.class)
-				public class ExplicitRunnerTest {
-					@Parameter
-					public int value;
+				@RunWith(Parameterized.class)
+				public class UnsupportedProviderTest {
+					private final int value;
+
+					public UnsupportedProviderTest(int value) {
+						this.value = value;
+					}
 
 					@Parameters
 					public static List<Object[]> data() {
@@ -179,7 +216,8 @@ public class ParameterizedMigrationDiagnosticsTest {
 				}
 				"""); //$NON-NLS-1$
 
-		assertReason(planClosed(unit), "PARAMETERIZED_FIELD_INJECTION"); //$NON-NLS-1$
+		assertReason(planClosed(unit),
+				"PARAMETERIZED_PROVIDER_BODY_UNSUPPORTED"); //$NON-NLS-1$
 	}
 
 	@Test
@@ -188,6 +226,7 @@ public class ParameterizedMigrationDiagnosticsTest {
 		ICompilationUnit unit= compilationUnit("supported", //$NON-NLS-1$
 				"SupportedTest", //$NON-NLS-1$
 				"""
+				import java.util.Arrays;
 				import java.util.List;
 				import org.junit.Test;
 				import org.junit.runner.RunWith;
@@ -204,7 +243,7 @@ public class ParameterizedMigrationDiagnosticsTest {
 
 					@Parameters
 					public static List<Object[]> data() {
-						return List.<Object[]>of(new Object[] { 1 });
+						return Arrays.asList(new Object[][] { { 1 } });
 					}
 
 					@Test


### PR DESCRIPTION
## Summary

Close a fail-open gap in the local JUnit 4 `Parameterized` migration from #1217.

The current rewriter can only transform the short runner syntax together with a static, parameterless provider whose body is exactly one `Arrays.asList(new Object[][] { ... })` return. Planning previously accepted any unique local `@Parameters` method, including `List.of(...)`, even though the rewrite would retain that incompatible body under a new `Stream<Arguments>` signature.

This PR:

- validates the exact runner syntax understood by the executable plugin;
- validates the exact `java.util.Arrays.asList` method binding;
- requires a non-empty two-dimensional `java.lang.Object[][]` initializer;
- rejects provider parameters, type parameters, throws clauses and additional statements;
- adds stable reasons `PARAMETERIZED_RUNNER_SYNTAX_UNSUPPORTED` and `PARAMETERIZED_PROVIDER_BODY_UNSUPPORTED`;
- corrects the previous false-positive supported fixture;
- proves unsupported syntax/provider bodies remain unchanged in the actual cleanup path, not only in planner diagnostics.

## Safety boundary

This does not widen Parameterized migration support. External/inherited providers, field injection, constructor/field mapping and lifecycle/helper-field use remain fail-closed or require later coordinated stages.

Refs #1217