### PR TITLE
Record Core 0.1.15 migration evidence

### DIFF
--- a/sandbox-jgit-server-webapp/docs/jgit-storage-migration-matrix.json
+++ b/sandbox-jgit-server-webapp/docs/jgit-storage-migration-matrix.json
@@ -1,13 +1,14 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "issue": 1303,
   "baselineCommit": "714bec5cf26e1554520ef063850865ec931a6624",
-  "purpose": "Machine-readable baseline for replacing the copied Sandbox JGit/Hibernate implementation with released jgit-storage-hibernate modules.",
+  "lastVerifiedCommit": "0804ae99532cbb9bfa551fbb6870c053c1938e5d",
+  "purpose": "Machine-readable baseline and evidence ledger for replacing the copied Sandbox JGit/Hibernate implementation with released jgit-storage-hibernate modules.",
   "releasePolicy": {
     "required": "non-SNAPSHOT",
     "minimumDocumentedCandidate": "0.1.13",
-    "selectedVersion": null,
-    "selectionState": "pending compatibility verification"
+    "selectedVersion": "0.1.15",
+    "selectionState": "selected; Core adapter lifecycle and restart verified on H2"
   },
   "runtime": {
     "currentDatabase": "MSSQL",
@@ -22,9 +23,11 @@
       "currentOwner": "sandbox-jgit-server-webapp",
       "currentEntrypoints": [
         "org.eclipse.jgit.server.repository.SandboxRepositoryService",
-        "org.eclipse.jgit.server.repository.CopiedHibernateRepositoryService"
+        "org.eclipse.jgit.server.repository.CopiedHibernateRepositoryService",
+        "org.eclipse.jgit.server.repository.ExternalHibernateRepositoryService",
+        "org.eclipse.jgit.server.config.ExternalServerPersistenceContext"
       ],
-      "currentBackend": "copied HibernateRepositoryBuilder and HibernateRepository",
+      "currentBackend": "Sandbox adapter boundary with copied backend for normal startup and released Core 0.1.15 for guarded external startup",
       "targetOwner": "jgit-storage-hibernate-core",
       "targetApi": [
         "HibernateRepositoryFactory",
@@ -32,43 +35,60 @@
         "HibernateGitStorage",
         "RepositoryName"
       ],
-      "migrationStatus": "adapter-boundary-present",
+      "migrationStatus": "core-adapter-lifecycle-verified",
       "requiredEvidence": [
         "open/create/close/reopen on H2",
         "two logical repositories in one schema",
         "concurrent opens",
         "shutdown without leaked handles"
+      ],
+      "verifiedEvidence": [
+        "ExternalHibernateRepositoryServiceTest.concurrentNormalizedOpensShareOneFactoryHandle",
+        "ExternalHibernateRepositoryServiceTest.shutdownClosesAStorageWhoseOpenWasAlreadyInFlight",
+        "ExternalHibernateRepositoryServiceTest.closeDoesNotHoldLifecycleLockWhileClosingStorage",
+        "ExternalRepositoryLifecycleH2Test.normalizesIsolatesAndReopensRepositories",
+        "PR #1362 / commit 0804ae99532cbb9bfa551fbb6870c053c1938e5d"
       ]
     },
     {
       "id": "repository-name-normalization",
       "currentOwner": "sandbox-jgit-server-webapp",
       "currentEntrypoints": [
-        "org.eclipse.jgit.server.repository.CopiedHibernateRepositoryService"
+        "org.eclipse.jgit.server.repository.CopiedHibernateRepositoryService",
+        "org.eclipse.jgit.server.repository.ExternalHibernateRepositoryService"
       ],
-      "currentBackend": "Sandbox-owned normalization of leading slash and .git suffix",
+      "currentBackend": "Sandbox-owned normalization of leading slash and .git suffix before backend-specific repository access",
       "targetOwner": "sandbox-jgit-server-webapp",
       "targetApi": [
         "RepositoryName"
       ],
-      "migrationStatus": "retain-adapter-policy",
+      "migrationStatus": "core-adapter-verified-retain-policy",
       "requiredEvidence": [
         "/name, name.git and name resolve to one cached repository identity"
+      ],
+      "verifiedEvidence": [
+        "ExternalHibernateRepositoryServiceTest.normalizesAndCachesFactoryOwnedStorage",
+        "ExternalRepositoryLifecycleH2Test.normalizesIsolatesAndReopensRepositories"
       ]
     },
     {
       "id": "repository-description",
-      "currentOwner": "sandbox-jgit-storage-hibernate",
+      "currentOwner": "sandbox-jgit-server-webapp",
       "currentEntrypoints": [
         "org.eclipse.jgit.server.repository.CopiedHibernateRepositoryService.info",
-        "org.eclipse.jgit.server.repository.CopiedHibernateRepositoryService.setDescription"
+        "org.eclipse.jgit.server.repository.CopiedHibernateRepositoryService.setDescription",
+        "org.eclipse.jgit.server.repository.ExternalHibernateRepositoryService.info",
+        "org.eclipse.jgit.server.repository.ExternalHibernateRepositoryService.setDescription"
       ],
-      "currentBackend": "HibernateRepository Gitweb description",
+      "currentBackend": "Sandbox metadata DTO backed by the repository Gitweb description",
       "targetOwner": "sandbox-jgit-server-webapp",
       "targetApi": [],
-      "migrationStatus": "sandbox-extension-required",
+      "migrationStatus": "core-adapter-verified-sandbox-policy-retained",
       "requiredEvidence": [
         "description remains available without treating it as authoritative Git storage state"
+      ],
+      "verifiedEvidence": [
+        "ExternalHibernateRepositoryServiceTest.readsAndUpdatesDescriptionThroughPublicRepository"
       ]
     },
     {
@@ -82,7 +102,7 @@
       "targetApi": [
         "HibernateGitStorage.repository"
       ],
-      "migrationStatus": "adapter-boundary-present",
+      "migrationStatus": "adapter-boundary-present-runtime-cutover-pending",
       "requiredEvidence": [
         "clone/fetch/push after restart",
         "normal RefUpdate creates queryable reflog entries",
@@ -92,20 +112,21 @@
     {
       "id": "repository-delete",
       "currentOwner": "sandbox-jgit-server-webapp",
-      "currentEntrypoints": [
-        "org.eclipse.jgit.server.rest.RepositoryResource",
-        "org.eclipse.jgit.server.rest.AdminResource"
-      ],
-      "currentBackend": "copied backend lifecycle and deletion behavior",
+      "currentEntrypoints": [],
+      "currentBackend": "No application deletion boundary is currently exposed; Sandbox-owned open handles are cached until service shutdown",
       "targetOwner": "jgit-storage-hibernate-core",
       "targetApi": [
         "HibernateRepositoryFactory.deleteRepository"
       ],
-      "migrationStatus": "not-migrated",
+      "migrationStatus": "core-api-available-adapter-policy-required",
       "requiredEvidence": [
-        "delete rejected while coordinated handle is open",
+        "delete rejected while a coordinated handle is open",
+        "Sandbox adapter either reports in-use or atomically evicts and closes its owned handle before deletion",
         "repeated deletion is idempotent",
         "Search deletion participant removes projections"
+      ],
+      "verifiedEvidence": [
+        "Core 0.1.15 DefaultHibernateRepositoryFactory serializes deletion and rejects open handles"
       ]
     },
     {
@@ -273,12 +294,16 @@
         "SearchEntities",
         "library Flyway migrations and legacy preflight APIs"
       ],
-      "migrationStatus": "guarded-core-preparation-present",
+      "migrationStatus": "guarded-core-preparation-h2-validated",
       "requiredEvidence": [
         "Core migrations precede Hibernate validation",
         "Search migrations follow Core migrations",
         "production uses hbm2ddl.auto=validate",
         "pack BLOB checksums and reflogs survive legacy adoption"
+      ],
+      "verifiedEvidence": [
+        "ExternalRepositoryLifecycleH2Test reopens the same schema with hbm2ddl.auto=validate",
+        "ExternalServerPersistenceContextTest verifies application-owned lifecycle"
       ]
     }
   ],
@@ -290,11 +315,16 @@
     {
       "path": "sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/repository/CopiedHibernateRepositoryService.java",
       "classification": "temporary-copied-adapter",
-      "replacement": "Core-backed SandboxRepositoryService implementation"
+      "replacement": "ExternalHibernateRepositoryService"
+    },
+    {
+      "path": "sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/repository/ExternalHibernateRepositoryService.java",
+      "classification": "released-core-adapter-lifecycle-verified",
+      "evidence": "PR #1362 / commit 0804ae99532cbb9bfa551fbb6870c053c1938e5d"
     },
     {
       "path": "sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/config/ExternalServerPersistenceContext.java",
-      "classification": "guarded-external-core-preparation"
+      "classification": "guarded-external-core-preparation-h2-validated"
     },
     {
       "path": "sandbox-jgit-storage-hibernate/src/org/eclipse/jgit/storage/hibernate/repository/HibernateRepositoryBuilder.java",

--- a/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/config/JGitStorageMigrationMatrixTest.java
+++ b/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/config/JGitStorageMigrationMatrixTest.java
@@ -1,0 +1,107 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jgit.server.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.Test;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+/** Keeps the machine-readable Core migration ledger aligned with build reality. */
+public class JGitStorageMigrationMatrixTest {
+
+	private static final Pattern CORE_VERSION= Pattern.compile(
+			"<jgit-storage-hibernate\\.version>([^<]+)</jgit-storage-hibernate\\.version>"); //$NON-NLS-1$
+	private static final Pattern COMMIT_SHA= Pattern.compile("[0-9a-f]{40}"); //$NON-NLS-1$
+
+	@Test
+	public void selectedCoreVersionMatchesTheModulePom() throws IOException {
+		JsonObject matrix= matrix();
+		String selectedVersion= matrix.getAsJsonObject("releasePolicy") //$NON-NLS-1$
+				.get("selectedVersion").getAsString(); //$NON-NLS-1$
+		Matcher pomVersion= CORE_VERSION.matcher(read("pom.xml")); //$NON-NLS-1$
+
+		assertTrue("The module POM must declare jgit-storage-hibernate.version", //$NON-NLS-1$
+				pomVersion.find());
+		assertEquals(pomVersion.group(1), selectedVersion);
+		assertFalse(selectedVersion.endsWith("-SNAPSHOT")); //$NON-NLS-1$
+	}
+
+	@Test
+	public void verifiedCapabilitiesReferenceConcreteEvidence() throws IOException {
+		JsonObject matrix= matrix();
+		assertEquals(2, matrix.get("schemaVersion").getAsInt()); //$NON-NLS-1$
+		assertTrue(COMMIT_SHA.matcher(matrix.get("lastVerifiedCommit") //$NON-NLS-1$
+				.getAsString()).matches());
+
+		Set<String> ids= new HashSet<>();
+		for (JsonElement element : matrix.getAsJsonArray("capabilities")) { //$NON-NLS-1$
+			JsonObject capability= element.getAsJsonObject();
+			String id= capability.get("id").getAsString(); //$NON-NLS-1$
+			assertTrue("Duplicate capability id: " + id, ids.add(id)); //$NON-NLS-1$
+			if (capability.get("migrationStatus").getAsString() //$NON-NLS-1$
+					.contains("verified")) { //$NON-NLS-1$
+				JsonArray evidence= capability.getAsJsonArray("verifiedEvidence"); //$NON-NLS-1$
+				assertNotNull("Verified capability lacks evidence: " + id, evidence); //$NON-NLS-1$
+				assertFalse("Verified capability has empty evidence: " + id, //$NON-NLS-1$
+						evidence.isEmpty());
+			}
+		}
+	}
+
+	@Test
+	public void repositoryDeletionRemainsExplicitlyUnwired() throws IOException {
+		JsonObject deletion= capability(matrix(), "repository-delete"); //$NON-NLS-1$
+
+		assertTrue(deletion.getAsJsonArray("currentEntrypoints").isEmpty()); //$NON-NLS-1$
+		assertEquals("core-api-available-adapter-policy-required", //$NON-NLS-1$
+				deletion.get("migrationStatus").getAsString()); //$NON-NLS-1$
+		assertTrue(deletion.getAsJsonArray("requiredEvidence").toString() //$NON-NLS-1$
+				.contains("atomically evicts and closes")); //$NON-NLS-1$
+	}
+
+	private static JsonObject capability(JsonObject matrix, String id) {
+		for (JsonElement element : matrix.getAsJsonArray("capabilities")) { //$NON-NLS-1$
+			JsonObject capability= element.getAsJsonObject();
+			if (id.equals(capability.get("id").getAsString())) { //$NON-NLS-1$
+				return capability;
+			}
+		}
+		throw new AssertionError("Missing capability: " + id); //$NON-NLS-1$
+	}
+
+	private static JsonObject matrix() throws IOException {
+		return JsonParser.parseString(read("docs/jgit-storage-migration-matrix.json")) //$NON-NLS-1$
+				.getAsJsonObject();
+	}
+
+	private static String read(String relativePath) throws IOException {
+		Path baseDirectory= Path.of(System.getProperty("basedir", ".")); //$NON-NLS-1$ //$NON-NLS-2$
+		return Files.readString(baseDirectory.resolve(relativePath),
+				StandardCharsets.UTF_8);
+	}
+}


### PR DESCRIPTION
## Summary

Bring the machine-readable #1303 migration matrix in line with the repository after #1362 and make that alignment executable.

- select the actually used non-SNAPSHOT `jgit-storage-hibernate-core` version 0.1.15;
- record the last verified Sandbox commit;
- mark Core adapter lifecycle, normalized identity, metadata access and H2 schema validation as verified;
- link the exact concurrency, shutdown and restart tests that provide the evidence;
- classify `ExternalHibernateRepositoryService` as the released-Core adapter replacing the temporary copied adapter;
- correct the repository-delete row: no Sandbox REST/application delete boundary exists yet;
- document the required future policy for cached open handles and Search deletion participants instead of implying deletion is already migrated;
- add a build-time contract that verifies the selected matrix version matches the module POM, is non-SNAPSHOT, verified capabilities contain evidence, capability IDs are unique, and deletion remains explicitly unwired.

This PR changes no runtime behavior. It makes the migration ledger accurate and prevents the same drift from silently returning.

Refs #1303