### PR TITLE
Compile concise declaration diffs to typed migration actions

### DIFF
--- a/sandbox_common/help/hints-actions-plans.html
+++ b/sandbox_common/help/hints-actions-plans.html
@@ -3,33 +3,38 @@
 <head><meta charset="UTF-8"><title>Structured actions and semantic plans</title></head>
 <body>
 <h1>Structured actions and semantic plans</h1>
-<p>Use a structured action when the rewrite changes declaration structure, modifiers, annotations, supertypes or invocation ownership. Structured actions preserve JDT AST and import-rewrite semantics and are validated against one shared action catalog.</p>
+<p>Use a structured action when the rewrite changes declaration structure, signatures, modifiers, annotations, supertypes or invocation ownership. Structured actions preserve JDT AST and import-rewrite semantics and are validated against one shared action catalog.</p>
 <h2>Action syntax</h2>
 <pre>@id: ordered.jupiter.test
 void $method($params$) :: plannedRole($method, "TEST_METHOD")
-=&gt;! addAnnotation(target=$method,
+=&gt;! addAnnotation(
         annotation="org.junit.jupiter.api.Order",
         value=planValue($method, "testOrder"));
-    addAnnotation(target=$method,
-        annotation="org.junit.jupiter.api.Test")
+    addAnnotation(annotation="org.junit.jupiter.api.Test")
 ;;</pre>
-<p>Arguments are named. Required, optional, unknown and duplicate arguments are checked during parsing. Actions execute in source order. This order can matter when several nodes are inserted at the same JDT list position.</p>
+<p>The primary matched node is the implicit action target. Use <code>target=$other</code> only when an action deliberately operates on another bound node. Arguments are named and actions execute in source order.</p>
 <h2>Standard actions</h2>
 <table border="1" cellspacing="0" cellpadding="4">
 <tr><th>Action</th><th>Arguments</th><th>Effect</th></tr>
-<tr><td><code>addAnnotation</code></td><td><code>target</code>, <code>annotation</code>, optional <code>value</code></td><td>Add a marker, single-value or array annotation.</td></tr>
-<tr><td><code>removeAnnotation</code></td><td><code>target</code>, <code>annotation</code></td><td>Remove one validated annotation.</td></tr>
-<tr><td><code>addModifier</code></td><td><code>target</code>, <code>modifier</code></td><td>Add one declaration modifier.</td></tr>
-<tr><td><code>removeModifier</code></td><td><code>target</code>, <code>modifier</code></td><td>Remove one declaration modifier.</td></tr>
-<tr><td><code>removeSupertype</code></td><td><code>target</code>, <code>type</code></td><td>Remove one binding-validated superclass or interface.</td></tr>
-<tr><td><code>replaceSupertype</code></td><td><code>target</code>, <code>type</code>, <code>replacement</code></td><td>Replace one binding-validated superclass or interface.</td></tr>
-<tr><td><code>removeDeclaration</code></td><td><code>target</code></td><td>Remove one exact declaration or field fragment.</td></tr>
-<tr><td><code>qualifyInvocation</code></td><td><code>target</code>, <code>owner</code></td><td>Qualify one exact unqualified static invocation.</td></tr>
+<tr><td><code>addAnnotation</code></td><td><code>annotation</code>, optional <code>value</code>, <code>target</code></td><td>Add a marker, single-value or array annotation.</td></tr>
+<tr><td><code>removeAnnotation</code></td><td><code>annotation</code>, optional <code>target</code></td><td>Remove one validated annotation.</td></tr>
+<tr><td><code>addModifier</code></td><td><code>modifier</code>, optional <code>target</code></td><td>Add one declaration modifier.</td></tr>
+<tr><td><code>removeModifier</code></td><td><code>modifier</code>, optional <code>target</code></td><td>Remove one declaration modifier.</td></tr>
+<tr><td><code>removeSupertype</code></td><td><code>type</code>, optional <code>target</code></td><td>Remove one binding-validated superclass or interface.</td></tr>
+<tr><td><code>replaceSupertype</code></td><td><code>type</code>, <code>replacement</code>, optional <code>target</code></td><td>Replace one binding-validated superclass or interface.</td></tr>
+<tr><td><code>removeDeclaration</code></td><td>optional <code>target</code></td><td>Remove the primary declaration or another exact bound declaration.</td></tr>
+<tr><td><code>qualifyInvocation</code></td><td><code>owner</code>, optional <code>target</code></td><td>Qualify one exact unqualified static invocation.</td></tr>
+<tr><td><code>renameDeclaration</code></td><td><code>name</code>, optional <code>target</code></td><td>Rename one exact planned method or single field declaration.</td></tr>
+<tr><td><code>replaceFieldType</code></td><td><code>type</code>, optional <code>target</code></td><td>Replace one single-fragment planned field type.</td></tr>
+<tr><td><code>addParameter</code></td><td><code>type</code>, <code>name</code>, optional <code>index</code>, <code>target</code></td><td>Add one parameter; omission of <code>index</code> appends it.</td></tr>
+<tr><td><code>removeParameter</code></td><td>exactly one of <code>name</code> or <code>index</code>, optional <code>target</code></td><td>Remove one parameter. Stable names are preferred.</td></tr>
+<tr><td><code>replaceParameterType</code></td><td><code>type</code>, exactly one of <code>name</code> or <code>index</code>, optional <code>target</code></td><td>Replace one selected parameter type.</td></tr>
 </table>
+<p>Signature actions accept primitive, imported reference and array types. Generic, wildcard, varargs and <code>void</code> type strings are rejected rather than reparsed as arbitrary Java.</p>
 <h2>Action values</h2>
 <ul>
 <li>Quoted strings, booleans and integers are typed literal values.</li>
-<li>A placeholder such as <code>$method</code> refers to the corresponding pattern binding.</li>
+<li>A placeholder such as <code>$method</code> refers to another exact pattern binding.</li>
 <li><code>planValue($method, "testOrder")</code> reads a typed fact for a planned node.</li>
 <li><code>classLiteral("example.Owner.Nested")</code> creates a class-literal annotation value with import handling.</li>
 <li><code>name("example.Qualified.Name")</code> represents a Java name rather than a string literal.</li>
@@ -47,11 +52,10 @@ void $method($params$) :: plannedRole($method, "TEST_METHOD")
 @kind: TYPE_DECLARATION
 class $type extends junit.framework.TestCase {}
     :: plannedRole($type, "JUNIT3_HIERARCHY_TYPE")
-    &amp;&amp; plannedValue($type, "removeTestCaseSuperclass", true)
-=&gt;! removeSupertype(target=$type, type="junit.framework.TestCase")
+=&gt;! removeSupertype(type="junit.framework.TestCase")
 ;;</pre>
-<p>A plan-aware program is rejected unless a non-empty plan with the required contract is installed. Every structured target must resolve to a stable key authorized by that plan. After matching, exact coverage checks compare the planned targets with the targets for which rewrite operations were produced.</p>
+<p>A plan-aware program is rejected unless a non-empty plan with the required contract is installed. Every action target must resolve to a stable key authorized by that plan. After matching, exact coverage checks compare planned targets with the targets for which rewrite operations were produced.</p>
 <h2>Text versus structured rules</h2>
-<p>A rule may use ordinary text replacement or structured actions, but a plan-aware rule must not mix both kinds in its alternatives. Split such behaviour into separately identified rules. Text-only rules continue through the established hint rewrite backend; action-only rules create typed AST operations directly.</p>
+<p>Prefer ordinary target code when it fully describes a local transformation. Structured actions are the typed execution form for changes that require plan values, exact target authorization or coordinated AST/import operations. A future declaration-diff compiler can derive these actions from richer before/after declaration syntax without changing their runtime safety contract.</p>
 </body>
 </html>

--- a/sandbox_common/help/language-reference.html
+++ b/sandbox_common/help/language-reference.html
@@ -34,17 +34,25 @@
 <tr><td><code>;;</code></td><td>Terminate one rule.</td></tr>
 <tr><td><code>&amp;&amp;</code>, <code>||</code>, <code>!</code></td><td>Guard conjunction, disjunction and negation.</td></tr>
 </table>
+<h2>Structured action target convention</h2>
+<p>The primary matched node is the implicit target. Add <code>target=$binding</code> only to operate on another bound node.</p>
 <h2>Standard structured actions</h2>
 <ul>
-<li><code>addAnnotation(target=VALUE, annotation=VALUE [, value=VALUE])</code></li>
-<li><code>removeAnnotation(target=VALUE, annotation=VALUE)</code></li>
-<li><code>addModifier(target=VALUE, modifier=VALUE)</code></li>
-<li><code>removeModifier(target=VALUE, modifier=VALUE)</code></li>
-<li><code>removeSupertype(target=VALUE, type=VALUE)</code></li>
-<li><code>replaceSupertype(target=VALUE, type=VALUE, replacement=VALUE)</code></li>
-<li><code>removeDeclaration(target=VALUE)</code></li>
-<li><code>qualifyInvocation(target=VALUE, owner=VALUE)</code></li>
+<li><code>addAnnotation(annotation=VALUE [, value=VALUE] [, target=VALUE])</code></li>
+<li><code>removeAnnotation(annotation=VALUE [, target=VALUE])</code></li>
+<li><code>addModifier(modifier=VALUE [, target=VALUE])</code></li>
+<li><code>removeModifier(modifier=VALUE [, target=VALUE])</code></li>
+<li><code>removeSupertype(type=VALUE [, target=VALUE])</code></li>
+<li><code>replaceSupertype(type=VALUE, replacement=VALUE [, target=VALUE])</code></li>
+<li><code>removeDeclaration([target=VALUE])</code></li>
+<li><code>qualifyInvocation(owner=VALUE [, target=VALUE])</code></li>
+<li><code>renameDeclaration(name=VALUE [, target=VALUE])</code></li>
+<li><code>replaceFieldType(type=VALUE [, target=VALUE])</code></li>
+<li><code>addParameter(type=VALUE, name=VALUE [, index=VALUE] [, target=VALUE])</code></li>
+<li><code>removeParameter(name=VALUE|index=VALUE [, target=VALUE])</code></li>
+<li><code>replaceParameterType(type=VALUE, name=VALUE|index=VALUE [, target=VALUE])</code></li>
 </ul>
+<p>For parameter selection, <code>name</code> is preferred because it remains stable when other parameters are inserted. <code>index</code> is an explicit positional escape hatch.</p>
 <h2>Important plan guards</h2>
 <p><code>plannedRole</code>, <code>enclosingPlannedRole</code>, <code>plannedValue</code>, <code>enclosingPlannedValue</code>, <code>plannedNodeValue</code>, <code>plannedListContains</code>, <code>plannedRelation</code>, <code>plannedRelationValue</code>, <code>plannedOutgoingRelation</code>, <code>plannedIncomingRelation</code> and <code>plannedRelationCount</code>.</p>
 <h2>Compatibility note</h2>

--- a/sandbox_common/src/org/sandbox/jdt/triggerpattern/cleanup/actions/SignatureStructuredRewriteActions.java
+++ b/sandbox_common/src/org/sandbox/jdt/triggerpattern/cleanup/actions/SignatureStructuredRewriteActions.java
@@ -1,0 +1,218 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.cleanup.actions;
+
+import javax.lang.model.SourceVersion;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.FieldDeclaration;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
+import org.eclipse.jdt.core.dom.Type;
+import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
+
+import org.sandbox.jdt.triggerpattern.api.RewriteActionValue;
+import org.sandbox.jdt.triggerpattern.api.StructuredRewriteAction;
+
+/** Typed declaration-signature actions used by coordinated migrations. */
+final class SignatureStructuredRewriteActions {
+
+	private SignatureStructuredRewriteActions() {
+	}
+
+	static void registerAll(StructuredRewriteActionRegistry registry) {
+		registry.register("renameDeclaration", SignatureStructuredRewriteActions::renameDeclaration); //$NON-NLS-1$
+		registry.register("replaceFieldType", SignatureStructuredRewriteActions::replaceFieldType); //$NON-NLS-1$
+		registry.register("addParameter", SignatureStructuredRewriteActions::addParameter); //$NON-NLS-1$
+		registry.register("removeParameter", SignatureStructuredRewriteActions::removeParameter); //$NON-NLS-1$
+		registry.register("replaceParameterType", SignatureStructuredRewriteActions::replaceParameterType); //$NON-NLS-1$
+	}
+
+	private static void renameDeclaration(StructuredRewriteAction action,
+			StructuredRewriteActionContext context) throws CoreException {
+		ASTNode target= context.resolveAuthorizedNode(action.requiredArgument("target")); //$NON-NLS-1$
+		String replacement= validIdentifier(
+				context.resolveString(action.requiredArgument("name")), context); //$NON-NLS-1$
+		SimpleName name= declarationName(target, context);
+		if (name.getIdentifier().equals(replacement)) {
+			throw context.failure("renameDeclaration target already has name " + replacement); //$NON-NLS-1$
+		}
+		context.cuRewrite().getASTRewrite().replace(name,
+				context.ast().newSimpleName(replacement), context.editGroup());
+	}
+
+	private static void replaceFieldType(StructuredRewriteAction action,
+			StructuredRewriteActionContext context) throws CoreException {
+		FieldDeclaration field= fieldTarget(context, action.requiredArgument("target")); //$NON-NLS-1$
+		if (field.fragments().size() != 1) {
+			throw context.failure("replaceFieldType requires a single-fragment field declaration"); //$NON-NLS-1$
+		}
+		Type replacement= context.createType(
+				context.resolveString(action.requiredArgument("type"))); //$NON-NLS-1$
+		replaceType(field.getType(), replacement, context);
+	}
+
+	private static void addParameter(StructuredRewriteAction action,
+			StructuredRewriteActionContext context) throws CoreException {
+		MethodDeclaration method= methodTarget(context, action.requiredArgument("target")); //$NON-NLS-1$
+		String name= validIdentifier(context.resolveString(action.requiredArgument("name")), context); //$NON-NLS-1$
+		if (findParameter(method, name) != null) {
+			throw context.failure("addParameter would duplicate parameter " + name); //$NON-NLS-1$
+		}
+		int index= action.arguments().containsKey("index") //$NON-NLS-1$
+				? context.resolveInteger(action.arguments().get("index")) : method.parameters().size(); //$NON-NLS-1$
+		if (index < 0 || index > method.parameters().size()) {
+			throw context.failure("addParameter index " + index + " is outside 0.." //$NON-NLS-1$ //$NON-NLS-2$
+					+ method.parameters().size());
+		}
+		SingleVariableDeclaration parameter= context.ast().newSingleVariableDeclaration();
+		parameter.setName(context.ast().newSimpleName(name));
+		parameter.setType(context.createType(
+				context.resolveString(action.requiredArgument("type")))); //$NON-NLS-1$
+		parameters(context, method).insertAt(parameter, index, context.editGroup());
+	}
+
+	private static void removeParameter(StructuredRewriteAction action,
+			StructuredRewriteActionContext context) throws CoreException {
+		MethodDeclaration method= methodTarget(context, action.requiredArgument("target")); //$NON-NLS-1$
+		SingleVariableDeclaration parameter= selectedParameter(action, method, context);
+		parameters(context, method).remove(parameter, context.editGroup());
+		context.cuRewrite().getImportRemover().registerRemovedNode(parameter);
+		context.cuRewrite().getImportRemover().applyRemoves(context.cuRewrite().getImportRewrite());
+	}
+
+	private static void replaceParameterType(StructuredRewriteAction action,
+			StructuredRewriteActionContext context) throws CoreException {
+		MethodDeclaration method= methodTarget(context, action.requiredArgument("target")); //$NON-NLS-1$
+		SingleVariableDeclaration parameter= selectedParameter(action, method, context);
+		Type replacement= context.createType(
+				context.resolveString(action.requiredArgument("type"))); //$NON-NLS-1$
+		replaceType(parameter.getType(), replacement, context);
+	}
+
+	private static SingleVariableDeclaration selectedParameter(StructuredRewriteAction action,
+			MethodDeclaration method, StructuredRewriteActionContext context) throws CoreException {
+		boolean hasName= action.arguments().containsKey("name"); //$NON-NLS-1$
+		boolean hasIndex= action.arguments().containsKey("index"); //$NON-NLS-1$
+		if (hasName == hasIndex) {
+			throw context.failure(action.name()
+					+ " requires exactly one parameter selector: name or index"); //$NON-NLS-1$
+		}
+		if (hasName) {
+			String name= context.resolveString(action.arguments().get("name")); //$NON-NLS-1$
+			SingleVariableDeclaration parameter= findParameter(method, name);
+			if (parameter == null) {
+				throw context.failure(action.name() + " cannot find parameter named " + name); //$NON-NLS-1$
+			}
+			return parameter;
+		}
+		int index= context.resolveInteger(action.arguments().get("index")); //$NON-NLS-1$
+		if (index < 0 || index >= method.parameters().size()) {
+			throw context.failure(action.name() + " index " + index + " is outside 0.." //$NON-NLS-1$ //$NON-NLS-2$
+					+ Math.max(-1, method.parameters().size() - 1));
+		}
+		return (SingleVariableDeclaration) method.parameters().get(index);
+	}
+
+	private static SingleVariableDeclaration findParameter(MethodDeclaration method, String name) {
+		for (Object parameterObject : method.parameters()) {
+			SingleVariableDeclaration parameter= (SingleVariableDeclaration) parameterObject;
+			if (name.equals(parameter.getName().getIdentifier())) {
+				return parameter;
+			}
+		}
+		return null;
+	}
+
+	private static SimpleName declarationName(ASTNode target,
+			StructuredRewriteActionContext context) throws CoreException {
+		if (target instanceof MethodDeclaration method) {
+			if (method.isConstructor()) {
+				throw context.failure("renameDeclaration does not rename constructors or their declaring types"); //$NON-NLS-1$
+			}
+			return method.getName();
+		}
+		if (target instanceof FieldDeclaration field && field.fragments().size() == 1) {
+			return ((VariableDeclarationFragment) field.fragments().get(0)).getName();
+		}
+		if (target instanceof VariableDeclarationFragment fragment
+				&& fragment.getParent() instanceof FieldDeclaration) {
+			return fragment.getName();
+		}
+		if (target instanceof SimpleName simple && simple.getParent() instanceof MethodDeclaration method
+				&& method.getName() == simple && !method.isConstructor()) {
+			return simple;
+		}
+		if (target instanceof SimpleName simple
+				&& simple.getParent() instanceof VariableDeclarationFragment fragment
+				&& fragment.getName() == simple && fragment.getParent() instanceof FieldDeclaration) {
+			return simple;
+		}
+		throw context.failure("renameDeclaration requires an exact planned method or single field declaration"); //$NON-NLS-1$
+	}
+
+	private static MethodDeclaration methodTarget(StructuredRewriteActionContext context,
+			RewriteActionValue value) throws CoreException {
+		ASTNode target= context.resolveAuthorizedNode(value);
+		if (target instanceof MethodDeclaration method) {
+			return method;
+		}
+		if (target instanceof SimpleName name && name.getParent() instanceof MethodDeclaration method
+				&& method.getName() == name) {
+			return method;
+		}
+		throw context.failure("Structured signature action target is not an exact method declaration"); //$NON-NLS-1$
+	}
+
+	private static FieldDeclaration fieldTarget(StructuredRewriteActionContext context,
+			RewriteActionValue value) throws CoreException {
+		ASTNode target= context.resolveAuthorizedNode(value);
+		if (target instanceof FieldDeclaration field) {
+			return field;
+		}
+		if (target instanceof VariableDeclarationFragment fragment
+				&& fragment.getParent() instanceof FieldDeclaration field) {
+			return field;
+		}
+		if (target instanceof SimpleName name && name.getParent() instanceof VariableDeclarationFragment fragment
+				&& fragment.getName() == name && fragment.getParent() instanceof FieldDeclaration field) {
+			return field;
+		}
+		throw context.failure("Structured field action target is not an exact field declaration"); //$NON-NLS-1$
+	}
+
+	private static ListRewrite parameters(StructuredRewriteActionContext context,
+			MethodDeclaration method) {
+		return context.cuRewrite().getASTRewrite()
+				.getListRewrite(method, MethodDeclaration.PARAMETERS_PROPERTY);
+	}
+
+	private static void replaceType(Type existing, Type replacement,
+			StructuredRewriteActionContext context) {
+		ASTRewrite rewrite= context.cuRewrite().getASTRewrite();
+		rewrite.replace(existing, replacement, context.editGroup());
+		context.cuRewrite().getImportRemover().registerRemovedNode(existing);
+		context.cuRewrite().getImportRemover().applyRemoves(context.cuRewrite().getImportRewrite());
+	}
+
+	private static String validIdentifier(String candidate,
+			StructuredRewriteActionContext context) throws CoreException {
+		if (!SourceVersion.isIdentifier(candidate) || SourceVersion.isKeyword(candidate)) {
+			throw context.failure("Structured action name is not a Java identifier: " + candidate); //$NON-NLS-1$
+		}
+		return candidate;
+	}
+}

--- a/sandbox_common/src/org/sandbox/jdt/triggerpattern/cleanup/actions/StructuredRewriteActionContext.java
+++ b/sandbox_common/src/org/sandbox/jdt/triggerpattern/cleanup/actions/StructuredRewriteActionContext.java
@@ -21,9 +21,15 @@ import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ArrayInitializer;
 import org.eclipse.jdt.core.dom.BooleanLiteral;
 import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.NumberLiteral;
+import org.eclipse.jdt.core.dom.PrimitiveType;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
 import org.eclipse.jdt.core.dom.StringLiteral;
+import org.eclipse.jdt.core.dom.Type;
 import org.eclipse.jdt.core.dom.TypeLiteral;
+import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
 import org.eclipse.text.edits.TextEditGroup;
@@ -70,7 +76,7 @@ public final class StructuredRewriteActionContext {
 		return cuRewrite.getRoot().getAST();
 	}
 
-	/** Resolves an exact binding and verifies that it participates in the plan. */
+	/** Resolves an exact target and verifies that it participates in the plan. */
 	public ASTNode resolveAuthorizedNode(RewriteActionValue value) throws CoreException {
 		ASTNode node= resolveNode(value);
 		NodeKey key= NodeKey.from(node);
@@ -86,8 +92,15 @@ public final class StructuredRewriteActionContext {
 		return node;
 	}
 
-	/** Resolves a binding-valued action expression. */
+	/** Resolves the primary match or one explicit pattern binding. */
 	public ASTNode resolveNode(RewriteActionValue value) throws CoreException {
+		if (value instanceof RewriteActionValue.MatchedNode) {
+			ASTNode node= result.match().getMatchedNode();
+			if (node == null) {
+				throw failure("Structured action has no primary matched node"); //$NON-NLS-1$
+			}
+			return node;
+		}
 		if (value instanceof RewriteActionValue.Binding binding) {
 			ASTNode node= result.match().getBinding(binding.placeholder());
 			if (node == null) {
@@ -95,7 +108,7 @@ public final class StructuredRewriteActionContext {
 			}
 			return node;
 		}
-		throw failure("Structured action target must be a pattern binding"); //$NON-NLS-1$
+		throw failure("Structured action target must be the primary match or a pattern binding"); //$NON-NLS-1$
 	}
 
 	/** Resolves a scalar typed value, including one semantic-plan fact reference. */
@@ -113,20 +126,88 @@ public final class StructuredRewriteActionContext {
 			return plan.value(target, reference.factName()).orElseThrow(() ->
 					failure("Missing semantic-plan fact " + reference.factName())); //$NON-NLS-1$
 		}
-		if (value instanceof RewriteActionValue.Binding binding) {
-			NodeKey key= NodeKey.from(resolveAuthorizedNode(binding));
+		if (value instanceof RewriteActionValue.Binding || value instanceof RewriteActionValue.MatchedNode) {
+			NodeKey key= NodeKey.from(resolveAuthorizedNode(value));
 			return SemanticPlanValue.node(key);
 		}
 		throw failure("Expected a scalar structured action value"); //$NON-NLS-1$
 	}
 
-	/** Resolves an exact string or enum-like plan value. */
+	/**
+	 * Resolves a literal/plan string or derives an identifier from one bound
+	 * declaration name. The latter lets a declaration-diff compiler reuse the
+	 * source placeholder instead of copying its runtime name into the DSL.
+	 */
 	public String resolveString(RewriteActionValue value) throws CoreException {
+		if (value instanceof RewriteActionValue.Binding || value instanceof RewriteActionValue.MatchedNode) {
+			ASTNode node= resolveNode(value);
+			if (node instanceof SimpleName name) {
+				return name.getIdentifier();
+			}
+			if (node instanceof SingleVariableDeclaration parameter) {
+				return parameter.getName().getIdentifier();
+			}
+			if (node instanceof MethodDeclaration method) {
+				return method.getName().getIdentifier();
+			}
+			if (node instanceof VariableDeclarationFragment fragment) {
+				return fragment.getName().getIdentifier();
+			}
+			throw failure("Bound action value does not denote a Java declaration name"); //$NON-NLS-1$
+		}
 		SemanticPlanValue resolved= resolveSemanticValue(value);
 		if (resolved instanceof SemanticPlanValue.StringValue string) {
 			return string.value();
 		}
 		throw failure("Structured action value must resolve to a string, but was " + resolved.kind()); //$NON-NLS-1$
+	}
+
+	/** Resolves an integer value without narrowing silently. */
+	public int resolveInteger(RewriteActionValue value) throws CoreException {
+		SemanticPlanValue resolved= resolveSemanticValue(value);
+		if (resolved instanceof SemanticPlanValue.IntegerValue integer
+				&& integer.value() >= Integer.MIN_VALUE && integer.value() <= Integer.MAX_VALUE) {
+			return (int) integer.value();
+		}
+		throw failure("Structured action value must resolve to a 32-bit integer, but was " //$NON-NLS-1$
+				+ resolved.kind());
+	}
+
+	/**
+	 * Creates one detached primitive, imported reference or array type.
+	 *
+	 * <p>Signature actions intentionally reject generic, wildcard, varargs and
+	 * {@code void} source text. Richer type shapes need dedicated typed values,
+	 * not arbitrary Java fragments embedded in strings.</p>
+	 */
+	public Type createType(String requestedType) throws CoreException {
+		if (requestedType == null || requestedType.isBlank()) {
+			throw failure("Structured action type must not be blank"); //$NON-NLS-1$
+		}
+		String typeName= requestedType.trim();
+		if (typeName.indexOf('<') >= 0 || typeName.indexOf('>') >= 0
+				|| typeName.indexOf('?') >= 0 || typeName.endsWith("...")) { //$NON-NLS-1$
+			throw failure("Structured signature actions currently support primitive, reference and array types only: " //$NON-NLS-1$
+					+ typeName);
+		}
+		int dimensions= 0;
+		while (typeName.endsWith("[]")) { //$NON-NLS-1$
+			dimensions++;
+			typeName= typeName.substring(0, typeName.length() - 2).trim();
+		}
+		PrimitiveType.Code primitive= PrimitiveType.toCode(typeName);
+		if (primitive == PrimitiveType.VOID) {
+			throw failure("Structured signature actions cannot use void as a field or parameter type"); //$NON-NLS-1$
+		}
+		Type elementType;
+		try {
+			elementType= primitive == null
+					? ast().newSimpleType(ast().newName(cuRewrite.getImportRewrite().addImport(typeName)))
+					: ast().newPrimitiveType(primitive);
+		} catch (IllegalArgumentException exception) {
+			throw failure("Structured action type is not a valid Java type name: " + requestedType); //$NON-NLS-1$
+		}
+		return dimensions == 0 ? elementType : ast().newArrayType(elementType, dimensions);
 	}
 
 	/** Builds one detached AST expression from a typed action value. */

--- a/sandbox_common/src/org/sandbox/jdt/triggerpattern/cleanup/actions/StructuredRewriteActionRegistry.java
+++ b/sandbox_common/src/org/sandbox/jdt/triggerpattern/cleanup/actions/StructuredRewriteActionRegistry.java
@@ -29,6 +29,7 @@ public final class StructuredRewriteActionRegistry {
 
 	private StructuredRewriteActionRegistry() {
 		BuiltInStructuredRewriteActions.registerAll(this);
+		SignatureStructuredRewriteActions.registerAll(this);
 	}
 
 	public static StructuredRewriteActionRegistry getInstance() {

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/api/RewriteActionCatalog.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/api/RewriteActionCatalog.java
@@ -19,23 +19,35 @@ import java.util.Set;
 /** Immutable catalog of schema-validated structured rewrite actions. */
 public final class RewriteActionCatalog {
 
+	private static final Set<String> TARGET= Set.of("target"); //$NON-NLS-1$
+
 	private static final RewriteActionCatalog STANDARD= builder()
-			.register(schema("addAnnotation", Set.of("target", "annotation"), Set.of("value"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-					"Add a marker, single-value or array annotation")) //$NON-NLS-1$
-			.register(schema("removeAnnotation", Set.of("target", "annotation"), Set.of(), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-					"Remove one validated annotation")) //$NON-NLS-1$
-			.register(schema("addModifier", Set.of("target", "modifier"), Set.of(), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			.register(schema("addAnnotation", Set.of("annotation"), Set.of("target", "value"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+					"Add a marker, single-value or array annotation to the primary match or an explicit target")) //$NON-NLS-1$
+			.register(schema("removeAnnotation", Set.of("annotation"), TARGET, //$NON-NLS-1$ //$NON-NLS-2$
+					"Remove one validated annotation from the primary match or an explicit target")) //$NON-NLS-1$
+			.register(schema("addModifier", Set.of("modifier"), TARGET, //$NON-NLS-1$ //$NON-NLS-2$
 					"Add one Java declaration modifier")) //$NON-NLS-1$
-			.register(schema("removeModifier", Set.of("target", "modifier"), Set.of(), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			.register(schema("removeModifier", Set.of("modifier"), TARGET, //$NON-NLS-1$ //$NON-NLS-2$
 					"Remove one Java declaration modifier")) //$NON-NLS-1$
-			.register(schema("removeSupertype", Set.of("target", "type"), Set.of(), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			.register(schema("removeSupertype", Set.of("type"), TARGET, //$NON-NLS-1$ //$NON-NLS-2$
 					"Remove one binding-validated superclass or interface")) //$NON-NLS-1$
-			.register(schema("replaceSupertype", Set.of("target", "type", "replacement"), Set.of(), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+			.register(schema("replaceSupertype", Set.of("type", "replacement"), TARGET, //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 					"Replace one binding-validated superclass or interface")) //$NON-NLS-1$
-			.register(schema("removeDeclaration", Set.of("target"), Set.of(), //$NON-NLS-1$ //$NON-NLS-2$
-					"Remove one exact declaration")) //$NON-NLS-1$
-			.register(schema("qualifyInvocation", Set.of("target", "owner"), Set.of(), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			.register(schema("removeDeclaration", Set.of(), TARGET, //$NON-NLS-1$
+					"Remove the primary matched declaration or an explicit target")) //$NON-NLS-1$
+			.register(schema("qualifyInvocation", Set.of("owner"), TARGET, //$NON-NLS-1$ //$NON-NLS-2$
 					"Qualify one exact static method invocation")) //$NON-NLS-1$
+			.register(schema("renameDeclaration", Set.of("name"), TARGET, //$NON-NLS-1$ //$NON-NLS-2$
+					"Rename one exact planned method or field declaration")) //$NON-NLS-1$
+			.register(schema("replaceFieldType", Set.of("type"), TARGET, //$NON-NLS-1$ //$NON-NLS-2$
+					"Replace the type of one single-fragment planned field")) //$NON-NLS-1$
+			.register(schema("addParameter", Set.of("type", "name"), Set.of("target", "index"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+					"Add one parameter to an exact planned method or constructor")) //$NON-NLS-1$
+			.register(schema("removeParameter", Set.of(), Set.of("target", "name", "index"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+					"Remove one parameter selected by stable name or, as an escape hatch, index")) //$NON-NLS-1$
+			.register(schema("replaceParameterType", Set.of("type"), Set.of("target", "name", "index"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+					"Replace one parameter type selected by stable name or index")) //$NON-NLS-1$
 			.build();
 
 	private final Map<String, RewriteActionSchema> schemas;

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/api/RewriteActionValue.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/api/RewriteActionValue.java
@@ -17,18 +17,23 @@ import java.util.Objects;
 /**
  * Immutable value expression used by a {@link StructuredRewriteAction}.
  *
- * <p>Action values remain declarative. They can reference one pattern binding,
- * read a typed semantic-plan fact, or describe Java annotation expressions such
- * as class literals, names and arrays without embedding arbitrary Java code.</p>
+ * <p>Action values remain declarative. They can reference the primary match,
+ * one pattern binding, a typed semantic-plan fact, or Java annotation values
+ * without embedding arbitrary Java code.</p>
  */
 public sealed interface RewriteActionValue permits RewriteActionValue.Literal,
-		RewriteActionValue.Binding, RewriteActionValue.PlanValue,
-		RewriteActionValue.ClassLiteral, RewriteActionValue.Name,
-		RewriteActionValue.ListValue {
+		RewriteActionValue.MatchedNode, RewriteActionValue.Binding,
+		RewriteActionValue.PlanValue, RewriteActionValue.ClassLiteral,
+		RewriteActionValue.Name, RewriteActionValue.ListValue {
 
 	/** Creates a typed literal value. */
 	static Literal literal(SemanticPlanValue value) {
 		return new Literal(value);
+	}
+
+	/** Refers to the rule's primary matched AST node. */
+	static MatchedNode matchedNode() {
+		return MatchedNode.INSTANCE;
 	}
 
 	/** Creates a reference to an exact pattern binding such as {@code $method}. */
@@ -66,6 +71,11 @@ public sealed interface RewriteActionValue permits RewriteActionValue.Literal,
 		public Literal {
 			Objects.requireNonNull(value);
 		}
+	}
+
+	/** Internal value denoting the rule's primary matched node. */
+	record MatchedNode() implements RewriteActionValue {
+		private static final MatchedNode INSTANCE= new MatchedNode();
 	}
 
 	/** Exact pattern-binding reference. */

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/api/StructuredRewriteAction.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/api/StructuredRewriteAction.java
@@ -38,9 +38,18 @@ public record StructuredRewriteAction(String name, Map<String, RewriteActionValu
 		}
 	}
 
-	/** Returns one required argument or fails with an actionable diagnostic. */
+	/**
+	 * Returns one required argument.
+	 *
+	 * <p>The conventional {@code target} argument defaults to the rule's primary
+	 * matched node. Authors only need to specify it when an action operates on a
+	 * different bound node.</p>
+	 */
 	public RewriteActionValue requiredArgument(String argumentName) {
 		RewriteActionValue value= arguments.get(argumentName);
+		if (value == null && "target".equals(argumentName)) { //$NON-NLS-1$
+			return RewriteActionValue.matchedNode();
+		}
 		if (value == null) {
 			throw new IllegalArgumentException("Action " + name + " requires argument " + argumentName); //$NON-NLS-1$ //$NON-NLS-2$
 		}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/HintDeclarationDiffPreprocessor.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/HintDeclarationDiffPreprocessor.java
@@ -1,0 +1,343 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.internal;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.Annotation;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.Modifier;
+import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
+
+import org.sandbox.jdt.triggerpattern.api.HintPlanRequirement;
+import org.sandbox.jdt.triggerpattern.api.Pattern;
+import org.sandbox.jdt.triggerpattern.api.PatternKind;
+import org.sandbox.jdt.triggerpattern.internal.HintFileParser.HintParseException;
+
+/**
+ * Lowers unambiguous plan-aware method declaration diffs to structured actions.
+ *
+ * <p>This is deliberately a small compiler, not a general Java text rewriter.
+ * It accepts one-line method headers without annotations, bodies, varargs,
+ * generic parameters or changed throws/return contracts. The supported surface
+ * covers method renames, modifier changes, retained-parameter type changes,
+ * parameter removals and append-only parameter additions. Anything ambiguous
+ * fails with a source diagnostic rather than silently becoming a text rewrite.</p>
+ */
+final class HintDeclarationDiffPreprocessor {
+
+	private HintDeclarationDiffPreprocessor() {
+	}
+
+	static String preprocess(String source) throws HintParseException {
+		String normalized= source == null ? "" : source.replace("\r\n", "\n").replace('\r', '\n'); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		if (HintPlanRequirement.fromContent(normalized).isEmpty()) {
+			return normalized;
+		}
+		String[] lines= normalized.split("\n", -1); //$NON-NLS-1$
+		List<String> output= new ArrayList<>(lines.length);
+		boolean inBlockComment= false;
+		boolean inEmbeddedJava= false;
+		int ruleStart= 0;
+
+		for (int lineIndex= 0; lineIndex < lines.length; lineIndex++) {
+			String line= lines[lineIndex];
+			String trimmed= line.stripLeading();
+			boolean visible= true;
+			if (inEmbeddedJava) {
+				visible= false;
+				if (trimmed.contains("?>")) { //$NON-NLS-1$
+					inEmbeddedJava= false;
+				}
+			} else if (inBlockComment) {
+				visible= false;
+				if (trimmed.contains("*/")) { //$NON-NLS-1$
+					inBlockComment= false;
+				}
+			} else if (trimmed.startsWith("<?")) { //$NON-NLS-1$
+				visible= false;
+				inEmbeddedJava= !trimmed.contains("?>"); //$NON-NLS-1$
+			} else if (trimmed.startsWith("/*")) { //$NON-NLS-1$
+				visible= false;
+				inBlockComment= !trimmed.contains("*/"); //$NON-NLS-1$
+			} else if (trimmed.startsWith("//")) { //$NON-NLS-1$
+				visible= false;
+			}
+
+			if (visible && trimmed.startsWith("=>") && !trimmed.startsWith("=>!")) { //$NON-NLS-1$ //$NON-NLS-2$
+				int sourceIndex= previousSourceLine(output, ruleStart);
+				if (sourceIndex >= 0) {
+					ActionAndGuard sourceSplit= splitGuard(output.get(sourceIndex).stripLeading());
+					ActionAndGuard targetSplit= splitGuard(trimmed.substring(2).trim());
+					Compilation compilation= compile(sourceSplit.actionText(), targetSplit.actionText(),
+							sourceIndex + 1, lineIndex + 1);
+					if (compilation != null && !compilation.actions().isEmpty()) {
+						String indentation= line.substring(0, line.length() - trimmed.length());
+						appendActions(output, indentation, compilation.actions(), targetSplit.guardText());
+						continue;
+					}
+				}
+			}
+
+			output.add(line);
+			if (visible && ";;".equals(trimmed)) { //$NON-NLS-1$
+				ruleStart= output.size();
+			}
+		}
+		return String.join("\n", output); //$NON-NLS-1$
+	}
+
+	private static int previousSourceLine(List<String> output, int ruleStart) {
+		for (int index= output.size() - 1; index >= ruleStart; index--) {
+			String candidate= output.get(index).stripLeading();
+			if (candidate.isBlank() || candidate.startsWith("@") //$NON-NLS-1$
+					|| candidate.startsWith("//") || candidate.startsWith("/*") //$NON-NLS-1$ //$NON-NLS-2$
+					|| candidate.startsWith("\"") || candidate.startsWith("<!")) { //$NON-NLS-1$ //$NON-NLS-2$
+				continue;
+			}
+			return index;
+		}
+		return -1;
+	}
+
+	private static void appendActions(List<String> output, String indentation,
+			List<String> actions, String guard) {
+		for (int index= 0; index < actions.size(); index++) {
+			String prefix= index == 0 ? "=>! " : "    "; //$NON-NLS-1$ //$NON-NLS-2$
+			String suffix= index + 1 < actions.size() ? ";" : ""; //$NON-NLS-1$ //$NON-NLS-2$
+			if (index + 1 == actions.size() && guard != null) {
+				suffix+= " :: " + guard.trim(); //$NON-NLS-1$
+			}
+			output.add(indentation + prefix + actions.get(index) + suffix);
+		}
+	}
+
+	private static Compilation compile(String sourceText, String targetText,
+			int sourceLine, int targetLine) throws HintParseException {
+		MethodShape source= MethodShape.parse(sourceText);
+		MethodShape target= MethodShape.parse(targetText);
+		if (source == null || target == null) {
+			return null;
+		}
+		if (source.hasAnnotations() || target.hasAnnotations()) {
+			return null;
+		}
+		if (source.constructor() || target.constructor()) {
+			return null;
+		}
+		if (!source.returnType().equals(target.returnType())) {
+			throw new HintParseException(
+					"Method declaration diff cannot change the return type yet; use a dedicated typed action", //$NON-NLS-1$
+					targetLine);
+		}
+		if (!source.typeParameters().equals(target.typeParameters())
+				|| !source.thrownTypes().equals(target.thrownTypes())) {
+			throw new HintParseException(
+					"Method declaration diff cannot change type parameters or thrown exceptions", targetLine); //$NON-NLS-1$
+		}
+		if (source.parameters().stream().anyMatch(ParameterShape::varargs)
+				|| target.parameters().stream().anyMatch(ParameterShape::varargs)) {
+			return null;
+		}
+
+		List<String> actions= new ArrayList<>();
+		compileName(source, target, actions, targetLine);
+		compileModifiers(source, target, actions);
+		compileParameters(source, target, actions, sourceLine, targetLine);
+		return new Compilation(actions);
+	}
+
+	private static void compileName(MethodShape source, MethodShape target,
+			List<String> actions, int targetLine) throws HintParseException {
+		if (source.name().equals(target.name())) {
+			return;
+		}
+		if (target.name().startsWith("$")) { //$NON-NLS-1$
+			throw new HintParseException(
+					"A changed method name must be a concrete target identifier", targetLine); //$NON-NLS-1$
+		}
+		actions.add("renameDeclaration(name=" + quote(target.name()) + ")"); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	private static void compileModifiers(MethodShape source, MethodShape target,
+			List<String> actions) {
+		for (String modifier : source.modifiers()) {
+			if (!target.modifiers().contains(modifier)) {
+				actions.add("removeModifier(modifier=" + modifier + ")"); //$NON-NLS-1$ //$NON-NLS-2$
+			}
+		}
+		for (String modifier : target.modifiers()) {
+			if (!source.modifiers().contains(modifier)) {
+				actions.add("addModifier(modifier=" + modifier + ")"); //$NON-NLS-1$ //$NON-NLS-2$
+			}
+		}
+	}
+
+	private static void compileParameters(MethodShape source, MethodShape target,
+			List<String> actions, int sourceLine, int targetLine) throws HintParseException {
+		Map<String, ParameterShape> sourceByName= uniqueParameters(source.parameters(), sourceLine);
+		Map<String, ParameterShape> targetByName= uniqueParameters(target.parameters(), targetLine);
+
+		List<String> retainedInSource= source.parameters().stream().map(ParameterShape::name)
+				.filter(targetByName::containsKey).toList();
+		List<String> retainedInTarget= target.parameters().stream().map(ParameterShape::name)
+				.filter(sourceByName::containsKey).toList();
+		if (!retainedInSource.equals(retainedInTarget)) {
+			throw new HintParseException(
+					"Method declaration diff cannot reorder retained parameters; bind them in their original order", //$NON-NLS-1$
+					targetLine);
+		}
+
+		boolean seenAdded= false;
+		for (ParameterShape parameter : target.parameters()) {
+			if (!sourceByName.containsKey(parameter.name())) {
+				seenAdded= true;
+				if (parameter.name().startsWith("$")) { //$NON-NLS-1$
+					throw new HintParseException(
+							"New parameters need a concrete target name", targetLine); //$NON-NLS-1$
+				}
+			} else if (seenAdded) {
+				throw new HintParseException(
+						"New parameters are currently append-only in declaration diffs", targetLine); //$NON-NLS-1$
+			}
+		}
+
+		for (ParameterShape sourceParameter : source.parameters()) {
+			ParameterShape targetParameter= targetByName.get(sourceParameter.name());
+			if (targetParameter == null) {
+				actions.add("removeParameter(name=" + selector(sourceParameter.name()) + ")"); //$NON-NLS-1$ //$NON-NLS-2$
+			} else if (!sourceParameter.type().equals(targetParameter.type())) {
+				ensureSupportedType(targetParameter.type(), targetLine);
+				actions.add("replaceParameterType(name=" + selector(sourceParameter.name()) //$NON-NLS-1$
+						+ ", type=" + quote(targetParameter.type()) + ")"); //$NON-NLS-1$ //$NON-NLS-2$
+			}
+		}
+		for (ParameterShape targetParameter : target.parameters()) {
+			if (!sourceByName.containsKey(targetParameter.name())) {
+				ensureSupportedType(targetParameter.type(), targetLine);
+				actions.add("addParameter(type=" + quote(targetParameter.type()) //$NON-NLS-1$
+						+ ", name=" + quote(targetParameter.name()) + ")"); //$NON-NLS-1$ //$NON-NLS-2$
+			}
+		}
+	}
+
+	private static Map<String, ParameterShape> uniqueParameters(List<ParameterShape> parameters,
+			int line) throws HintParseException {
+		Map<String, ParameterShape> result= new LinkedHashMap<>();
+		for (ParameterShape parameter : parameters) {
+			if (result.putIfAbsent(parameter.name(), parameter) != null) {
+				throw new HintParseException("Method declaration contains duplicate parameter name " //$NON-NLS-1$
+						+ parameter.name(), line);
+			}
+		}
+		return result;
+	}
+
+	private static void ensureSupportedType(String type, int line) throws HintParseException {
+		if (type.indexOf('<') >= 0 || type.indexOf('>') >= 0 || type.indexOf('?') >= 0
+				|| type.endsWith("...") || type.contains("$")) { //$NON-NLS-1$ //$NON-NLS-2$
+			throw new HintParseException(
+					"Declaration diff target type requires a dedicated typed representation: " + type, line); //$NON-NLS-1$
+		}
+	}
+
+	private static String selector(String name) {
+		return name.startsWith("$") ? name : quote(name); //$NON-NLS-1$
+	}
+
+	private static String quote(String value) {
+		return '"' + value.replace("\\", "\\\\").replace("\"", "\\\"") + '"'; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+	}
+
+	private static ActionAndGuard splitGuard(String text) {
+		int depth= 0;
+		boolean inQuote= false;
+		boolean escaped= false;
+		for (int index= 0; index < text.length() - 1; index++) {
+			char current= text.charAt(index);
+			if (inQuote) {
+				if (escaped) {
+					escaped= false;
+				} else if (current == '\\') {
+					escaped= true;
+				} else if (current == '"') {
+					inQuote= false;
+				}
+				continue;
+			}
+			if (current == '"') {
+				inQuote= true;
+			} else if (current == '(') {
+				depth++;
+			} else if (current == ')') {
+				depth--;
+			} else if (depth == 0 && current == ':' && text.charAt(index + 1) == ':') {
+				return new ActionAndGuard(text.substring(0, index), text.substring(index + 2));
+			}
+		}
+		return new ActionAndGuard(text, null);
+	}
+
+	private record ActionAndGuard(String actionText, String guardText) {
+	}
+
+	private record Compilation(List<String> actions) {
+		Compilation {
+			actions= List.copyOf(actions);
+		}
+	}
+
+	private record ParameterShape(String name, String type, boolean varargs) {
+	}
+
+	private record MethodShape(String name, String returnType, List<ParameterShape> parameters,
+			Set<String> modifiers, List<String> typeParameters, List<String> thrownTypes,
+			boolean hasAnnotations, boolean constructor) {
+
+		static MethodShape parse(String text) {
+			if (text == null || text.isBlank() || text.contains("{") || text.contains("}")) { //$NON-NLS-1$ //$NON-NLS-2$
+				return null;
+			}
+			ASTNode parsed= new PatternParser().parse(Pattern.of(text.trim(), PatternKind.METHOD_DECLARATION));
+			if (!(parsed instanceof MethodDeclaration method)) {
+				return null;
+			}
+			boolean annotations= method.modifiers().stream().anyMatch(Annotation.class::isInstance);
+			Set<String> modifiers= new LinkedHashSet<>();
+			for (Object modifierObject : method.modifiers()) {
+				if (modifierObject instanceof Modifier modifier) {
+					modifiers.add(modifier.getKeyword().toString());
+				}
+			}
+			List<ParameterShape> parameters= new ArrayList<>();
+			for (Object parameterObject : method.parameters()) {
+				SingleVariableDeclaration parameter= (SingleVariableDeclaration) parameterObject;
+				String type= parameter.getType().toString();
+				for (int dimension= 0; dimension < parameter.getExtraDimensions(); dimension++) {
+					type+= "[]"; //$NON-NLS-1$
+				}
+				parameters.add(new ParameterShape(parameter.getName().getIdentifier(), type,
+						parameter.isVarargs()));
+			}
+			String returnType= method.getReturnType2() == null ? "" : method.getReturnType2().toString(); //$NON-NLS-1$
+			return new MethodShape(method.getName().getIdentifier(), returnType, parameters,
+					Set.copyOf(modifiers), method.typeParameters().stream().map(Object::toString).toList(),
+					method.thrownExceptionTypes().stream().map(Object::toString).toList(),
+					annotations, method.isConstructor());
+		}
+	}
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/HintDeclarationDiffPreprocessor.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/HintDeclarationDiffPreprocessor.java
@@ -235,7 +235,7 @@ final class HintDeclarationDiffPreprocessor {
 		}
 	}
 
-	private static Map<String, ParameterShape> uniqueParameters(List<ParameterShape> parameters,
+	private static Map<String, ParameterShape> uniqueParameters(Iterable<ParameterShape> parameters,
 			int line) throws HintParseException {
 		Map<String, ParameterShape> result= new LinkedHashMap<>();
 		for (ParameterShape parameter : parameters) {
@@ -323,7 +323,7 @@ final class HintDeclarationDiffPreprocessor {
 					modifiers.add(modifier.getKeyword().toString());
 				}
 			}
-			List<ParameterShape> parameters= new ArrayList<>();
+			List<ParameterShape> parameters= new ArrayList<>(method.parameters().size());
 			for (Object parameterObject : method.parameters()) {
 				SingleVariableDeclaration parameter= (SingleVariableDeclaration) parameterObject;
 				String type= parameter.getType().toString();

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/HintLanguageVocabulary.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/HintLanguageVocabulary.java
@@ -121,12 +121,20 @@ public final class HintLanguageVocabulary {
 		String documentedRequired= schema.requiredArguments().stream().sorted()
 				.map(name -> name + "=VALUE") //$NON-NLS-1$
 				.collect(java.util.stream.Collectors.joining(", ")); //$NON-NLS-1$
-		String documentedOptional= schema.optionalArguments().stream().sorted()
-				.map(name -> "[, " + name + "=VALUE]") //$NON-NLS-1$ //$NON-NLS-2$
-				.collect(java.util.stream.Collectors.joining());
+		String documentedOptional= optionalSyntax(schema, !documentedRequired.isEmpty());
 		String replacement= schema.name() + "(" + replacementArguments + ")"; //$NON-NLS-1$ //$NON-NLS-2$
 		String syntax= "=>! " + schema.name() + "(" + documentedRequired + documentedOptional + ")"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		return new Action(schema.name(), replacement, syntax, schema.description());
+	}
+
+	private static String optionalSyntax(RewriteActionSchema schema, boolean followsRequired) {
+		List<String> optional= schema.optionalArguments().stream().sorted().toList();
+		StringBuilder result= new StringBuilder();
+		for (int index= 0; index < optional.size(); index++) {
+			String prefix= followsRequired || index > 0 ? ", " : ""; //$NON-NLS-1$ //$NON-NLS-2$
+			result.append('[').append(prefix).append(optional.get(index)).append("=VALUE]"); //$NON-NLS-1$
+		}
+		return result.toString();
 	}
 
 	private static String humanize(String name) {

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/HintProgramParser.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/triggerpattern/internal/HintProgramParser.java
@@ -118,8 +118,9 @@ public final class HintProgramParser {
 		validatePredicateNames(predicates.predicates());
 		HintRuleKindPreprocessor.Result kinds=
 				HintRuleKindPreprocessor.preprocess(predicates.expandedSource());
+		String declarationDiffs= HintDeclarationDiffPreprocessor.preprocess(kinds.parserSource());
 		String normalizedTypeSources= HintTypeDeclarationSourcePreprocessor.preprocess(
-				kinds.parserSource(), kinds.kindsByRuleId());
+				declarationDiffs, kinds.kindsByRuleId());
 		HintStructuredActionPreprocessor.Result actions=
 				HintStructuredActionPreprocessor.preprocess(normalizedTypeSources, catalog);
 		return new PreparedProgram(predicates.predicates(), actions.parserSource(),

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/internal/HintDeclarationDiffPreprocessorTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/internal/HintDeclarationDiffPreprocessorTest.java
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import org.sandbox.jdt.triggerpattern.api.HintFile;
+import org.sandbox.jdt.triggerpattern.api.RewriteActionValue;
+import org.sandbox.jdt.triggerpattern.api.SemanticPlanValue;
+import org.sandbox.jdt.triggerpattern.api.StructuredRewriteAction;
+import org.sandbox.jdt.triggerpattern.internal.HintFileParser.HintParseException;
+
+class HintDeclarationDiffPreprocessorTest {
+
+	@Test
+	void lowersOneTargetDeclarationToTypedActions() throws Exception {
+		String source= """
+				<!requires-plan: signature-demo>
+				@id: signature.demo
+				public void $method(String $value, int $obsolete)
+				=> protected void parameterized(Integer $value, long count)
+				;;
+				""";
+
+		HintProgramParser.ParsedProgram program= new HintProgramParser().parse(source);
+		HintFile hint= program.hintFile();
+		List<StructuredRewriteAction> actions= hint.getRules().get(0)
+				.alternatives().get(0).structuredActions();
+
+		assertEquals(List.of("renameDeclaration", "removeModifier", "addModifier", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+				"replaceParameterType", "removeParameter", "addParameter"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+				actions.stream().map(StructuredRewriteAction::name).toList());
+		assertTrue(actions.stream().noneMatch(action -> action.arguments().containsKey("target"))); //$NON-NLS-1$
+		assertEquals(new RewriteActionValue.Literal(SemanticPlanValue.string("parameterized")), //$NON-NLS-1$
+				actions.get(0).arguments().get("name")); //$NON-NLS-1$
+		assertEquals(new RewriteActionValue.Binding("$value"), //$NON-NLS-1$
+				actions.get(3).arguments().get("name")); //$NON-NLS-1$
+		assertEquals(new RewriteActionValue.Binding("$obsolete"), //$NON-NLS-1$
+				actions.get(4).arguments().get("name")); //$NON-NLS-1$
+		assertEquals(new RewriteActionValue.Literal(SemanticPlanValue.string("count")), //$NON-NLS-1$
+				actions.get(5).arguments().get("name")); //$NON-NLS-1$
+		assertFalse(program.expandedSource().contains("protected void parameterized")); //$NON-NLS-1$
+	}
+
+	@Test
+	void ordinaryNonPlanDeclarationReplacementIsNotLowered() throws Exception {
+		String source= """
+				void $method()
+				=> void renamed()
+				;;
+				""";
+
+		String processed= HintDeclarationDiffPreprocessor.preprocess(source);
+
+		assertEquals(source, processed);
+	}
+
+	@Test
+	void annotationOnlyMethodReplacementKeepsTheEstablishedTextPath() throws Exception {
+		String source= """
+				<!requires-plan: annotation-demo>
+				void $method()
+				=> @Deprecated void $method()
+				;;
+				""";
+
+		HintFile hint= new HintProgramParser().parseHintFile(source);
+
+		assertTrue(hint.getRules().get(0).alternatives().get(0).hasTextReplacement());
+		assertFalse(hint.getRules().get(0).alternatives().get(0).hasStructuredActions());
+	}
+
+	@Test
+	void rejectsReturnTypeChangesAndParameterReordering() {
+		assertThrows(HintParseException.class, () -> new HintProgramParser().parse("""
+				<!requires-plan: signature-demo>
+				void $method(String $value)
+				=> int $method(String $value)
+				;;
+				"""));
+		assertThrows(HintParseException.class, () -> new HintProgramParser().parse("""
+				<!requires-plan: signature-demo>
+				void $method(String $first, int $second)
+				=> void $method(int $second, String $first)
+				;;
+				"""));
+	}
+}

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/internal/HintLanguageVocabularyTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/internal/HintLanguageVocabularyTest.java
@@ -54,6 +54,7 @@ class HintLanguageVocabularyTest {
 		for (HintLanguageVocabulary.Action action : HintLanguageVocabulary.actions()) {
 			assertTrue(action.syntax().startsWith("=>! " + action.name() + "(")); //$NON-NLS-1$ //$NON-NLS-2$
 			assertTrue(action.replacement().startsWith(action.name() + "(")); //$NON-NLS-1$
+			assertFalse(action.syntax().contains("([,"), action.syntax()); //$NON-NLS-1$
 			assertFalse(action.description().isBlank());
 		}
 	}

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/internal/StructuredRewriteActionParserTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/triggerpattern/internal/StructuredRewriteActionParserTest.java
@@ -34,15 +34,15 @@ import org.sandbox.jdt.triggerpattern.internal.HintFileParser.HintParseException
 class StructuredRewriteActionParserTest {
 
 	@Test
-	void parsesOrderedActionsAndTypedValueExpressions() throws HintParseException {
+	void parsesImplicitPrimaryTargetAndTypedValueExpressions() throws HintParseException {
 		String source= """
 				<!id: structured.demo>
 				<!requires-plan: structured/demo>
 				void $name()
-				=>! addAnnotation(target=$name,
+				=>! addAnnotation(
 				        annotation="org.junit.jupiter.api.Order",
 				        value=planValue($name, "order"));
-				    addModifier(target=$name, modifier=public)
+				    addModifier(modifier=public)
 				;;
 				""";
 
@@ -55,7 +55,9 @@ class StructuredRewriteActionParserTest {
 		assertEquals(2, alternative.structuredActions().size());
 		StructuredRewriteAction annotation= alternative.structuredActions().get(0);
 		assertEquals("addAnnotation", annotation.name()); //$NON-NLS-1$
-		assertEquals(new RewriteActionValue.Binding("$name"), annotation.arguments().get("target")); //$NON-NLS-1$ //$NON-NLS-2$
+		assertFalse(annotation.arguments().containsKey("target")); //$NON-NLS-1$
+		assertInstanceOf(RewriteActionValue.MatchedNode.class,
+				annotation.requiredArgument("target")); //$NON-NLS-1$
 		assertEquals(new RewriteActionValue.Literal(
 				SemanticPlanValue.string("org.junit.jupiter.api.Order")), //$NON-NLS-1$
 				annotation.arguments().get("annotation")); //$NON-NLS-1$
@@ -67,15 +69,18 @@ class StructuredRewriteActionParserTest {
 	}
 
 	@Test
-	void parsesClassLiteralNameAndListExpressions() throws HintParseException {
+	void explicitTargetStillAddressesAnotherBinding() throws HintParseException {
 		HintFile hintFile= new HintProgramParser().parseHintFile("""
 				Object $field;
 				=>! addAnnotation(target=$field, annotation="example.Values",
 				        value=list(classLiteral("example.One"), name("example.Mode.TWO"), 3, true))
 				;;
 				""");
-		RewriteActionValue value= hintFile.getRules().get(0).alternatives().get(0)
-				.structuredActions().get(0).arguments().get("value"); //$NON-NLS-1$
+		StructuredRewriteAction action= hintFile.getRules().get(0).alternatives().get(0)
+				.structuredActions().get(0);
+		assertEquals(new RewriteActionValue.Binding("$field"), //$NON-NLS-1$
+				action.arguments().get("target")); //$NON-NLS-1$
+		RewriteActionValue value= action.arguments().get("value"); //$NON-NLS-1$
 		RewriteActionValue.ListValue list= assertInstanceOf(RewriteActionValue.ListValue.class, value);
 		assertEquals(4, list.values().size());
 		assertInstanceOf(RewriteActionValue.ClassLiteral.class, list.values().get(0));
@@ -85,11 +90,44 @@ class StructuredRewriteActionParserTest {
 	}
 
 	@Test
-	void catalogCanBeExtendedWithoutChangingTheCompatibilityParser() throws HintParseException {
+	void parsesConciseSignatureActionsWithStableParameterNames() throws HintParseException {
+		HintFile hintFile= new HintProgramParser().parseHintFile("""
+				void $method($params$)
+				=>! renameDeclaration(name="parameterized");
+				    addParameter(type="java.lang.String", name="value");
+				    replaceParameterType(name="oldValue", type="java.lang.Integer");
+				    removeParameter(name="obsolete")
+				;;
+				""");
+		List<StructuredRewriteAction> actions= hintFile.getRules().get(0)
+				.alternatives().get(0).structuredActions();
+		assertEquals(List.of("renameDeclaration", "addParameter", //$NON-NLS-1$ //$NON-NLS-2$
+				"replaceParameterType", "removeParameter"), //$NON-NLS-1$ //$NON-NLS-2$
+				actions.stream().map(StructuredRewriteAction::name).toList());
+		assertTrue(actions.stream().noneMatch(action -> action.arguments().containsKey("target"))); //$NON-NLS-1$
+		assertEquals(new RewriteActionValue.Literal(SemanticPlanValue.string("oldValue")), //$NON-NLS-1$
+				actions.get(2).arguments().get("name")); //$NON-NLS-1$
+	}
+
+	@Test
+	void allStandardActionsTreatTargetAsOptionalContext() {
+		for (RewriteActionSchema schema : RewriteActionCatalog.standard().schemas()) {
+			assertFalse(schema.requiredArguments().contains("target"), schema.name()); //$NON-NLS-1$
+			assertTrue(schema.optionalArguments().contains("target"), schema.name()); //$NON-NLS-1$
+		}
+	}
+
+	@Test
+	void catalogCanBeExtendedWithAnExplicitRequiredTarget() throws HintParseException {
 		RewriteActionCatalog catalog= RewriteActionCatalog.standard().toBuilder()
 				.register(new RewriteActionSchema("generateAdapter", Set.of("target"), //$NON-NLS-1$ //$NON-NLS-2$
 						Set.of("name"), "Generate one adapter")) //$NON-NLS-1$ //$NON-NLS-2$
 				.build();
+		assertThrows(HintParseException.class, () -> new HintProgramParser(catalog).parseHintFile("""
+				class $type {}
+				=>! generateAdapter(name="Generated")
+				;;
+				"""));
 		HintFile hintFile= new HintProgramParser(catalog).parseHintFile("""
 				class $type {}
 				=>! generateAdapter(target=$type, name="Generated")
@@ -102,11 +140,12 @@ class StructuredRewriteActionParserTest {
 	@Test
 	void rejectsUnknownMissingDuplicateAndMalformedActions() {
 		List<String> invalid= List.of(
-				"void $name()\n=>! unknown(target=$name)\n;;", //$NON-NLS-1$
-				"void $name()\n=>! addAnnotation(target=$name)\n;;", //$NON-NLS-1$
+				"void $name()\n=>! unknown()\n;;", //$NON-NLS-1$
+				"void $name()\n=>! addAnnotation()\n;;", //$NON-NLS-1$
 				"void $name()\n=>! removeDeclaration(target=$name, target=$name)\n;;", //$NON-NLS-1$
-				"void $name()\n=>! addModifier(target=$name, modifier=public);\n;;", //$NON-NLS-1$
-				"void $name()\n=>! addAnnotation(target=$name, annotation=planValue($name))\n;;"); //$NON-NLS-1$
+				"void $name()\n=>! addModifier(modifier=public);\n;;", //$NON-NLS-1$
+				"void $name()\n=>! addParameter(type=\"java.lang.String\")\n;;", //$NON-NLS-1$
+				"void $name()\n=>! addAnnotation(annotation=planValue($name))\n;;"); //$NON-NLS-1$
 
 		for (String source : invalid) {
 			assertThrows(HintParseException.class, () -> new HintProgramParser().parse(source), source);

--- a/sandbox_common_test/src/org/sandbox/jdt/triggerpattern/cleanup/actions/StructuredRewriteActionRegistryTest.java
+++ b/sandbox_common_test/src/org/sandbox/jdt/triggerpattern/cleanup/actions/StructuredRewriteActionRegistryTest.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.triggerpattern.cleanup.actions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import org.sandbox.jdt.triggerpattern.api.RewriteActionCatalog;
+
+/** Keeps the parser-visible action catalog aligned with executable handlers. */
+class StructuredRewriteActionRegistryTest {
+
+	@Test
+	void everyStandardActionHasExactlyOneRuntimeHandler() {
+		assertEquals(RewriteActionCatalog.standard().names(),
+				StructuredRewriteActionRegistry.getInstance().registeredNames());
+	}
+}

--- a/sandbox_common_test/src/org/sandbox/jdt/triggerpattern/editor/SandboxHintStructuredActionEditorTest.java
+++ b/sandbox_common_test/src/org/sandbox/jdt/triggerpattern/editor/SandboxHintStructuredActionEditorTest.java
@@ -57,7 +57,8 @@ class SandboxHintStructuredActionEditorTest {
 		SandboxHintContentAssistProcessor.CompletionEntry addAnnotation= entries.get("addAnnotation"); //$NON-NLS-1$
 		assertTrue(addAnnotation.replacement().startsWith("addAnnotation(")); //$NON-NLS-1$
 		assertTrue(addAnnotation.replacement().contains("annotation=")); //$NON-NLS-1$
-		assertTrue(addAnnotation.replacement().contains("target=")); //$NON-NLS-1$
+		assertFalse(addAnnotation.replacement().contains("target=")); //$NON-NLS-1$
+		assertTrue(addAnnotation.description().contains("target=VALUE")); //$NON-NLS-1$
 		assertFalse(addAnnotation.replacement().contains("?")); //$NON-NLS-1$
 		assertTrue(addAnnotation.cursorPosition() > addAnnotation.replacement().indexOf('='));
 	}

--- a/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/hints/junit3-hierarchy-to-jupiter.sandbox-hint
+++ b/sandbox_junit_cleanup/src/org/sandbox/jdt/internal/corext/fix/hints/junit3-hierarchy-to-jupiter.sandbox-hint
@@ -13,39 +13,39 @@
 @id: junit3.planned.hierarchyRoot
 @kind: TYPE_DECLARATION
 class $name extends junit.framework.TestCase {} :: plannedRole($name, "JUNIT3_HIERARCHY_TYPE") && plannedValue($name, "removeTestCaseSuperclass", true)
-=>! removeSupertype(target=$name, type="junit.framework.TestCase");
-    addAnnotation(target=$name,
+=>! removeSupertype(type="junit.framework.TestCase");
+    addAnnotation(
         annotation="org.junit.jupiter.api.TestMethodOrder",
         value=classLiteral("org.junit.jupiter.api.MethodOrderer.OrderAnnotation"))
 ;;
 
 @id: junit3.planned.test
 void $name($params$) :: plannedRole($name, "JUNIT3_TEST_METHOD")
-=>! addAnnotation(target=$name, annotation="org.junit.jupiter.api.Order",
+=>! addAnnotation(annotation="org.junit.jupiter.api.Order",
         value=planValue($name, "testOrder"));
-    addAnnotation(target=$name, annotation="org.junit.jupiter.api.Test")
+    addAnnotation(annotation="org.junit.jupiter.api.Test")
 ;;
 
 @id: junit3.planned.beforeEach.override
 void $name($params$) :: plannedRole($name, "JUNIT3_BEFORE_EACH") && plannedValue($name, "removeOverride", true) && hasOverrideAnnotation($name)
-=>! removeAnnotation(target=$name, annotation="java.lang.Override");
-    addAnnotation(target=$name, annotation="org.junit.jupiter.api.BeforeEach")
+=>! removeAnnotation(annotation="java.lang.Override");
+    addAnnotation(annotation="org.junit.jupiter.api.BeforeEach")
 ;;
 
 @id: junit3.planned.beforeEach
 void $name($params$) :: plannedRole($name, "JUNIT3_BEFORE_EACH") && plannedValue($name, "removeOverride", false) && !hasOverrideAnnotation($name)
-=>! addAnnotation(target=$name, annotation="org.junit.jupiter.api.BeforeEach")
+=>! addAnnotation(annotation="org.junit.jupiter.api.BeforeEach")
 ;;
 
 @id: junit3.planned.afterEach.override
 void $name($params$) :: plannedRole($name, "JUNIT3_AFTER_EACH") && plannedValue($name, "removeOverride", true) && hasOverrideAnnotation($name)
-=>! removeAnnotation(target=$name, annotation="java.lang.Override");
-    addAnnotation(target=$name, annotation="org.junit.jupiter.api.AfterEach")
+=>! removeAnnotation(annotation="java.lang.Override");
+    addAnnotation(annotation="org.junit.jupiter.api.AfterEach")
 ;;
 
 @id: junit3.planned.afterEach
 void $name($params$) :: plannedRole($name, "JUNIT3_AFTER_EACH") && plannedValue($name, "removeOverride", false) && !hasOverrideAnnotation($name)
-=>! addAnnotation(target=$name, annotation="org.junit.jupiter.api.AfterEach")
+=>! addAnnotation(annotation="org.junit.jupiter.api.AfterEach")
 ;;
 
 // Message-first JUnit 3 overloads.

--- a/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/PlanAwareStructuredActionHintTest.java
+++ b/sandbox_junit_cleanup_test/src/org/eclipse/jdt/ui/tests/quickfix/PlanAwareStructuredActionHintTest.java
@@ -47,7 +47,7 @@ class PlanAwareStructuredActionHintTest {
 	AbstractEclipseJava context= new EclipseJava17();
 
 	@Test
-	void factBackedActionSequenceReachesTheTypedAstOperation() throws CoreException {
+	void implicitPrimaryTargetReachesTheTypedAstOperation() throws CoreException {
 		IPackageFragmentRoot root= context.createClasspathForJUnit(JUnitCore.JUNIT5_CONTAINER_PATH);
 		IPackageFragment pack= root.createPackageFragment("sample", true, null); //$NON-NLS-1$
 		ICompilationUnit unit= pack.createCompilationUnit("Sample.java", //$NON-NLS-1$
@@ -69,10 +69,10 @@ class PlanAwareStructuredActionHintTest {
 				<!id: structured-demo>
 				<!requires-plan: structured-demo>
 				void $name() :: plannedRole($name, "TEST_METHOD")
-				=>! addAnnotation(target=$name, annotation="org.junit.jupiter.api.Test");
-				    addAnnotation(target=$name, annotation="org.junit.jupiter.api.Order",
+				=>! addAnnotation(annotation="org.junit.jupiter.api.Test");
+				    addAnnotation(annotation="org.junit.jupiter.api.Order",
 				        value=planValue($name, "order"));
-				    removeModifier(target=$name, modifier=public)
+				    removeModifier(modifier=public)
 				;;
 				""";
 		Set<CompilationUnitRewriteOperationWithSourceRange> operations= new LinkedHashSet<>();

--- a/sandbox_triggerpattern/src/org/sandbox/jdt/internal/ui/wizard/SandboxHintTemplates.java
+++ b/sandbox_triggerpattern/src/org/sandbox/jdt/internal/ui/wizard/SandboxHintTemplates.java
@@ -81,9 +81,8 @@ public enum SandboxHintTemplates {
 
 				@id: add-jupiter-test
 				void $method($params$) :: isPublic($method)
-				=>! removeModifier(target=$method, modifier=public);
-				    addAnnotation(target=$method,
-				        annotation="org.junit.jupiter.api.Test")
+				=>! removeModifier(modifier=public);
+				    addAnnotation(annotation="org.junit.jupiter.api.Test")
 				;;
 				"""; //$NON-NLS-1$
 		}
@@ -98,8 +97,7 @@ public enum SandboxHintTemplates {
 
 				@id: planned-jupiter-test
 				void $method($params$) :: plannedRole($method, "TEST_METHOD")
-				=>! addAnnotation(target=$method,
-				        annotation="org.junit.jupiter.api.Test")
+				=>! addAnnotation(annotation="org.junit.jupiter.api.Test")
 				;;
 				"""; //$NON-NLS-1$
 		}


### PR DESCRIPTION
## Summary

Implement the information-economical authoring layer from #1367 on top of the concise plan contract merged by #1368.

Authors can use either concise structured actions or, for an unambiguous supported method signature change, state the desired target declaration once. Both forms lower to the same typed, plan-authorized runtime actions.

## Implicit primary target

The rule's primary matched AST node is the default target for every standard action:

```text
void $method($params$)
=>! addAnnotation(annotation="org.junit.jupiter.api.Test");
    removeModifier(modifier=public)
;;
```

`target=$other` remains available only when an action intentionally operates on another binding. Extension catalogs may still declare `target` as required.

## Typed signature actions

- `renameDeclaration(name[, target])`;
- `replaceFieldType(type[, target])`;
- `addParameter(type, name[, index][, target])`;
- `removeParameter(name|index[, target])`;
- `replaceParameterType(type, name|index[, target])`.

Stable parameter names are preferred. Index selection remains an explicit positional escape hatch. Runtime validation rejects missing/conflicting selectors, invalid identifiers, duplicate parameter names, ambiguous fields, out-of-range indices, unsupported type syntax and `void` field/parameter types.

## Declaration target-code compiler

A plan-aware one-line method declaration can now describe the result directly:

```text
<!requires-plan: signature-demo>

public void $method(String $value)
=> protected void parameterized(Integer $value, long count)
;;
```

The high-level compiler derives the normalized actions for:

- method rename;
- modifier additions/removals;
- retained-parameter type replacement;
- unambiguous parameter removal by bound name;
- append-only parameter additions.

It deliberately rejects return-type changes, changed type parameters/throws clauses, parameter reordering, varargs/generic target types and simultaneous removal/addition that could really be a parameter rename. Annotation-only method replacements stay on the established text/annotation path.

## Internal model

- add an internal matched-node action value rather than another DSL token;
- move `target` from required to optional in all standard action schemas;
- resolve implicit and explicit targets through the same semantic-plan authorization;
- allow bound declaration names such as `$value` to serve as stable selector values;
- keep parser-visible schemas and runtime handlers synchronized by tests;
- render generated optional-only action syntax without phantom commas.

## Product integration

- update bundled JUnit 3 hierarchy rules to omit repeated primary targets;
- keep only one executable plan-aware structured wizard template;
- update Eclipse help and the canonical language reference;
- add parser, lowering, ambiguity, registry and plan-aware operation tests.

## Scope boundary

This PR implements the first bounded declaration-diff compiler. Rich return/generic types, annotation/member diffs, body changes and bulk materialization from semantic-plan relations remain explicit later phases in #1367 and should extend this compiler/IR rather than adding duplicated DSL fields.

Refs #1367
Refs #1217