### PR TITLE
Validate repository deletion slice after #1370

### DIFF
--- a/sandbox-jgit-server-webapp/docs/jgit-storage-migration-matrix.json
+++ b/sandbox-jgit-server-webapp/docs/jgit-storage-migration-matrix.json
@@ -2,13 +2,13 @@
   "schemaVersion": 2,
   "issue": 1303,
   "baselineCommit": "714bec5cf26e1554520ef063850865ec931a6624",
-  "lastVerifiedCommit": "0804ae99532cbb9bfa551fbb6870c053c1938e5d",
+  "lastVerifiedCommit": "073e6e2277bb17aad2963d8dc4ece74d0022ea0a",
   "purpose": "Machine-readable baseline and evidence ledger for replacing the copied Sandbox JGit/Hibernate implementation with released jgit-storage-hibernate modules.",
   "releasePolicy": {
     "required": "non-SNAPSHOT",
     "minimumDocumentedCandidate": "0.1.13",
     "selectedVersion": "0.1.15",
-    "selectionState": "selected; Core adapter lifecycle and restart verified on H2"
+    "selectionState": "selected; Core adapter lifecycle, restart and deletion policy verified on H2"
   },
   "runtime": {
     "currentDatabase": "MSSQL",
@@ -112,21 +112,28 @@
     {
       "id": "repository-delete",
       "currentOwner": "sandbox-jgit-server-webapp",
-      "currentEntrypoints": [],
-      "currentBackend": "No application deletion boundary is currently exposed; Sandbox-owned open handles are cached until service shutdown",
+      "currentEntrypoints": [
+        "org.eclipse.jgit.server.repository.SandboxRepositoryService.delete",
+        "org.eclipse.jgit.server.repository.ExternalHibernateRepositoryService.delete"
+      ],
+      "currentBackend": "Sandbox deletion boundary defaults fail closed; the released Core adapter serializes deletion against local opens and maps Core results without exposing Core DTOs. Copied normal startup and REST deletion remain disabled.",
       "targetOwner": "jgit-storage-hibernate-core",
       "targetApi": [
         "HibernateRepositoryFactory.deleteRepository"
       ],
-      "migrationStatus": "core-api-available-adapter-policy-required",
+      "migrationStatus": "core-adapter-delete-policy-verified-runtime-cutover-pending",
       "requiredEvidence": [
-        "delete rejected while a coordinated handle is open",
-        "Sandbox adapter either reports in-use or atomically evicts and closes its owned handle before deletion",
-        "repeated deletion is idempotent",
+        "normal startup uses the released Core adapter before deletion is exposed",
+        "REST or administrative deletion remains disabled until authorization and runtime cut-over are complete",
         "Search deletion participant removes projections"
       ],
       "verifiedEvidence": [
-        "Core 0.1.15 DefaultHibernateRepositoryFactory serializes deletion and rejects open handles"
+        "ExternalHibernateRepositoryDeletionTest.normalizesAndMapsCoreDeletionResultsWithoutLeakingCoreTypes",
+        "ExternalHibernateRepositoryDeletionTest.rejectsDeletionWhileTheAdapterOwnsAnOpenHandle",
+        "ExternalHibernateRepositoryDeletionTest.repeatedDeletionIsIdempotent",
+        "SandboxRepositoryServiceBoundaryTest exposes only SandboxRepositoryDeletionResult",
+        "Core 0.1.15 DefaultHibernateRepositoryFactory serializes deletion and rejects open handles",
+        "draft PR #1371 / commit 073e6e2277bb17aad2963d8dc4ece74d0022ea0a"
       ]
     },
     {
@@ -313,14 +320,18 @@
       "classification": "sandbox-adapter-retained"
     },
     {
+      "path": "sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/repository/SandboxRepositoryDeletionResult.java",
+      "classification": "sandbox-deletion-dto-retained"
+    },
+    {
       "path": "sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/repository/CopiedHibernateRepositoryService.java",
       "classification": "temporary-copied-adapter",
       "replacement": "ExternalHibernateRepositoryService"
     },
     {
       "path": "sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/repository/ExternalHibernateRepositoryService.java",
-      "classification": "released-core-adapter-lifecycle-verified",
-      "evidence": "PR #1362 / commit 0804ae99532cbb9bfa551fbb6870c053c1938e5d"
+      "classification": "released-core-adapter-lifecycle-and-delete-policy-verified",
+      "evidence": "draft PR #1371 / commit 073e6e2277bb17aad2963d8dc4ece74d0022ea0a"
     },
     {
       "path": "sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/config/ExternalServerPersistenceContext.java",

--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/repository/ExternalHibernateRepositoryService.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/repository/ExternalHibernateRepositoryService.java
@@ -21,6 +21,7 @@ import org.eclipse.jgit.lib.Repository;
 
 import io.github.carstenartur.jgit.storage.hibernate.HibernateGitStorage;
 import io.github.carstenartur.jgit.storage.hibernate.HibernateRepositoryFactory;
+import io.github.carstenartur.jgit.storage.hibernate.RepositoryDeletionResult;
 import io.github.carstenartur.jgit.storage.hibernate.RepositoryName;
 
 /**
@@ -67,6 +68,25 @@ public final class ExternalHibernateRepositoryService implements SandboxReposito
 			Repository repository= storageLocked(normalized).repository();
 			repository.setGitwebDescription(description);
 			return new SandboxRepositoryInfo(normalized, repository.getGitwebDescription());
+		}
+	}
+
+	@Override
+	public SandboxRepositoryDeletionResult delete(String name) {
+		synchronized (lifecycleLock) {
+			if (closed) {
+				throw new IllegalStateException("Repository service is already closed."); //$NON-NLS-1$
+			}
+			String normalized= normalize(name);
+			if (storages.containsKey(normalized)) {
+				throw new IllegalStateException(
+						"Repository is open in this process and cannot be deleted: " + normalized); //$NON-NLS-1$
+			}
+			RepositoryDeletionResult result= Objects.requireNonNull(
+					repositoryFactory.deleteRepository(new RepositoryName(normalized)),
+					"repository deletion result"); //$NON-NLS-1$
+			return new SandboxRepositoryDeletionResult(
+					result.packRows(), result.reflogRows(), result.projectionRows());
 		}
 	}
 

--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/repository/SandboxRepositoryDeletionResult.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/repository/SandboxRepositoryDeletionResult.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jgit.server.repository;
+
+/** Application-owned summary of one logical repository deletion. */
+public record SandboxRepositoryDeletionResult(int packRows, int reflogRows, int projectionRows) {
+
+	/** Rejects invalid row counts before they cross the application boundary. */
+	public SandboxRepositoryDeletionResult {
+		if (packRows < 0 || reflogRows < 0 || projectionRows < 0) {
+			throw new IllegalArgumentException("Deleted row counts must not be negative."); //$NON-NLS-1$
+		}
+	}
+
+	/** Returns whether the deletion removed any persisted state. */
+	public boolean deletedAnything() {
+		return packRows > 0 || reflogRows > 0 || projectionRows > 0;
+	}
+}

--- a/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/repository/SandboxRepositoryService.java
+++ b/sandbox-jgit-server-webapp/src/org/eclipse/jgit/server/repository/SandboxRepositoryService.java
@@ -26,6 +26,16 @@ public interface SandboxRepositoryService extends AutoCloseable {
 	/** Normalizes the identity and updates metadata without exposing a backend-specific repository. */
 	SandboxRepositoryInfo setDescription(String name, String description) throws IOException;
 
+	/**
+	 * Deletes a closed logical repository when the selected backend supports coordinated deletion.
+	 *
+	 * <p>The released Core adapter overrides this operation. The copied transition backend deliberately
+	 * keeps deletion disabled until normal startup has completed the Core cut-over.</p>
+	 */
+	default SandboxRepositoryDeletionResult delete(String name) throws IOException {
+		throw new UnsupportedOperationException("Repository deletion requires the released Core backend."); //$NON-NLS-1$
+	}
+
 	/** Returns whether this process already owns an open handle for the normalized identity. */
 	boolean isOpen(String name);
 

--- a/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/config/JGitStorageMigrationMatrixTest.java
+++ b/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/config/JGitStorageMigrationMatrixTest.java
@@ -74,14 +74,20 @@ public class JGitStorageMigrationMatrixTest {
 	}
 
 	@Test
-	public void repositoryDeletionRemainsExplicitlyUnwired() throws IOException {
+	public void repositoryDeletionPolicyIsVerifiedButNotPubliclyExposed() throws IOException {
 		JsonObject deletion= capability(matrix(), "repository-delete"); //$NON-NLS-1$
+		String entrypoints= deletion.getAsJsonArray("currentEntrypoints").toString(); //$NON-NLS-1$
 
-		assertTrue(deletion.getAsJsonArray("currentEntrypoints").isEmpty()); //$NON-NLS-1$
-		assertEquals("core-api-available-adapter-policy-required", //$NON-NLS-1$
+		assertTrue(entrypoints.contains("SandboxRepositoryService.delete")); //$NON-NLS-1$
+		assertTrue(entrypoints.contains("ExternalHibernateRepositoryService.delete")); //$NON-NLS-1$
+		assertEquals("core-adapter-delete-policy-verified-runtime-cutover-pending", //$NON-NLS-1$
 				deletion.get("migrationStatus").getAsString()); //$NON-NLS-1$
+		assertTrue(deletion.get("currentBackend").getAsString() //$NON-NLS-1$
+				.contains("REST deletion remain disabled")); //$NON-NLS-1$
 		assertTrue(deletion.getAsJsonArray("requiredEvidence").toString() //$NON-NLS-1$
-				.contains("atomically evicts and closes")); //$NON-NLS-1$
+				.contains("Search deletion participant")); //$NON-NLS-1$
+		assertTrue(deletion.getAsJsonArray("verifiedEvidence").toString() //$NON-NLS-1$
+				.contains("rejectsDeletionWhileTheAdapterOwnsAnOpenHandle")); //$NON-NLS-1$
 	}
 
 	private static JsonObject capability(JsonObject matrix, String id) {

--- a/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/repository/ExternalHibernateRepositoryDeletionTest.java
+++ b/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/repository/ExternalHibernateRepositoryDeletionTest.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jgit.server.repository;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.jgit.internal.storage.dfs.DfsRepositoryDescription;
+import org.eclipse.jgit.internal.storage.dfs.InMemoryRepository;
+import org.eclipse.jgit.lib.Repository;
+import org.junit.Test;
+
+import io.github.carstenartur.jgit.storage.hibernate.HibernateGitStorage;
+import io.github.carstenartur.jgit.storage.hibernate.HibernateRepositoryFactory;
+import io.github.carstenartur.jgit.storage.hibernate.RepositoryDeletionResult;
+import io.github.carstenartur.jgit.storage.hibernate.RepositoryName;
+
+/** Verifies the application policy around the released Core deletion API. */
+public class ExternalHibernateRepositoryDeletionTest {
+
+	@Test
+	public void normalizesAndMapsCoreDeletionResultsWithoutLeakingCoreTypes() {
+		FakeFactory factory= new FakeFactory();
+		factory.deletionResults.add(new RepositoryDeletionResult(2, 3, 4));
+		try (ExternalHibernateRepositoryService service= new ExternalHibernateRepositoryService(factory)) {
+			SandboxRepositoryDeletionResult result= service.delete(" /demo.git "); //$NON-NLS-1$
+
+			assertEquals("demo", factory.lastDeletedRepository); //$NON-NLS-1$
+			assertEquals(1, factory.deleteCalls.get());
+			assertEquals(new SandboxRepositoryDeletionResult(2, 3, 4), result);
+			assertTrue(result.deletedAnything());
+		}
+	}
+
+	@Test
+	public void rejectsDeletionWhileTheAdapterOwnsAnOpenHandle() throws Exception {
+		FakeFactory factory= new FakeFactory();
+		try (ExternalHibernateRepositoryService service= new ExternalHibernateRepositoryService(factory)) {
+			service.openOrCreate("demo"); //$NON-NLS-1$
+
+			IllegalStateException failure= assertThrows(IllegalStateException.class,
+					() -> service.delete("/demo.git")); //$NON-NLS-1$
+
+			assertTrue(failure.getMessage().contains("demo")); //$NON-NLS-1$
+			assertEquals(0, factory.deleteCalls.get());
+			assertTrue(service.isOpen("demo")); //$NON-NLS-1$
+		}
+	}
+
+	@Test
+	public void repeatedDeletionIsIdempotent() {
+		FakeFactory factory= new FakeFactory();
+		factory.deletionResults.add(new RepositoryDeletionResult(1, 1, 0));
+		factory.deletionResults.add(new RepositoryDeletionResult(0, 0, 0));
+		try (ExternalHibernateRepositoryService service= new ExternalHibernateRepositoryService(factory)) {
+			assertTrue(service.delete("demo").deletedAnything()); //$NON-NLS-1$
+			assertFalse(service.delete("demo.git").deletedAnything()); //$NON-NLS-1$
+			assertEquals(2, factory.deleteCalls.get());
+		}
+	}
+
+	@Test
+	public void rejectsInvalidCountsAndDeletionAfterShutdown() {
+		assertThrows(IllegalArgumentException.class,
+				() -> new SandboxRepositoryDeletionResult(-1, 0, 0));
+		ExternalHibernateRepositoryService service= new ExternalHibernateRepositoryService(new FakeFactory());
+		service.close();
+		assertThrows(IllegalStateException.class, () -> service.delete("demo")); //$NON-NLS-1$
+	}
+
+	private static final class FakeFactory implements HibernateRepositoryFactory {
+
+		private final Deque<RepositoryDeletionResult> deletionResults= new ArrayDeque<>();
+		private final AtomicInteger deleteCalls= new AtomicInteger();
+		private String lastDeletedRepository;
+
+		@Override
+		public HibernateGitStorage open(RepositoryName repositoryName) {
+			return new FakeStorage(new InMemoryRepository(
+					new DfsRepositoryDescription(repositoryName.value())));
+		}
+
+		@Override
+		public RepositoryDeletionResult deleteRepository(RepositoryName repositoryName) {
+			deleteCalls.incrementAndGet();
+			lastDeletedRepository= repositoryName.value();
+			return deletionResults.isEmpty()
+					? new RepositoryDeletionResult(0, 0, 0)
+					: deletionResults.removeFirst();
+		}
+	}
+
+	private static final class FakeStorage implements HibernateGitStorage {
+
+		private final Repository repository;
+
+		private FakeStorage(Repository repository) {
+			this.repository= repository;
+		}
+
+		@Override
+		public Repository repository() {
+			return repository;
+		}
+
+		@Override
+		public void close() {
+			repository.close();
+		}
+	}
+}

--- a/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/repository/SandboxRepositoryServiceBoundaryTest.java
+++ b/sandbox-jgit-server-webapp/tst/org/eclipse/jgit/server/repository/SandboxRepositoryServiceBoundaryTest.java
@@ -38,7 +38,9 @@ public class SandboxRepositoryServiceBoundaryTest {
 	@Test
 	public void exposesPublicJGitRepositoryContract() throws Exception {
 		Method open= SandboxRepositoryService.class.getMethod("openOrCreate", String.class); //$NON-NLS-1$
+		Method delete= SandboxRepositoryService.class.getMethod("delete", String.class); //$NON-NLS-1$
 		assertEquals(Repository.class, open.getReturnType());
+		assertEquals(SandboxRepositoryDeletionResult.class, delete.getReturnType());
 		assertNotNull(RepositoryResource.class.getConstructor(SandboxRepositoryService.class));
 		assertNotNull(HibernateRepositoryResolver.class.getConstructor(SandboxRepositoryService.class));
 		assertNotNull(HibernateRepositoryResolver.class.getConstructor(SessionFactory.class));


### PR DESCRIPTION
Temporary draft validation PR for the seven-file #1371 repository-deletion slice, based directly on the clean #1370 head. It will be closed after the original #1371 branch is reparented onto main and must not be merged.