### PR TITLE
Start semantic container contract analysis

### DIFF
--- a/sandbox_common_core/bnd.bnd
+++ b/sandbox_common_core/bnd.bnd
@@ -4,6 +4,8 @@ Bundle-Name: Sandbox Common Core
 Bundle-Vendor: Carsten Hammer
 
 Export-Package: org.sandbox.jdt.cleanup.multifile.api,\
+ org.sandbox.jdt.container.api,\
+ org.sandbox.jdt.container.analysis,\
  org.sandbox.jdt.internal.common,\
  org.sandbox.jdt.triggerpattern.api,\
  org.sandbox.jdt.triggerpattern.internal,\

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/AppendOnlyArraySeedDetector.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/AppendOnlyArraySeedDetector.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.sandbox.jdt.container.analysis;
 
-import static org.sandbox.jdt.container.analysis.ContainerAstFacts.assignment;
 import static org.sandbox.jdt.container.analysis.ContainerAstFacts.expressionStatement;
 import static org.sandbox.jdt.container.analysis.ContainerAstFacts.isArrayLength;
 import static org.sandbox.jdt.container.analysis.ContainerAstFacts.isOne;
@@ -20,8 +19,9 @@ import static org.sandbox.jdt.container.analysis.ContainerAstFacts.unwrap;
 import static org.sandbox.jdt.container.analysis.ContainerAstFacts.variableBinding;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -31,11 +31,12 @@ import org.eclipse.jdt.core.dom.Assignment;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.ExpressionStatement;
-import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.IVariableBinding;
 import org.eclipse.jdt.core.dom.InfixExpression;
 import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.ParenthesizedExpression;
+import org.eclipse.jdt.core.dom.Statement;
 import org.sandbox.jdt.container.api.ContainerShape;
 import org.sandbox.jdt.container.api.ContainerUsageProfile;
 import org.sandbox.jdt.container.api.ContainerUsageProfile.AliasingContract;
@@ -50,12 +51,16 @@ import org.sandbox.jdt.container.api.ContainerUsageProfile.OrderRequirement;
 import org.sandbox.jdt.container.api.ContainerUsageProfile.UniquenessRequirement;
 import org.sandbox.jdt.container.api.UsageEvidence;
 import org.sandbox.jdt.container.api.UsageEvidence.Kind;
-import org.sandbox.jdt.internal.common.AstProcessorBuilder;
+import org.sandbox.jdt.internal.common.ASTProcessor;
 import org.sandbox.jdt.internal.common.ReferenceHolder;
 
 /**
  * Finds local seeds where a reference array is grown by one element and the new tail
  * slot is assigned immediately afterwards.
+ *
+ * <p>The implementation uses the scoped {@link ASTProcessor} chain deliberately:
+ * after a matching {@link Arrays#copyOf(Object[], int)} invocation, the next stage
+ * searches only the immediately following statement for the corresponding tail write.</p>
  *
  * <p>This detector deliberately stops at {@link AnalysisCompleteness#LOCAL_SEED}.
  * It does not claim that all array uses are append-only, that aliases do not escape or
@@ -63,6 +68,8 @@ import org.sandbox.jdt.internal.common.ReferenceHolder;
  * usage and multi-file planning stages.</p>
  */
 public final class AppendOnlyArraySeedDetector {
+
+	private static final int CURRENT_GROWTH= 0;
 
 	/**
 	 * Finds deterministic, source-ordered append-only array seeds.
@@ -72,44 +79,46 @@ public final class AppendOnlyArraySeedDetector {
 	 */
 	public List<ContainerUsageProfile> findSeeds(CompilationUnit compilationUnit) {
 		Objects.requireNonNull(compilationUnit, "compilationUnit"); //$NON-NLS-1$
-		ReferenceHolder<Integer, ContainerUsageProfile> profiles= ReferenceHolder.createIndexed();
 
-		AstProcessorBuilder.with(profiles)
-				.onAssignment((candidate, holder) -> {
-					detectSeed(candidate).ifPresent(profile ->
-						holder.put(profile.identity().sourceStart(), profile));
-					return true;
-				})
+		List<ContainerUsageProfile> profiles= new ArrayList<>();
+		ReferenceHolder<Integer, GrowthSeed> state= ReferenceHolder.createIndexed();
+		ASTProcessor<ReferenceHolder<Integer, GrowthSeed>, Integer, GrowthSeed> processor=
+				new ASTProcessor<>(state, new HashSet<>());
+
+		processor
+				.callMethodInvocationVisitor(Arrays.class, "copyOf", //$NON-NLS-1$
+						AppendOnlyArraySeedDetector::rememberGrowth,
+						AppendOnlyArraySeedDetector::followingStatementScope)
+				.callArrayAccessVisitor((node, holder) ->
+						collectTailWrite((ArrayAccess) node, holder, profiles))
 				.build(compilationUnit);
 
-		return profiles.entrySet().stream()
-				.sorted(Map.Entry.comparingByKey())
-				.map(Map.Entry::getValue)
-				.toList();
+		return List.copyOf(profiles);
 	}
 
-	private Optional<ContainerUsageProfile> detectSeed(Assignment growthAssignment) {
-		if (growthAssignment.getOperator() != Assignment.Operator.ASSIGN) {
+	private static boolean rememberGrowth(MethodInvocation copyOf,
+			ReferenceHolder<Integer, GrowthSeed> state) {
+		state.remove(CURRENT_GROWTH);
+		growthSeed(copyOf).ifPresent(seed -> state.put(CURRENT_GROWTH, seed));
+		return false;
+	}
+
+	private static Optional<GrowthSeed> growthSeed(MethodInvocation copyOf) {
+		if (copyOf.arguments().size() != 2) {
+			return Optional.empty();
+		}
+
+		Assignment growthAssignment= enclosingAssignment(copyOf);
+		if (growthAssignment == null
+				|| growthAssignment.getOperator() != Assignment.Operator.ASSIGN
+				|| unwrap(growthAssignment.getRightHandSide()) != copyOf) {
 			return Optional.empty();
 		}
 
 		Expression array= unwrap(growthAssignment.getLeftHandSide());
-		MethodInvocation copyOf= methodInvocation(growthAssignment.getRightHandSide());
-		if (copyOf == null || !isArraysCopyOf(copyOf) || copyOf.arguments().size() != 2) {
-			return Optional.empty();
-		}
-
 		Expression sourceArray= (Expression) copyOf.arguments().get(0);
 		Expression requestedLength= (Expression) copyOf.arguments().get(1);
 		if (!sameVariable(array, sourceArray) || !isLengthPlusOne(requestedLength, array)) {
-			return Optional.empty();
-		}
-
-		ExpressionStatement growthStatement= expressionStatement(growthAssignment);
-		Assignment appendAssignment= growthStatement == null
-				? null
-				: assignment(nextStatement(growthStatement));
-		if (!isTailWrite(appendAssignment, array)) {
 			return Optional.empty();
 		}
 
@@ -121,27 +130,61 @@ public final class AppendOnlyArraySeedDetector {
 			return Optional.empty();
 		}
 
+		return Optional.of(new GrowthSeed(array, growthAssignment, binding, elementDomain));
+	}
+
+	private static ASTNode followingStatementScope(ASTNode node) {
+		MethodInvocation copyOf= (MethodInvocation) node;
+		Assignment assignment= enclosingAssignment(copyOf);
+		ExpressionStatement statement= assignment == null ? null : expressionStatement(assignment);
+		Statement next= statement == null ? null : nextStatement(statement);
+		return next != null ? next : copyOf;
+	}
+
+	private static boolean collectTailWrite(ArrayAccess arrayAccess,
+			ReferenceHolder<Integer, GrowthSeed> state,
+			List<ContainerUsageProfile> profiles) {
+		GrowthSeed seed= state.get(CURRENT_GROWTH);
+		if (seed == null) {
+			return true;
+		}
+
+		Assignment appendAssignment= enclosingAssignment(arrayAccess);
+		if (appendAssignment == null
+				|| unwrap(appendAssignment.getLeftHandSide()) != arrayAccess
+				|| !sameVariable(seed.array(), arrayAccess.getArray())
+				|| !isLengthMinusOne(arrayAccess.getIndex(), seed.array())) {
+			return true;
+		}
+
+		profiles.add(createProfile(seed, appendAssignment));
+		state.remove(CURRENT_GROWTH);
+		return false;
+	}
+
+	private static ContainerUsageProfile createProfile(GrowthSeed seed, Assignment appendAssignment) {
 		List<UsageEvidence> evidence= new ArrayList<>();
 		evidence.add(evidence(Kind.ARRAY_GROWTH,
-				"Array capacity is increased by one element", growthAssignment)); //$NON-NLS-1$
+				"Array capacity is increased by one element", seed.growthAssignment())); //$NON-NLS-1$
 		evidence.add(evidence(Kind.APPEND_WRITE,
 				"The immediately following write targets the new tail slot", appendAssignment)); //$NON-NLS-1$
-		if (elementDomain == ElementDomain.REFERENCE || elementDomain == ElementDomain.ENUM) {
+		if (seed.elementDomain() == ElementDomain.REFERENCE
+				|| seed.elementDomain() == ElementDomain.ENUM) {
 			evidence.add(evidence(Kind.REFERENCE_COMPONENT,
-					"The resolved array component is a reference type", array)); //$NON-NLS-1$
+					"The resolved array component is a reference type", seed.array())); //$NON-NLS-1$
 		} else {
 			evidence.add(evidence(Kind.UNRESOLVED_BINDING,
-					"The array component type still requires binding validation", array)); //$NON-NLS-1$
+					"The array component type still requires binding validation", seed.array())); //$NON-NLS-1$
 		}
 
 		ContainerIdentity identity= new ContainerIdentity(
-				binding.map(value -> value.getVariableDeclaration().getKey()).orElse(""), //$NON-NLS-1$
-				array.toString(), array.getStartPosition(), array.getLength());
+				seed.binding().map(value -> value.getVariableDeclaration().getKey()).orElse(""), //$NON-NLS-1$
+				seed.array().toString(), seed.array().getStartPosition(), seed.array().getLength());
 
-		return Optional.of(new ContainerUsageProfile(
+		return new ContainerUsageProfile(
 				identity,
 				ContainerShape.ARRAY,
-				elementDomain,
+				seed.elementDomain(),
 				ContainerUsageProfile.AccessProfile.appendOnlyArraySeed(),
 				OrderRequirement.UNKNOWN,
 				UniquenessRequirement.UNKNOWN,
@@ -151,7 +194,15 @@ public final class AppendOnlyArraySeedDetector {
 				EscapeLevel.UNKNOWN,
 				ConcurrencyProfile.unknown(),
 				AnalysisCompleteness.LOCAL_SEED,
-				evidence));
+				evidence);
+	}
+
+	private static Assignment enclosingAssignment(ASTNode node) {
+		ASTNode current= node;
+		while (current.getParent() instanceof ParenthesizedExpression) {
+			current= current.getParent();
+		}
+		return current.getParent() instanceof Assignment assignment ? assignment : null;
 	}
 
 	private static UsageEvidence evidence(Kind kind, String summary, ASTNode node) {
@@ -159,10 +210,7 @@ public final class AppendOnlyArraySeedDetector {
 	}
 
 	private static ElementDomain elementDomain(ITypeBinding arrayType) {
-		if (arrayType == null) {
-			return ElementDomain.UNKNOWN;
-		}
-		if (!arrayType.isArray()) {
+		if (arrayType == null || !arrayType.isArray()) {
 			return ElementDomain.UNKNOWN;
 		}
 		ITypeBinding componentType= arrayType.getComponentType();
@@ -173,41 +221,6 @@ public final class AppendOnlyArraySeedDetector {
 			return ElementDomain.PRIMITIVE;
 		}
 		return componentType.isEnum() ? ElementDomain.ENUM : ElementDomain.REFERENCE;
-	}
-
-	private static boolean isTailWrite(Assignment appendAssignment, Expression array) {
-		if (appendAssignment == null || appendAssignment.getOperator() != Assignment.Operator.ASSIGN) {
-			return false;
-		}
-		Expression leftHandSide= unwrap(appendAssignment.getLeftHandSide());
-		if (!(leftHandSide instanceof ArrayAccess arrayAccess)) {
-			return false;
-		}
-		return sameVariable(array, arrayAccess.getArray())
-				&& isLengthMinusOne(arrayAccess.getIndex(), array);
-	}
-
-	private static MethodInvocation methodInvocation(Expression expression) {
-		Expression unwrapped= unwrap(expression);
-		return unwrapped instanceof MethodInvocation invocation ? invocation : null;
-	}
-
-	private static boolean isArraysCopyOf(MethodInvocation invocation) {
-		if (!"copyOf".equals(invocation.getName().getIdentifier())) { //$NON-NLS-1$
-			return false;
-		}
-
-		IMethodBinding binding= invocation.resolveMethodBinding();
-		if (binding != null && binding.getDeclaringClass() != null) {
-			return "java.util.Arrays".equals(binding.getDeclaringClass().getErasure().getQualifiedName()); //$NON-NLS-1$
-		}
-
-		Expression expression= invocation.getExpression();
-		if (expression == null) {
-			return false;
-		}
-		String owner= expression.toString();
-		return "Arrays".equals(owner) || "java.util.Arrays".equals(owner); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
 	private static boolean isLengthPlusOne(Expression expression, Expression array) {
@@ -229,5 +242,19 @@ public final class AppendOnlyArraySeedDetector {
 			return false;
 		}
 		return isArrayLength(infix.getLeftOperand(), array) && isOne(infix.getRightOperand());
+	}
+
+	private record GrowthSeed(
+			Expression array,
+			Assignment growthAssignment,
+			Optional<IVariableBinding> binding,
+			ElementDomain elementDomain) {
+
+		private GrowthSeed {
+			Objects.requireNonNull(array, "array"); //$NON-NLS-1$
+			Objects.requireNonNull(growthAssignment, "growthAssignment"); //$NON-NLS-1$
+			Objects.requireNonNull(binding, "binding"); //$NON-NLS-1$
+			Objects.requireNonNull(elementDomain, "elementDomain"); //$NON-NLS-1$
+		}
 	}
 }

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/AppendOnlyArraySeedDetector.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/AppendOnlyArraySeedDetector.java
@@ -1,0 +1,315 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.container.analysis;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.jdt.core.dom.ASTMatcher;
+import org.eclipse.jdt.core.dom.Assignment;
+import org.eclipse.jdt.core.dom.Block;
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.ExpressionStatement;
+import org.eclipse.jdt.core.dom.FieldAccess;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.IVariableBinding;
+import org.eclipse.jdt.core.dom.InfixExpression;
+import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.NumberLiteral;
+import org.eclipse.jdt.core.dom.ParenthesizedExpression;
+import org.eclipse.jdt.core.dom.QualifiedName;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.Statement;
+import org.eclipse.jdt.core.dom.SuperFieldAccess;
+import org.eclipse.jdt.core.dom.ArrayAccess;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.sandbox.jdt.container.api.ContainerShape;
+import org.sandbox.jdt.container.api.ContainerUsageProfile;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.AliasingContract;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.AnalysisCompleteness;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.ConcurrencyContract;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.ContainerIdentity;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.ElementDomain;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.EscapeLevel;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.MutationLifecycle;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.NullContract;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.OrderRequirement;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.UniquenessRequirement;
+import org.sandbox.jdt.container.api.UsageEvidence;
+import org.sandbox.jdt.container.api.UsageEvidence.Kind;
+import org.sandbox.jdt.internal.common.AstProcessorBuilder;
+import org.sandbox.jdt.internal.common.ReferenceHolder;
+
+/**
+ * Finds local seeds where a reference array is grown by one element and the new tail
+ * slot is assigned immediately afterwards.
+ *
+ * <p>This detector deliberately stops at {@link AnalysisCompleteness#LOCAL_SEED}.
+ * It does not claim that all array uses are append-only, that aliases do not escape or
+ * that method signatures may already be migrated. Those proofs belong to the later
+ * usage and multi-file planning stages.</p>
+ */
+public final class AppendOnlyArraySeedDetector {
+
+	/**
+	 * Finds deterministic, source-ordered append-only array seeds.
+	 *
+	 * @param compilationUnit compilation unit to inspect
+	 * @return immutable list of local usage profiles
+	 */
+	public List<ContainerUsageProfile> findSeeds(CompilationUnit compilationUnit) {
+		Objects.requireNonNull(compilationUnit, "compilationUnit"); //$NON-NLS-1$
+		ReferenceHolder<Integer, ContainerUsageProfile> profiles= ReferenceHolder.createIndexed();
+
+		AstProcessorBuilder.with(profiles)
+				.onAssignment((assignment, holder) -> {
+					detectSeed(assignment).ifPresent(profile ->
+						holder.put(profile.identity().sourceStart(), profile));
+					return true;
+				})
+				.build(compilationUnit);
+
+		return profiles.entrySet().stream()
+				.sorted(Map.Entry.comparingByKey())
+				.map(Map.Entry::getValue)
+				.toList();
+	}
+
+	private Optional<ContainerUsageProfile> detectSeed(Assignment growthAssignment) {
+		if (growthAssignment.getOperator() != Assignment.Operator.ASSIGN) {
+			return Optional.empty();
+		}
+
+		Expression array= unwrap(growthAssignment.getLeftHandSide());
+		MethodInvocation copyOf= asMethodInvocation(growthAssignment.getRightHandSide());
+		if (copyOf == null || !isArraysCopyOf(copyOf) || copyOf.arguments().size() != 2) {
+			return Optional.empty();
+		}
+
+		Expression sourceArray= (Expression) copyOf.arguments().get(0);
+		Expression requestedLength= (Expression) copyOf.arguments().get(1);
+		if (!sameVariable(array, sourceArray) || !isLengthPlusOne(requestedLength, array)) {
+			return Optional.empty();
+		}
+
+		ExpressionStatement growthStatement= asExpressionStatement(growthAssignment);
+		Assignment appendAssignment= growthStatement == null
+				? null
+				: asAssignment(nextStatement(growthStatement));
+		if (!isTailWrite(appendAssignment, array)) {
+			return Optional.empty();
+		}
+
+		Optional<IVariableBinding> variableBinding= resolveVariableBinding(array);
+		ITypeBinding arrayType= variableBinding.map(IVariableBinding::getType)
+				.orElseGet(array::resolveTypeBinding);
+		ElementDomain elementDomain= elementDomain(arrayType);
+		if (elementDomain == ElementDomain.PRIMITIVE) {
+			return Optional.empty();
+		}
+
+		List<UsageEvidence> evidence= new ArrayList<>();
+		evidence.add(evidence(Kind.ARRAY_GROWTH,
+				"Array capacity is increased by one element", growthAssignment)); //$NON-NLS-1$
+		evidence.add(evidence(Kind.APPEND_WRITE,
+				"The immediately following write targets the new tail slot", appendAssignment)); //$NON-NLS-1$
+		if (elementDomain == ElementDomain.REFERENCE || elementDomain == ElementDomain.ENUM) {
+			evidence.add(evidence(Kind.REFERENCE_COMPONENT,
+					"The resolved array component is a reference type", array)); //$NON-NLS-1$
+		} else {
+			evidence.add(evidence(Kind.UNRESOLVED_BINDING,
+					"The array component type still requires binding validation", array)); //$NON-NLS-1$
+		}
+
+		ContainerIdentity identity= new ContainerIdentity(
+				variableBinding.map(binding -> binding.getVariableDeclaration().getKey()).orElse(""), //$NON-NLS-1$
+				array.toString(), array.getStartPosition(), array.getLength());
+
+		return Optional.of(new ContainerUsageProfile(
+				identity,
+				ContainerShape.ARRAY,
+				elementDomain,
+				ContainerUsageProfile.AccessProfile.appendOnlyArraySeed(),
+				OrderRequirement.UNKNOWN,
+				UniquenessRequirement.UNKNOWN,
+				MutationLifecycle.UNKNOWN,
+				NullContract.UNKNOWN,
+				AliasingContract.UNKNOWN,
+				EscapeLevel.UNKNOWN,
+				ConcurrencyContract.UNKNOWN,
+				AnalysisCompleteness.LOCAL_SEED,
+				evidence));
+	}
+
+	private static UsageEvidence evidence(Kind kind, String summary, org.eclipse.jdt.core.dom.ASTNode node) {
+		return new UsageEvidence(kind, summary, node.getStartPosition(), node.getLength());
+	}
+
+	private static ElementDomain elementDomain(ITypeBinding arrayType) {
+		if (arrayType == null) {
+			return ElementDomain.UNKNOWN;
+		}
+		if (!arrayType.isArray()) {
+			return ElementDomain.PRIMITIVE;
+		}
+		ITypeBinding componentType= arrayType.getComponentType();
+		if (componentType == null) {
+			return ElementDomain.UNKNOWN;
+		}
+		if (componentType.isPrimitive()) {
+			return ElementDomain.PRIMITIVE;
+		}
+		return componentType.isEnum() ? ElementDomain.ENUM : ElementDomain.REFERENCE;
+	}
+
+	private static boolean isTailWrite(Assignment assignment, Expression array) {
+		if (assignment == null || assignment.getOperator() != Assignment.Operator.ASSIGN) {
+			return false;
+		}
+		Expression leftHandSide= unwrap(assignment.getLeftHandSide());
+		if (!(leftHandSide instanceof ArrayAccess arrayAccess)) {
+			return false;
+		}
+		return sameVariable(array, arrayAccess.getArray())
+				&& isLengthMinusOne(arrayAccess.getIndex(), array);
+	}
+
+	private static MethodInvocation asMethodInvocation(Expression expression) {
+		Expression unwrapped= unwrap(expression);
+		return unwrapped instanceof MethodInvocation invocation ? invocation : null;
+	}
+
+	private static ExpressionStatement asExpressionStatement(Assignment assignment) {
+		return assignment.getParent() instanceof ExpressionStatement statement ? statement : null;
+	}
+
+	private static Assignment asAssignment(Statement statement) {
+		if (!(statement instanceof ExpressionStatement expressionStatement)) {
+			return null;
+		}
+		Expression expression= unwrap(expressionStatement.getExpression());
+		return expression instanceof Assignment assignment ? assignment : null;
+	}
+
+	private static Statement nextStatement(Statement statement) {
+		if (!(statement.getParent() instanceof Block block)) {
+			return null;
+		}
+		List<?> statements= block.statements();
+		int index= statements.indexOf(statement);
+		return index >= 0 && index + 1 < statements.size()
+				? (Statement) statements.get(index + 1)
+				: null;
+	}
+
+	private static boolean isArraysCopyOf(MethodInvocation invocation) {
+		if (!"copyOf".equals(invocation.getName().getIdentifier())) { //$NON-NLS-1$
+			return false;
+		}
+
+		IMethodBinding binding= invocation.resolveMethodBinding();
+		if (binding != null && binding.getDeclaringClass() != null) {
+			return "java.util.Arrays".equals(binding.getDeclaringClass().getErasure().getQualifiedName()); //$NON-NLS-1$
+		}
+
+		Expression expression= invocation.getExpression();
+		if (expression == null) {
+			return false;
+		}
+		String owner= expression.toString();
+		return "Arrays".equals(owner) || "java.util.Arrays".equals(owner); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	private static boolean isLengthPlusOne(Expression expression, Expression array) {
+		Expression unwrapped= unwrap(expression);
+		if (!(unwrapped instanceof InfixExpression infix)
+				|| infix.getOperator() != InfixExpression.Operator.PLUS
+				|| !infix.extendedOperands().isEmpty()) {
+			return false;
+		}
+		return isArrayLength(infix.getLeftOperand(), array) && isOne(infix.getRightOperand())
+				|| isOne(infix.getLeftOperand()) && isArrayLength(infix.getRightOperand(), array);
+	}
+
+	private static boolean isLengthMinusOne(Expression expression, Expression array) {
+		Expression unwrapped= unwrap(expression);
+		if (!(unwrapped instanceof InfixExpression infix)
+				|| infix.getOperator() != InfixExpression.Operator.MINUS
+				|| !infix.extendedOperands().isEmpty()) {
+			return false;
+		}
+		return isArrayLength(infix.getLeftOperand(), array) && isOne(infix.getRightOperand());
+	}
+
+	private static boolean isArrayLength(Expression expression, Expression array) {
+		Expression unwrapped= unwrap(expression);
+		if (unwrapped instanceof QualifiedName qualifiedName) {
+			return "length".equals(qualifiedName.getName().getIdentifier()) //$NON-NLS-1$
+					&& sameVariable(array, qualifiedName.getQualifier());
+		}
+		if (unwrapped instanceof FieldAccess fieldAccess) {
+			return "length".equals(fieldAccess.getName().getIdentifier()) //$NON-NLS-1$
+					&& sameVariable(array, fieldAccess.getExpression());
+		}
+		return false;
+	}
+
+	private static boolean isOne(Expression expression) {
+		Expression unwrapped= unwrap(expression);
+		Object constant= unwrapped.resolveConstantExpressionValue();
+		if (constant instanceof Number number) {
+			return number.longValue() == 1L;
+		}
+		return unwrapped instanceof NumberLiteral literal && "1".equals(literal.getToken()); //$NON-NLS-1$
+	}
+
+	private static boolean sameVariable(Expression first, Expression second) {
+		Expression left= unwrap(first);
+		Expression right= unwrap(second);
+		Optional<IVariableBinding> leftBinding= resolveVariableBinding(left);
+		Optional<IVariableBinding> rightBinding= resolveVariableBinding(right);
+		if (leftBinding.isPresent() && rightBinding.isPresent()) {
+			return leftBinding.get().getVariableDeclaration()
+					.isEqualTo(rightBinding.get().getVariableDeclaration());
+		}
+		return left.subtreeMatch(new ASTMatcher(true), right);
+	}
+
+	private static Optional<IVariableBinding> resolveVariableBinding(Expression expression) {
+		Expression unwrapped= unwrap(expression);
+		IBinding binding= null;
+		if (unwrapped instanceof SimpleName simpleName) {
+			binding= simpleName.resolveBinding();
+		} else if (unwrapped instanceof QualifiedName qualifiedName) {
+			binding= qualifiedName.resolveBinding();
+		} else if (unwrapped instanceof FieldAccess fieldAccess) {
+			binding= fieldAccess.resolveFieldBinding();
+		} else if (unwrapped instanceof SuperFieldAccess superFieldAccess) {
+			binding= superFieldAccess.resolveFieldBinding();
+		}
+		return binding instanceof IVariableBinding variableBinding
+				? Optional.of(variableBinding)
+				: Optional.empty();
+	}
+
+	private static Expression unwrap(Expression expression) {
+		Expression result= expression;
+		while (result instanceof ParenthesizedExpression parenthesized) {
+			result= parenthesized.getExpression();
+		}
+		return result;
+	}
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/AppendOnlyArraySeedDetector.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/AppendOnlyArraySeedDetector.java
@@ -10,32 +10,32 @@
  *******************************************************************************/
 package org.sandbox.jdt.container.analysis;
 
+import static org.sandbox.jdt.container.analysis.ContainerAstFacts.assignment;
+import static org.sandbox.jdt.container.analysis.ContainerAstFacts.expressionStatement;
+import static org.sandbox.jdt.container.analysis.ContainerAstFacts.isArrayLength;
+import static org.sandbox.jdt.container.analysis.ContainerAstFacts.isOne;
+import static org.sandbox.jdt.container.analysis.ContainerAstFacts.nextStatement;
+import static org.sandbox.jdt.container.analysis.ContainerAstFacts.sameVariable;
+import static org.sandbox.jdt.container.analysis.ContainerAstFacts.unwrap;
+import static org.sandbox.jdt.container.analysis.ContainerAstFacts.variableBinding;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.eclipse.jdt.core.dom.ASTMatcher;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ArrayAccess;
 import org.eclipse.jdt.core.dom.Assignment;
-import org.eclipse.jdt.core.dom.Block;
+import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.ExpressionStatement;
-import org.eclipse.jdt.core.dom.FieldAccess;
-import org.eclipse.jdt.core.dom.IBinding;
 import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.IVariableBinding;
 import org.eclipse.jdt.core.dom.InfixExpression;
 import org.eclipse.jdt.core.dom.MethodInvocation;
-import org.eclipse.jdt.core.dom.NumberLiteral;
-import org.eclipse.jdt.core.dom.ParenthesizedExpression;
-import org.eclipse.jdt.core.dom.QualifiedName;
-import org.eclipse.jdt.core.dom.SimpleName;
-import org.eclipse.jdt.core.dom.Statement;
-import org.eclipse.jdt.core.dom.SuperFieldAccess;
-import org.eclipse.jdt.core.dom.ArrayAccess;
-import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.sandbox.jdt.container.api.ContainerShape;
 import org.sandbox.jdt.container.api.ContainerUsageProfile;
 import org.sandbox.jdt.container.api.ContainerUsageProfile.AliasingContract;
@@ -75,8 +75,8 @@ public final class AppendOnlyArraySeedDetector {
 		ReferenceHolder<Integer, ContainerUsageProfile> profiles= ReferenceHolder.createIndexed();
 
 		AstProcessorBuilder.with(profiles)
-				.onAssignment((assignment, holder) -> {
-					detectSeed(assignment).ifPresent(profile ->
+				.onAssignment((candidate, holder) -> {
+					detectSeed(candidate).ifPresent(profile ->
 						holder.put(profile.identity().sourceStart(), profile));
 					return true;
 				})
@@ -94,7 +94,7 @@ public final class AppendOnlyArraySeedDetector {
 		}
 
 		Expression array= unwrap(growthAssignment.getLeftHandSide());
-		MethodInvocation copyOf= asMethodInvocation(growthAssignment.getRightHandSide());
+		MethodInvocation copyOf= methodInvocation(growthAssignment.getRightHandSide());
 		if (copyOf == null || !isArraysCopyOf(copyOf) || copyOf.arguments().size() != 2) {
 			return Optional.empty();
 		}
@@ -105,16 +105,16 @@ public final class AppendOnlyArraySeedDetector {
 			return Optional.empty();
 		}
 
-		ExpressionStatement growthStatement= asExpressionStatement(growthAssignment);
+		ExpressionStatement growthStatement= expressionStatement(growthAssignment);
 		Assignment appendAssignment= growthStatement == null
 				? null
-				: asAssignment(nextStatement(growthStatement));
+				: assignment(nextStatement(growthStatement));
 		if (!isTailWrite(appendAssignment, array)) {
 			return Optional.empty();
 		}
 
-		Optional<IVariableBinding> variableBinding= resolveVariableBinding(array);
-		ITypeBinding arrayType= variableBinding.map(IVariableBinding::getType)
+		Optional<IVariableBinding> binding= variableBinding(array);
+		ITypeBinding arrayType= binding.map(IVariableBinding::getType)
 				.orElseGet(array::resolveTypeBinding);
 		ElementDomain elementDomain= elementDomain(arrayType);
 		if (elementDomain == ElementDomain.PRIMITIVE) {
@@ -135,7 +135,7 @@ public final class AppendOnlyArraySeedDetector {
 		}
 
 		ContainerIdentity identity= new ContainerIdentity(
-				variableBinding.map(binding -> binding.getVariableDeclaration().getKey()).orElse(""), //$NON-NLS-1$
+				binding.map(value -> value.getVariableDeclaration().getKey()).orElse(""), //$NON-NLS-1$
 				array.toString(), array.getStartPosition(), array.getLength());
 
 		return Optional.of(new ContainerUsageProfile(
@@ -154,7 +154,7 @@ public final class AppendOnlyArraySeedDetector {
 				evidence));
 	}
 
-	private static UsageEvidence evidence(Kind kind, String summary, org.eclipse.jdt.core.dom.ASTNode node) {
+	private static UsageEvidence evidence(Kind kind, String summary, ASTNode node) {
 		return new UsageEvidence(kind, summary, node.getStartPosition(), node.getLength());
 	}
 
@@ -163,7 +163,7 @@ public final class AppendOnlyArraySeedDetector {
 			return ElementDomain.UNKNOWN;
 		}
 		if (!arrayType.isArray()) {
-			return ElementDomain.PRIMITIVE;
+			return ElementDomain.UNKNOWN;
 		}
 		ITypeBinding componentType= arrayType.getComponentType();
 		if (componentType == null) {
@@ -175,11 +175,11 @@ public final class AppendOnlyArraySeedDetector {
 		return componentType.isEnum() ? ElementDomain.ENUM : ElementDomain.REFERENCE;
 	}
 
-	private static boolean isTailWrite(Assignment assignment, Expression array) {
-		if (assignment == null || assignment.getOperator() != Assignment.Operator.ASSIGN) {
+	private static boolean isTailWrite(Assignment appendAssignment, Expression array) {
+		if (appendAssignment == null || appendAssignment.getOperator() != Assignment.Operator.ASSIGN) {
 			return false;
 		}
-		Expression leftHandSide= unwrap(assignment.getLeftHandSide());
+		Expression leftHandSide= unwrap(appendAssignment.getLeftHandSide());
 		if (!(leftHandSide instanceof ArrayAccess arrayAccess)) {
 			return false;
 		}
@@ -187,32 +187,9 @@ public final class AppendOnlyArraySeedDetector {
 				&& isLengthMinusOne(arrayAccess.getIndex(), array);
 	}
 
-	private static MethodInvocation asMethodInvocation(Expression expression) {
+	private static MethodInvocation methodInvocation(Expression expression) {
 		Expression unwrapped= unwrap(expression);
 		return unwrapped instanceof MethodInvocation invocation ? invocation : null;
-	}
-
-	private static ExpressionStatement asExpressionStatement(Assignment assignment) {
-		return assignment.getParent() instanceof ExpressionStatement statement ? statement : null;
-	}
-
-	private static Assignment asAssignment(Statement statement) {
-		if (!(statement instanceof ExpressionStatement expressionStatement)) {
-			return null;
-		}
-		Expression expression= unwrap(expressionStatement.getExpression());
-		return expression instanceof Assignment assignment ? assignment : null;
-	}
-
-	private static Statement nextStatement(Statement statement) {
-		if (!(statement.getParent() instanceof Block block)) {
-			return null;
-		}
-		List<?> statements= block.statements();
-		int index= statements.indexOf(statement);
-		return index >= 0 && index + 1 < statements.size()
-				? (Statement) statements.get(index + 1)
-				: null;
 	}
 
 	private static boolean isArraysCopyOf(MethodInvocation invocation) {
@@ -252,64 +229,5 @@ public final class AppendOnlyArraySeedDetector {
 			return false;
 		}
 		return isArrayLength(infix.getLeftOperand(), array) && isOne(infix.getRightOperand());
-	}
-
-	private static boolean isArrayLength(Expression expression, Expression array) {
-		Expression unwrapped= unwrap(expression);
-		if (unwrapped instanceof QualifiedName qualifiedName) {
-			return "length".equals(qualifiedName.getName().getIdentifier()) //$NON-NLS-1$
-					&& sameVariable(array, qualifiedName.getQualifier());
-		}
-		if (unwrapped instanceof FieldAccess fieldAccess) {
-			return "length".equals(fieldAccess.getName().getIdentifier()) //$NON-NLS-1$
-					&& sameVariable(array, fieldAccess.getExpression());
-		}
-		return false;
-	}
-
-	private static boolean isOne(Expression expression) {
-		Expression unwrapped= unwrap(expression);
-		Object constant= unwrapped.resolveConstantExpressionValue();
-		if (constant instanceof Number number) {
-			return number.longValue() == 1L;
-		}
-		return unwrapped instanceof NumberLiteral literal && "1".equals(literal.getToken()); //$NON-NLS-1$
-	}
-
-	private static boolean sameVariable(Expression first, Expression second) {
-		Expression left= unwrap(first);
-		Expression right= unwrap(second);
-		Optional<IVariableBinding> leftBinding= resolveVariableBinding(left);
-		Optional<IVariableBinding> rightBinding= resolveVariableBinding(right);
-		if (leftBinding.isPresent() && rightBinding.isPresent()) {
-			return leftBinding.get().getVariableDeclaration()
-					.isEqualTo(rightBinding.get().getVariableDeclaration());
-		}
-		return left.subtreeMatch(new ASTMatcher(true), right);
-	}
-
-	private static Optional<IVariableBinding> resolveVariableBinding(Expression expression) {
-		Expression unwrapped= unwrap(expression);
-		IBinding binding= null;
-		if (unwrapped instanceof SimpleName simpleName) {
-			binding= simpleName.resolveBinding();
-		} else if (unwrapped instanceof QualifiedName qualifiedName) {
-			binding= qualifiedName.resolveBinding();
-		} else if (unwrapped instanceof FieldAccess fieldAccess) {
-			binding= fieldAccess.resolveFieldBinding();
-		} else if (unwrapped instanceof SuperFieldAccess superFieldAccess) {
-			binding= superFieldAccess.resolveFieldBinding();
-		}
-		return binding instanceof IVariableBinding variableBinding
-				? Optional.of(variableBinding)
-				: Optional.empty();
-	}
-
-	private static Expression unwrap(Expression expression) {
-		Expression result= expression;
-		while (result instanceof ParenthesizedExpression parenthesized) {
-			result= parenthesized.getExpression();
-		}
-		return result;
 	}
 }

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/AppendOnlyArraySeedDetector.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/AppendOnlyArraySeedDetector.java
@@ -40,7 +40,7 @@ import org.sandbox.jdt.container.api.ContainerShape;
 import org.sandbox.jdt.container.api.ContainerUsageProfile;
 import org.sandbox.jdt.container.api.ContainerUsageProfile.AliasingContract;
 import org.sandbox.jdt.container.api.ContainerUsageProfile.AnalysisCompleteness;
-import org.sandbox.jdt.container.api.ContainerUsageProfile.ConcurrencyContract;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.ConcurrencyProfile;
 import org.sandbox.jdt.container.api.ContainerUsageProfile.ContainerIdentity;
 import org.sandbox.jdt.container.api.ContainerUsageProfile.ElementDomain;
 import org.sandbox.jdt.container.api.ContainerUsageProfile.EscapeLevel;
@@ -149,7 +149,7 @@ public final class AppendOnlyArraySeedDetector {
 				NullContract.UNKNOWN,
 				AliasingContract.UNKNOWN,
 				EscapeLevel.UNKNOWN,
-				ConcurrencyContract.UNKNOWN,
+				ConcurrencyProfile.unknown(),
 				AnalysisCompleteness.LOCAL_SEED,
 				evidence));
 	}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/ContainerAstFacts.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/ContainerAstFacts.java
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.container.analysis;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.jdt.core.dom.ASTMatcher;
+import org.eclipse.jdt.core.dom.Assignment;
+import org.eclipse.jdt.core.dom.Block;
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.ExpressionStatement;
+import org.eclipse.jdt.core.dom.FieldAccess;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.IVariableBinding;
+import org.eclipse.jdt.core.dom.NumberLiteral;
+import org.eclipse.jdt.core.dom.ParenthesizedExpression;
+import org.eclipse.jdt.core.dom.QualifiedName;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.Statement;
+import org.eclipse.jdt.core.dom.SuperFieldAccess;
+
+/** Shared, side-effect-free AST facts used by semantic container detectors. */
+final class ContainerAstFacts {
+
+	private ContainerAstFacts() {
+		// Static utility.
+	}
+
+	static Expression unwrap(Expression expression) {
+		Expression result= expression;
+		while (result instanceof ParenthesizedExpression parenthesized) {
+			result= parenthesized.getExpression();
+		}
+		return result;
+	}
+
+	static ExpressionStatement expressionStatement(Assignment assignment) {
+		return assignment.getParent() instanceof ExpressionStatement statement ? statement : null;
+	}
+
+	static Assignment assignment(Statement statement) {
+		if (!(statement instanceof ExpressionStatement expressionStatement)) {
+			return null;
+		}
+		Expression expression= unwrap(expressionStatement.getExpression());
+		return expression instanceof Assignment assignment ? assignment : null;
+	}
+
+	static Statement nextStatement(Statement statement) {
+		if (!(statement.getParent() instanceof Block block)) {
+			return null;
+		}
+		List<?> statements= block.statements();
+		int index= statements.indexOf(statement);
+		return index >= 0 && index + 1 < statements.size()
+				? (Statement) statements.get(index + 1)
+				: null;
+	}
+
+	static boolean isArrayLength(Expression expression, Expression array) {
+		Expression unwrapped= unwrap(expression);
+		if (unwrapped instanceof QualifiedName qualifiedName) {
+			return "length".equals(qualifiedName.getName().getIdentifier()) //$NON-NLS-1$
+					&& sameVariable(array, qualifiedName.getQualifier());
+		}
+		if (unwrapped instanceof FieldAccess fieldAccess) {
+			return "length".equals(fieldAccess.getName().getIdentifier()) //$NON-NLS-1$
+					&& sameVariable(array, fieldAccess.getExpression());
+		}
+		return false;
+	}
+
+	static boolean isOne(Expression expression) {
+		Expression unwrapped= unwrap(expression);
+		Object constant= unwrapped.resolveConstantExpressionValue();
+		if (constant instanceof Number number) {
+			return number.longValue() == 1L;
+		}
+		return unwrapped instanceof NumberLiteral literal && "1".equals(literal.getToken()); //$NON-NLS-1$
+	}
+
+	static boolean sameVariable(Expression first, Expression second) {
+		Expression left= unwrap(first);
+		Expression right= unwrap(second);
+		Optional<IVariableBinding> leftBinding= variableBinding(left);
+		Optional<IVariableBinding> rightBinding= variableBinding(right);
+		if (leftBinding.isPresent() && rightBinding.isPresent()) {
+			return leftBinding.get().getVariableDeclaration()
+					.isEqualTo(rightBinding.get().getVariableDeclaration());
+		}
+		return left.subtreeMatch(new ASTMatcher(true), right);
+	}
+
+	static Optional<IVariableBinding> variableBinding(Expression expression) {
+		Expression unwrapped= unwrap(expression);
+		IBinding binding= null;
+		if (unwrapped instanceof SimpleName simpleName) {
+			binding= simpleName.resolveBinding();
+		} else if (unwrapped instanceof QualifiedName qualifiedName) {
+			binding= qualifiedName.resolveBinding();
+		} else if (unwrapped instanceof FieldAccess fieldAccess) {
+			binding= fieldAccess.resolveFieldBinding();
+		} else if (unwrapped instanceof SuperFieldAccess superFieldAccess) {
+			binding= superFieldAccess.resolveFieldBinding();
+		}
+		return binding instanceof IVariableBinding variableBinding
+				? Optional.of(variableBinding)
+				: Optional.empty();
+	}
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/api/ContainerShape.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/api/ContainerShape.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.container.api;
+
+/**
+ * Structural representation used by a container before or after a semantic migration.
+ *
+ * <p>The shape describes representation only. Ordering, uniqueness, mutability and
+ * concurrency are modelled separately by {@link ContainerUsageProfile}.</p>
+ */
+public enum ContainerShape {
+	ARRAY,
+	LIST,
+	SET,
+	MAP,
+	DEQUE,
+	SYNCHRONIZED_WRAPPER,
+	CONCURRENT_CONTAINER,
+	CUSTOM_BUFFER
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/api/ContainerUsageProfile.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/api/ContainerUsageProfile.java
@@ -1,0 +1,191 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.container.api;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Immutable semantic description of how one connected container value is used.
+ *
+ * <p>A profile is an analysis result, not yet a rewrite decision. In particular,
+ * {@link AnalysisCompleteness#LOCAL_SEED} means that a useful local motif was found
+ * but project-wide data flow, escape and compatibility checks are still outstanding.</p>
+ *
+ * @param identity stable identity and source anchor of the candidate
+ * @param currentShape current structural representation
+ * @param elementDomain known element-domain category
+ * @param access observed access operations
+ * @param orderRequirement ordering required by observed code
+ * @param uniquenessRequirement uniqueness required by observed code
+ * @param mutationLifecycle observed mutation lifecycle
+ * @param nullContract observed null behaviour
+ * @param aliasingContract observed aliasing behaviour
+ * @param escapeLevel widest known escape boundary
+ * @param concurrencyContract observed concurrency behaviour
+ * @param completeness completeness of the semantic proof
+ * @param evidence source-backed observations supporting the profile
+ */
+public record ContainerUsageProfile(
+		ContainerIdentity identity,
+		ContainerShape currentShape,
+		ElementDomain elementDomain,
+		AccessProfile access,
+		OrderRequirement orderRequirement,
+		UniquenessRequirement uniquenessRequirement,
+		MutationLifecycle mutationLifecycle,
+		NullContract nullContract,
+		AliasingContract aliasingContract,
+		EscapeLevel escapeLevel,
+		ConcurrencyContract concurrencyContract,
+		AnalysisCompleteness completeness,
+		List<UsageEvidence> evidence) {
+
+	public ContainerUsageProfile {
+		Objects.requireNonNull(identity, "identity"); //$NON-NLS-1$
+		Objects.requireNonNull(currentShape, "currentShape"); //$NON-NLS-1$
+		Objects.requireNonNull(elementDomain, "elementDomain"); //$NON-NLS-1$
+		Objects.requireNonNull(access, "access"); //$NON-NLS-1$
+		Objects.requireNonNull(orderRequirement, "orderRequirement"); //$NON-NLS-1$
+		Objects.requireNonNull(uniquenessRequirement, "uniquenessRequirement"); //$NON-NLS-1$
+		Objects.requireNonNull(mutationLifecycle, "mutationLifecycle"); //$NON-NLS-1$
+		Objects.requireNonNull(nullContract, "nullContract"); //$NON-NLS-1$
+		Objects.requireNonNull(aliasingContract, "aliasingContract"); //$NON-NLS-1$
+		Objects.requireNonNull(escapeLevel, "escapeLevel"); //$NON-NLS-1$
+		Objects.requireNonNull(concurrencyContract, "concurrencyContract"); //$NON-NLS-1$
+		Objects.requireNonNull(completeness, "completeness"); //$NON-NLS-1$
+		evidence= List.copyOf(Objects.requireNonNull(evidence, "evidence")); //$NON-NLS-1$
+	}
+
+	/** Returns whether a later planner may treat this profile as a complete flow proof. */
+	public boolean isFlowComplete() {
+		return completeness == AnalysisCompleteness.FLOW_COMPLETE;
+	}
+
+	/** Stable identity of the represented value, independent of retained AST nodes. */
+	public record ContainerIdentity(String bindingKey, String displayName, int sourceStart, int sourceLength) {
+
+		public ContainerIdentity {
+			bindingKey= bindingKey == null ? "" : bindingKey; //$NON-NLS-1$
+			displayName= Objects.requireNonNull(displayName, "displayName").strip(); //$NON-NLS-1$
+			if (displayName.isEmpty()) {
+				throw new IllegalArgumentException("displayName must not be empty"); //$NON-NLS-1$
+			}
+			if (sourceStart < 0) {
+				throw new IllegalArgumentException("sourceStart must not be negative"); //$NON-NLS-1$
+			}
+			if (sourceLength < 0) {
+				throw new IllegalArgumentException("sourceLength must not be negative"); //$NON-NLS-1$
+			}
+		}
+
+		/** Returns whether binding resolution supplied a stable key. */
+		public boolean hasResolvedBinding() {
+			return !bindingKey.isBlank();
+		}
+
+		/** Returns a deterministic identifier suitable for reports and maps. */
+		public String stableId() {
+			return hasResolvedBinding() ? bindingKey : displayName + '@' + sourceStart;
+		}
+	}
+
+	/** Operations observed on the represented value. */
+	public record AccessProfile(
+			boolean indexedRead,
+			boolean indexedWrite,
+			boolean append,
+			boolean positionalInsert,
+			boolean positionalRemove,
+			boolean membershipQuery,
+			boolean keyLookup) {
+
+		/** Initial access facts for a syntactically recognised append-only array seed. */
+		public static AccessProfile appendOnlyArraySeed() {
+			return new AccessProfile(false, true, true, false, false, false, false);
+		}
+
+		/** Returns whether position is already part of the observed contract. */
+		public boolean hasPositionalSemantics() {
+			return indexedRead || positionalInsert || positionalRemove;
+		}
+	}
+
+	public enum ElementDomain {
+		REFERENCE,
+		PRIMITIVE,
+		ENUM,
+		UNKNOWN
+	}
+
+	public enum OrderRequirement {
+		NONE,
+		ENCOUNTER,
+		SORTED,
+		POSITIONAL,
+		UNKNOWN
+	}
+
+	public enum UniquenessRequirement {
+		REQUIRED,
+		DUPLICATES_ALLOWED,
+		UNKNOWN
+	}
+
+	public enum MutationLifecycle {
+		FIXED,
+		BUILD_THEN_FREEZE,
+		CONTINUOUSLY_MUTABLE,
+		SNAPSHOT_PUBLISHED,
+		UNKNOWN
+	}
+
+	public enum NullContract {
+		ALLOWED,
+		REJECTED,
+		NOT_APPLICABLE,
+		UNKNOWN
+	}
+
+	public enum AliasingContract {
+		SHARED_MUTATION,
+		DEFENSIVE_COPY,
+		IDENTITY_OBSERVED,
+		NO_OBSERVED_ALIAS,
+		UNKNOWN
+	}
+
+	public enum EscapeLevel {
+		LOCAL,
+		FIELD,
+		METHOD_BOUNDARY,
+		OVERRIDE_FAMILY,
+		EXTERNAL_OR_BINARY,
+		UNKNOWN
+	}
+
+	public enum ConcurrencyContract {
+		THREAD_CONFINED,
+		LOCK_PROTECTED,
+		COPY_ON_WRITE,
+		CONCURRENT_MEMBERSHIP,
+		PRODUCER_CONSUMER,
+		ATOMIC_DRAIN,
+		UNKNOWN
+	}
+
+	public enum AnalysisCompleteness {
+		LOCAL_SEED,
+		LOCAL_USAGE_COMPLETE,
+		FLOW_COMPLETE,
+		REJECTED
+	}
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/api/ContainerUsageProfile.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/api/ContainerUsageProfile.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * @param nullContract observed null behaviour
  * @param aliasingContract observed aliasing behaviour
  * @param escapeLevel widest known escape boundary
- * @param concurrencyContract observed concurrency behaviour
+ * @param concurrency observed concurrency and publication behaviour
  * @param completeness completeness of the semantic proof
  * @param evidence source-backed observations supporting the profile
  */
@@ -45,7 +45,7 @@ public record ContainerUsageProfile(
 		NullContract nullContract,
 		AliasingContract aliasingContract,
 		EscapeLevel escapeLevel,
-		ConcurrencyContract concurrencyContract,
+		ConcurrencyProfile concurrency,
 		AnalysisCompleteness completeness,
 		List<UsageEvidence> evidence) {
 
@@ -60,7 +60,7 @@ public record ContainerUsageProfile(
 		Objects.requireNonNull(nullContract, "nullContract"); //$NON-NLS-1$
 		Objects.requireNonNull(aliasingContract, "aliasingContract"); //$NON-NLS-1$
 		Objects.requireNonNull(escapeLevel, "escapeLevel"); //$NON-NLS-1$
-		Objects.requireNonNull(concurrencyContract, "concurrencyContract"); //$NON-NLS-1$
+		Objects.requireNonNull(concurrency, "concurrency"); //$NON-NLS-1$
 		Objects.requireNonNull(completeness, "completeness"); //$NON-NLS-1$
 		evidence= List.copyOf(Objects.requireNonNull(evidence, "evidence")); //$NON-NLS-1$
 	}
@@ -119,6 +119,33 @@ public record ContainerUsageProfile(
 		}
 	}
 
+	/** Structured concurrency facts; unknown values are preferable to guessed guarantees. */
+	public record ConcurrencyProfile(
+			ThreadExposure exposure,
+			SynchronizationKind synchronization,
+			IterationSemantics iteration,
+			AtomicityRequirement atomicity,
+			WorkloadShape workload) {
+
+		public ConcurrencyProfile {
+			Objects.requireNonNull(exposure, "exposure"); //$NON-NLS-1$
+			Objects.requireNonNull(synchronization, "synchronization"); //$NON-NLS-1$
+			Objects.requireNonNull(iteration, "iteration"); //$NON-NLS-1$
+			Objects.requireNonNull(atomicity, "atomicity"); //$NON-NLS-1$
+			Objects.requireNonNull(workload, "workload"); //$NON-NLS-1$
+		}
+
+		/** Returns a profile that makes no concurrency claim. */
+		public static ConcurrencyProfile unknown() {
+			return new ConcurrencyProfile(
+					ThreadExposure.UNKNOWN,
+					SynchronizationKind.UNKNOWN,
+					IterationSemantics.UNKNOWN,
+					AtomicityRequirement.UNKNOWN,
+					WorkloadShape.UNKNOWN);
+		}
+	}
+
 	public enum ElementDomain {
 		REFERENCE,
 		PRIMITIVE,
@@ -172,13 +199,51 @@ public record ContainerUsageProfile(
 		UNKNOWN
 	}
 
-	public enum ConcurrencyContract {
+	public enum ThreadExposure {
 		THREAD_CONFINED,
-		LOCK_PROTECTED,
+		PUBLISHED,
+		CALLBACK_SHARED,
+		WORKER_SHARED,
+		UNKNOWN
+	}
+
+	public enum SynchronizationKind {
+		NONE,
+		INTRINSIC_LOCK,
+		EXPLICIT_LOCK,
+		SYNCHRONIZED_WRAPPER,
+		VOLATILE_SNAPSHOT,
+		ATOMIC_REFERENCE,
+		CONCURRENT_COLLECTION,
+		UNKNOWN
+	}
+
+	public enum IterationSemantics {
+		LIVE,
+		EXTERNALLY_LOCKED,
+		WEAKLY_CONSISTENT,
+		IMMUTABLE_SNAPSHOT,
 		COPY_ON_WRITE,
-		CONCURRENT_MEMBERSHIP,
+		UNKNOWN
+	}
+
+	public enum AtomicityRequirement {
+		INDIVIDUAL_OPERATIONS,
+		CHECK_THEN_ACT,
+		COMPOUND_UPDATE,
+		DRAIN,
+		REPLACE_ALL,
+		TRANSACTION,
+		UNKNOWN
+	}
+
+	public enum WorkloadShape {
+		READ_MOSTLY,
+		WRITE_MOSTLY,
+		BALANCED,
+		REGISTRATION_HEAVY,
+		NOTIFICATION_HEAVY,
 		PRODUCER_CONSUMER,
-		ATOMIC_DRAIN,
 		UNKNOWN
 	}
 

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/api/TargetContainerContract.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/api/TargetContainerContract.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.container.api;
+
+import java.util.Objects;
+
+import org.sandbox.jdt.container.api.ContainerUsageProfile.NullContract;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.OrderRequirement;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.UniquenessRequirement;
+
+/**
+ * A semantic target contract proposed from a {@link ContainerUsageProfile}.
+ *
+ * <p>The contract intentionally names properties before implementation classes.
+ * A later migration planner may select a concrete implementation only after source
+ * level, compatibility and concurrency checks.</p>
+ *
+ * @param shape proposed structural representation
+ * @param orderRequirement required ordering
+ * @param uniquenessRequirement required uniqueness
+ * @param mutability required publication mutability
+ * @param nullContract required null behaviour
+ * @param rationale concise explanation of the proposal
+ */
+public record TargetContainerContract(
+		ContainerShape shape,
+		OrderRequirement orderRequirement,
+		UniquenessRequirement uniquenessRequirement,
+		Mutability mutability,
+		NullContract nullContract,
+		String rationale) {
+
+	public TargetContainerContract {
+		Objects.requireNonNull(shape, "shape"); //$NON-NLS-1$
+		Objects.requireNonNull(orderRequirement, "orderRequirement"); //$NON-NLS-1$
+		Objects.requireNonNull(uniquenessRequirement, "uniquenessRequirement"); //$NON-NLS-1$
+		Objects.requireNonNull(mutability, "mutability"); //$NON-NLS-1$
+		Objects.requireNonNull(nullContract, "nullContract"); //$NON-NLS-1$
+		rationale= Objects.requireNonNull(rationale, "rationale").strip(); //$NON-NLS-1$
+		if (rationale.isEmpty()) {
+			throw new IllegalArgumentException("rationale must not be empty"); //$NON-NLS-1$
+		}
+	}
+
+	public enum Mutability {
+		MUTABLE,
+		IMMUTABLE,
+		BUILD_THEN_FREEZE,
+		UNKNOWN
+	}
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/api/UsageEvidence.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/api/UsageEvidence.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.container.api;
+
+import java.util.Objects;
+
+/**
+ * One source-backed fact contributing to a container usage profile.
+ *
+ * <p>The record deliberately stores only stable scalar data. AST nodes belong to the
+ * parser pass that produced the evidence and must not be retained by a multi-file plan.</p>
+ *
+ * @param kind semantic category of the observation
+ * @param summary concise explanation suitable for reports
+ * @param sourceStart zero-based source offset
+ * @param sourceLength source length in characters
+ */
+public record UsageEvidence(Kind kind, String summary, int sourceStart, int sourceLength) {
+
+	public UsageEvidence {
+		Objects.requireNonNull(kind, "kind"); //$NON-NLS-1$
+		summary= Objects.requireNonNull(summary, "summary").strip(); //$NON-NLS-1$
+		if (summary.isEmpty()) {
+			throw new IllegalArgumentException("summary must not be empty"); //$NON-NLS-1$
+		}
+		if (sourceStart < 0) {
+			throw new IllegalArgumentException("sourceStart must not be negative"); //$NON-NLS-1$
+		}
+		if (sourceLength < 0) {
+			throw new IllegalArgumentException("sourceLength must not be negative"); //$NON-NLS-1$
+		}
+	}
+
+	/** Semantic categories understood by the initial container analysis. */
+	public enum Kind {
+		ARRAY_GROWTH,
+		APPEND_WRITE,
+		REFERENCE_COMPONENT,
+		UNRESOLVED_BINDING,
+		REJECTION_BOUNDARY
+	}
+}

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/container/analysis/AppendOnlyArraySeedDetectorTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/container/analysis/AppendOnlyArraySeedDetectorTest.java
@@ -1,0 +1,154 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.container.analysis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.junit.jupiter.api.Test;
+import org.sandbox.jdt.container.api.ContainerShape;
+import org.sandbox.jdt.container.api.ContainerUsageProfile;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.AnalysisCompleteness;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.ElementDomain;
+import org.sandbox.jdt.container.api.UsageEvidence.Kind;
+
+class AppendOnlyArraySeedDetectorTest {
+
+	private final AppendOnlyArraySeedDetector detector= new AppendOnlyArraySeedDetector();
+
+	@Test
+	void detectsReferenceArrayGrowthFollowedByTailWrite() {
+		CompilationUnit compilationUnit= parse("""
+			import java.util.Arrays;
+
+			class Sample {
+				void append(String value) {
+					String[] values = new String[0];
+					values = Arrays.copyOf(values, values.length + 1);
+					values[values.length - 1] = value;
+				}
+			}
+			""");
+
+		List<ContainerUsageProfile> profiles= detector.findSeeds(compilationUnit);
+
+		assertEquals(1, profiles.size());
+		ContainerUsageProfile profile= profiles.get(0);
+		assertEquals(ContainerShape.ARRAY, profile.currentShape());
+		assertEquals(ElementDomain.REFERENCE, profile.elementDomain());
+		assertEquals(AnalysisCompleteness.LOCAL_SEED, profile.completeness());
+		assertTrue(profile.access().append());
+		assertTrue(profile.access().indexedWrite());
+		assertFalse(profile.isFlowComplete());
+		assertEquals(List.of(Kind.ARRAY_GROWTH, Kind.APPEND_WRITE, Kind.REFERENCE_COMPONENT),
+				profile.evidence().stream().map(evidence -> evidence.kind()).toList());
+		assertThrows(UnsupportedOperationException.class,
+				() -> profile.evidence().add(profile.evidence().get(0)));
+	}
+
+	@Test
+	void ignoresPrimitiveArrays() {
+		CompilationUnit compilationUnit= parse("""
+			import java.util.Arrays;
+
+			class Sample {
+				void append(int value) {
+					int[] values = new int[0];
+					values = Arrays.copyOf(values, values.length + 1);
+					values[values.length - 1] = value;
+				}
+			}
+			""");
+
+		assertTrue(detector.findSeeds(compilationUnit).isEmpty());
+	}
+
+	@Test
+	void ignoresWriteToExistingPosition() {
+		CompilationUnit compilationUnit= parse("""
+			import java.util.Arrays;
+
+			class Sample {
+				void append(String value) {
+					String[] values = new String[0];
+					values = Arrays.copyOf(values, values.length + 1);
+					values[0] = value;
+				}
+			}
+			""");
+
+		assertTrue(detector.findSeeds(compilationUnit).isEmpty());
+	}
+
+	@Test
+	void ignoresTailWriteToDifferentArray() {
+		CompilationUnit compilationUnit= parse("""
+			import java.util.Arrays;
+
+			class Sample {
+				void append(String value) {
+					String[] values = new String[0];
+					String[] other = new String[1];
+					values = Arrays.copyOf(values, values.length + 1);
+					other[other.length - 1] = value;
+				}
+			}
+			""");
+
+		assertTrue(detector.findSeeds(compilationUnit).isEmpty());
+	}
+
+	@Test
+	void returnsCandidatesInSourceOrder() {
+		CompilationUnit compilationUnit= parse("""
+			import java.util.Arrays;
+
+			class Sample {
+				void appendFirst(String value) {
+					String[] first = new String[0];
+					first = Arrays.copyOf(first, first.length + 1);
+					first[first.length - 1] = value;
+				}
+
+				void appendSecond(Object value) {
+					Object[] second = new Object[0];
+					second = Arrays.copyOf(second, 1 + second.length);
+					second[second.length - 1] = value;
+				}
+			}
+			""");
+
+		List<ContainerUsageProfile> profiles= detector.findSeeds(compilationUnit);
+
+		assertEquals(List.of("first", "second"),
+				profiles.stream().map(profile -> profile.identity().displayName()).toList());
+		assertTrue(profiles.get(0).identity().sourceStart() < profiles.get(1).identity().sourceStart());
+	}
+
+	private static CompilationUnit parse(String source) {
+		ASTParser parser= ASTParser.newParser(AST.getJLSLatest());
+		parser.setSource(source.toCharArray());
+		parser.setKind(ASTParser.K_COMPILATION_UNIT);
+		parser.setResolveBindings(true);
+		parser.setBindingsRecovery(true);
+		parser.setStatementsRecovery(true);
+		parser.setUnitName("Sample.java"); //$NON-NLS-1$
+		parser.setEnvironment(new String[0], new String[0], new String[0], true);
+		return (CompilationUnit) parser.createAST(null);
+	}
+}

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/container/analysis/AppendOnlyArraySeedDetectorTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/container/analysis/AppendOnlyArraySeedDetectorTest.java
@@ -62,6 +62,28 @@ class AppendOnlyArraySeedDetectorTest {
 	}
 
 	@Test
+	void detectsExplicitFieldAccess() {
+		CompilationUnit compilationUnit= parse("""
+			import java.util.Arrays;
+
+			class Sample {
+				private String[] values = new String[0];
+
+				void append(String value) {
+					this.values = Arrays.copyOf(this.values, this.values.length + 1);
+					this.values[this.values.length - 1] = value;
+				}
+			}
+			""");
+
+		List<ContainerUsageProfile> profiles= detector.findSeeds(compilationUnit);
+
+		assertEquals(1, profiles.size());
+		assertEquals("this.values", profiles.get(0).identity().displayName());
+		assertTrue(profiles.get(0).identity().hasResolvedBinding());
+	}
+
+	@Test
 	void ignoresPrimitiveArrays() {
 		CompilationUnit compilationUnit= parse("""
 			import java.util.Arrays;
@@ -106,6 +128,27 @@ class AppendOnlyArraySeedDetectorTest {
 					String[] other = new String[1];
 					values = Arrays.copyOf(values, values.length + 1);
 					other[other.length - 1] = value;
+				}
+			}
+			""");
+
+		assertTrue(detector.findSeeds(compilationUnit).isEmpty());
+	}
+
+	@Test
+	void ignoresSameNamedCopyMethodFromAnotherType() {
+		CompilationUnit compilationUnit= parse("""
+			class Arrays {
+				static String[] copyOf(String[] source, int length) {
+					return source;
+				}
+			}
+
+			class Sample {
+				void append(String value) {
+					String[] values = new String[0];
+					values = Arrays.copyOf(values, values.length + 1);
+					values[values.length - 1] = value;
 				}
 			}
 			""");


### PR DESCRIPTION
## Summary

Begins #1379 with a deliberately report-only vertical slice.

- adds immutable container shape, usage-profile, evidence and target-contract models in `sandbox_common_core`;
- models concurrency as separate exposure, synchronization, iteration, atomicity and workload facts rather than a single `thread-safe` category;
- adds a first `AppendOnlyArraySeedDetector` for reference arrays grown with `Arrays.copyOf(..., length + 1)` followed by a tail write;
- expresses the local semantic relationship through the existing scoped `ASTProcessor` chain: `Arrays.copyOf` invocation → immediately following statement → tail `ArrayAccess`;
- supports local variables and explicit field access while preserving stable binding keys when available;
- reuses `ReferenceHolder` for short-lived chain state and centralizes reusable AST facts for later set, map and parallel-array detectors;
- labels results as `LOCAL_SEED`; no rewrite or safety claim is produced yet;
- excludes resolved primitive arrays and tests important rejection boundaries;
- exports the new analysis and API packages from the common-core bundle.

## Scoped-chain follow-up

The detector intentionally uses the lower-level scoped chain because the typed `AstProcessorBuilder` does not expose navigation clearly. The central API limitations and a compatibility-safe redesign are tracked in #1384, including explicit independent/scoped modes, typed navigation, repeated node types and separate matcher/handler semantics.

## Safety boundary

The detector only records local evidence. Project-wide usage, aliases, escapes, signature impact, compatibility and concurrency remain unknown and must be proven by later stages before any cleanup can become executable.

## Tests

Added unit coverage for:

- reference-array append recognition;
- explicit field-array recognition;
- primitive-array exclusion;
- rejection of writes to an existing position;
- rejection of writes to a different array;
- binding-based rejection of an unrelated same-named `copyOf` method;
- deterministic source ordering and immutable evidence.

## Validation

- Core Module Build was green before the scoped-chain readability refactor.
- Core and full Java CI are running for the latest revision.

Refs #1378
Closes no issue; this is the first implementation slice of #1379.