### PR TITLE
Make scoped AST processing explicit

### DIFF
--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/AppendOnlyArraySeedDetector.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/AppendOnlyArraySeedDetector.java
@@ -4,7 +4,7 @@
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-2.0/
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
@@ -19,8 +19,6 @@ import static org.sandbox.jdt.container.analysis.ContainerAstFacts.unwrap;
 import static org.sandbox.jdt.container.analysis.ContainerAstFacts.variableBinding;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -31,12 +29,12 @@ import org.eclipse.jdt.core.dom.Assignment;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.ExpressionStatement;
+import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.IVariableBinding;
 import org.eclipse.jdt.core.dom.InfixExpression;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.core.dom.ParenthesizedExpression;
-import org.eclipse.jdt.core.dom.Statement;
 import org.sandbox.jdt.container.api.ContainerShape;
 import org.sandbox.jdt.container.api.ContainerUsageProfile;
 import org.sandbox.jdt.container.api.ContainerUsageProfile.AliasingContract;
@@ -51,16 +49,16 @@ import org.sandbox.jdt.container.api.ContainerUsageProfile.OrderRequirement;
 import org.sandbox.jdt.container.api.ContainerUsageProfile.UniquenessRequirement;
 import org.sandbox.jdt.container.api.UsageEvidence;
 import org.sandbox.jdt.container.api.UsageEvidence.Kind;
-import org.sandbox.jdt.internal.common.ASTProcessor;
+import org.sandbox.jdt.internal.common.AstProcessing;
 import org.sandbox.jdt.internal.common.ReferenceHolder;
 
 /**
  * Finds local seeds where a reference array is grown by one element and the new tail
  * slot is assigned immediately afterwards.
  *
- * <p>The implementation uses the scoped {@link ASTProcessor} chain deliberately:
- * after a matching {@link Arrays#copyOf(Object[], int)} invocation, the next stage
- * searches only the immediately following statement for the corresponding tail write.</p>
+ * <p>The implementation uses an explicit scoped AST pipeline: after a semantically
+ * matching {@code java.util.Arrays.copyOf(...)} invocation, the next stage searches
+ * only the immediately following statement for the corresponding tail write.</p>
  *
  * <p>This detector deliberately stops at {@link AnalysisCompleteness#LOCAL_SEED}.
  * It does not claim that all array uses are append-only, that aliases do not escape or
@@ -71,40 +69,29 @@ public final class AppendOnlyArraySeedDetector {
 
 	private static final int CURRENT_GROWTH= 0;
 
-	/**
-	 * Finds deterministic, source-ordered append-only array seeds.
-	 *
-	 * @param compilationUnit compilation unit to inspect
-	 * @return immutable list of local usage profiles
-	 */
+	/** Finds deterministic, source-ordered append-only array seeds. */
 	public List<ContainerUsageProfile> findSeeds(CompilationUnit compilationUnit) {
 		Objects.requireNonNull(compilationUnit, "compilationUnit"); //$NON-NLS-1$
 
 		List<ContainerUsageProfile> profiles= new ArrayList<>();
 		ReferenceHolder<Integer, GrowthSeed> state= ReferenceHolder.createIndexed();
-		ASTProcessor<ReferenceHolder<Integer, GrowthSeed>, Integer, GrowthSeed> processor=
-				new ASTProcessor<>(state, new HashSet<>());
 
-		processor
-				.callMethodInvocationVisitor(Arrays.class, "copyOf", //$NON-NLS-1$
-						AppendOnlyArraySeedDetector::rememberGrowth,
+		AstProcessing.scoped(state)
+				.find(MethodInvocation.class,
+						(copyOf, holder) -> growthSeed(copyOf).isPresent(),
+						(copyOf, holder) -> holder.put(
+								CURRENT_GROWTH, growthSeed(copyOf).orElseThrow()),
 						AppendOnlyArraySeedDetector::followingStatementScope)
-				.callArrayAccessVisitor((node, holder) ->
-						collectTailWrite((ArrayAccess) node, holder, profiles))
+				.then(ArrayAccess.class,
+						AppendOnlyArraySeedDetector::isTailWrite,
+						(arrayAccess, holder) -> collectTailWrite(arrayAccess, holder, profiles))
 				.build(compilationUnit);
 
 		return List.copyOf(profiles);
 	}
 
-	private static boolean rememberGrowth(MethodInvocation copyOf,
-			ReferenceHolder<Integer, GrowthSeed> state) {
-		state.remove(CURRENT_GROWTH);
-		growthSeed(copyOf).ifPresent(seed -> state.put(CURRENT_GROWTH, seed));
-		return false;
-	}
-
 	private static Optional<GrowthSeed> growthSeed(MethodInvocation copyOf) {
-		if (copyOf.arguments().size() != 2) {
+		if (!isArraysCopyOf(copyOf) || copyOf.arguments().size() != 2) {
 			return Optional.empty();
 		}
 
@@ -133,53 +120,81 @@ public final class AppendOnlyArraySeedDetector {
 		return Optional.of(new GrowthSeed(array, growthAssignment, binding, elementDomain));
 	}
 
-	private static ASTNode followingStatementScope(ASTNode node) {
-		MethodInvocation copyOf= (MethodInvocation) node;
+	private static boolean isArraysCopyOf(MethodInvocation invocation) {
+		if (!"copyOf".equals(invocation.getName().getIdentifier())) { //$NON-NLS-1$
+			return false;
+		}
+		IMethodBinding binding= invocation.resolveMethodBinding();
+		if (binding != null && binding.getDeclaringClass() != null) {
+			return "java.util.Arrays".equals( //$NON-NLS-1$
+					binding.getDeclaringClass().getErasure().getQualifiedName());
+		}
+		Expression owner= invocation.getExpression();
+		return owner != null && ("Arrays".equals(owner.toString()) //$NON-NLS-1$
+				|| "java.util.Arrays".equals(owner.toString())); //$NON-NLS-1$
+	}
+
+	private static ASTNode followingStatementScope(MethodInvocation copyOf) {
 		Assignment assignment= enclosingAssignment(copyOf);
 		ExpressionStatement statement= assignment == null ? null : expressionStatement(assignment);
-		Statement next= statement == null ? null : nextStatement(statement);
-		return next != null ? next : copyOf;
+		return statement == null ? null : nextStatement(statement);
 	}
 
-	private static boolean collectTailWrite(ArrayAccess arrayAccess,
-			ReferenceHolder<Integer, GrowthSeed> state,
-			List<ContainerUsageProfile> profiles) {
+	private static boolean isTailWrite(
+			ArrayAccess arrayAccess,
+			ReferenceHolder<Integer, GrowthSeed> state) {
 		GrowthSeed seed= state.get(CURRENT_GROWTH);
 		if (seed == null) {
-			return true;
+			return false;
 		}
-
 		Assignment appendAssignment= enclosingAssignment(arrayAccess);
-		if (appendAssignment == null
-				|| unwrap(appendAssignment.getLeftHandSide()) != arrayAccess
-				|| !sameVariable(seed.array(), arrayAccess.getArray())
-				|| !isLengthMinusOne(arrayAccess.getIndex(), seed.array())) {
-			return true;
-		}
-
-		profiles.add(createProfile(seed, appendAssignment));
-		state.remove(CURRENT_GROWTH);
-		return false;
+		return appendAssignment != null
+				&& unwrap(appendAssignment.getLeftHandSide()) == arrayAccess
+				&& sameVariable(seed.array(), arrayAccess.getArray())
+				&& isLengthMinusOne(arrayAccess.getIndex(), seed.array());
 	}
 
-	private static ContainerUsageProfile createProfile(GrowthSeed seed, Assignment appendAssignment) {
+	private static void collectTailWrite(
+			ArrayAccess arrayAccess,
+			ReferenceHolder<Integer, GrowthSeed> state,
+			List<ContainerUsageProfile> profiles) {
+		GrowthSeed seed= state.remove(CURRENT_GROWTH);
+		Assignment appendAssignment= enclosingAssignment(arrayAccess);
+		if (seed != null && appendAssignment != null) {
+			profiles.add(createProfile(seed, appendAssignment));
+		}
+	}
+
+	private static ContainerUsageProfile createProfile(
+			GrowthSeed seed,
+			Assignment appendAssignment) {
 		List<UsageEvidence> evidence= new ArrayList<>();
-		evidence.add(evidence(Kind.ARRAY_GROWTH,
-				"Array capacity is increased by one element", seed.growthAssignment())); //$NON-NLS-1$
-		evidence.add(evidence(Kind.APPEND_WRITE,
-				"The immediately following write targets the new tail slot", appendAssignment)); //$NON-NLS-1$
+		evidence.add(evidence(
+				Kind.ARRAY_GROWTH,
+				"Array capacity is increased by one element", //$NON-NLS-1$
+				seed.growthAssignment()));
+		evidence.add(evidence(
+				Kind.APPEND_WRITE,
+				"The immediately following write targets the new tail slot", //$NON-NLS-1$
+				appendAssignment));
 		if (seed.elementDomain() == ElementDomain.REFERENCE
 				|| seed.elementDomain() == ElementDomain.ENUM) {
-			evidence.add(evidence(Kind.REFERENCE_COMPONENT,
-					"The resolved array component is a reference type", seed.array())); //$NON-NLS-1$
+			evidence.add(evidence(
+					Kind.REFERENCE_COMPONENT,
+					"The resolved array component is a reference type", //$NON-NLS-1$
+					seed.array()));
 		} else {
-			evidence.add(evidence(Kind.UNRESOLVED_BINDING,
-					"The array component type still requires binding validation", seed.array())); //$NON-NLS-1$
+			evidence.add(evidence(
+					Kind.UNRESOLVED_BINDING,
+					"The array component type still requires binding validation", //$NON-NLS-1$
+					seed.array()));
 		}
 
 		ContainerIdentity identity= new ContainerIdentity(
 				seed.binding().map(value -> value.getVariableDeclaration().getKey()).orElse(""), //$NON-NLS-1$
-				seed.array().toString(), seed.array().getStartPosition(), seed.array().getLength());
+				seed.array().toString(),
+				seed.array().getStartPosition(),
+				seed.array().getLength());
 
 		return new ContainerUsageProfile(
 				identity,

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/internal/common/AstProcessing.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/internal/common/AstProcessing.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.common;
+
+import java.util.Objects;
+
+import org.eclipse.jdt.core.dom.ASTNode;
+
+/**
+ * Entry point for AST processing whose execution model is explicit at the call site.
+ *
+ * <p>{@link #scoped(ReferenceHolder)} creates a semantic pipeline in which every
+ * stage searches only the scope selected by the preceding stage. In contrast,
+ * {@link #independent(ReferenceHolder)} registers visitors that each inspect the
+ * complete root passed to {@code build(...)}.</p>
+ */
+public final class AstProcessing {
+
+	private AstProcessing() {
+		// Static factory.
+	}
+
+	/** Creates an ordered, scoped semantic processing pipeline. */
+	public static <V, T> ScopedAstProcessorBuilder<V, T> scoped(ReferenceHolder<V, T> holder) {
+		return new ScopedAstProcessorBuilder<>(Objects.requireNonNull(holder, "holder")); //$NON-NLS-1$
+	}
+
+	/** Creates a group of visitors that each inspect the complete configured root. */
+	public static <V, T> IndependentAstProcessorBuilder<V, T> independent(ReferenceHolder<V, T> holder) {
+		return new IndependentAstProcessorBuilder<>(Objects.requireNonNull(holder, "holder")); //$NON-NLS-1$
+	}
+
+	static VisitorEnum visitorType(Class<? extends ASTNode> nodeType) {
+		Objects.requireNonNull(nodeType, "nodeType"); //$NON-NLS-1$
+		try {
+			return VisitorEnum.valueOf(nodeType.getSimpleName());
+		} catch (IllegalArgumentException exception) {
+			throw new IllegalArgumentException(
+					"No HelperVisitor dispatch is available for " + nodeType.getName(), exception); //$NON-NLS-1$
+		}
+	}
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/internal/common/IndependentAstProcessorBuilder.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/internal/common/IndependentAstProcessorBuilder.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.common;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.BiPredicate;
+
+import org.eclipse.jdt.core.dom.ASTNode;
+
+/**
+ * Collects independent AST visitors that each inspect the complete root supplied to
+ * {@link #build(ASTNode)}.
+ *
+ * <p>Registration order is deterministic, but one visitor never narrows the scope of
+ * another. Use {@link AstProcessing#scoped(ReferenceHolder)} when later stages are
+ * semantically dependent on an earlier match.</p>
+ *
+ * @param <V> reference-holder key type
+ * @param <T> reference-holder value type
+ */
+public final class IndependentAstProcessorBuilder<V, T> {
+
+	private final ReferenceHolder<V, T> holder;
+	private final List<Stage<V, T>> stages= new ArrayList<>();
+	private Set<ASTNode> excludedNodes= Set.of();
+
+	IndependentAstProcessorBuilder(ReferenceHolder<V, T> holder) {
+		this.holder= holder;
+	}
+
+	/**
+	 * Registers one typed visitor that will inspect the complete build root.
+	 *
+	 * @param <N> AST node type
+	 * @param nodeType node class to visit
+	 * @param handler processing callback; its result controls child traversal
+	 * @return this builder
+	 */
+	public <N extends ASTNode> IndependentAstProcessorBuilder<V, T> on(
+			Class<N> nodeType,
+			BiPredicate<? super N, ReferenceHolder<V, T>> handler) {
+		Objects.requireNonNull(nodeType, "nodeType"); //$NON-NLS-1$
+		Objects.requireNonNull(handler, "handler"); //$NON-NLS-1$
+		VisitorEnum visitorType= AstProcessing.visitorType(nodeType);
+		stages.add(new Stage<>(visitorType,
+				(node, data) -> handler.test(nodeType.cast(node), data)));
+		return this;
+	}
+
+	/** Applies one shared exclusion set to every independent visitor traversal. */
+	public IndependentAstProcessorBuilder<V, T> excluding(Set<? extends ASTNode> nodes) {
+		excludedNodes= Set.copyOf(Objects.requireNonNull(nodes, "nodes")); //$NON-NLS-1$
+		return this;
+	}
+
+	/** Executes every registered visitor independently against {@code root}. */
+	public void build(ASTNode root) {
+		Objects.requireNonNull(root, "root"); //$NON-NLS-1$
+		for (Stage<V, T> stage : stages) {
+			HelperVisitor<ReferenceHolder<V, T>, V, T> visitor=
+					new HelperVisitor<>(new HashSet<>(excludedNodes), holder);
+			visitor.add(stage.visitorType(), stage.handler());
+			visitor.build(root);
+		}
+	}
+
+	private record Stage<V, T>(
+			VisitorEnum visitorType,
+			BiPredicate<ASTNode, ReferenceHolder<V, T>> handler) {
+	}
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/internal/common/ScopedAstProcessorBuilder.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/internal/common/ScopedAstProcessorBuilder.java
@@ -1,0 +1,257 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.common;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.eclipse.jdt.core.dom.ASTNode;
+
+/**
+ * Builds an ordered semantic AST pipeline.
+ *
+ * <p>Each successful stage selects the scope in which the next stage searches. A
+ * stage that finds no matching node ends that branch of the pipeline; later stages
+ * are never retried independently against an earlier scope.</p>
+ *
+ * <p>Matcher, handler, navigation and child traversal are separate concerns. The
+ * matcher decides whether the semantic chain advances and may inspect facts stored by
+ * preceding stages. The handler records facts. Navigation chooses the next search
+ * scope. {@link TraversalDecision} controls only whether the current visitor descends
+ * below the matched node.</p>
+ *
+ * @param <V> reference-holder key type
+ * @param <T> reference-holder value type
+ */
+public final class ScopedAstProcessorBuilder<V, T> {
+
+	/** Child-traversal decision for the visitor executing one matched stage. */
+	public enum TraversalDecision {
+		DESCEND,
+		SKIP_CHILDREN
+	}
+
+	private final ReferenceHolder<V, T> holder;
+	private final List<Stage<V, T>> stages= new ArrayList<>();
+	private Set<ASTNode> excludedNodes= Set.of();
+
+	ScopedAstProcessorBuilder(ReferenceHolder<V, T> holder) {
+		this.holder= holder;
+	}
+
+	/** Registers the first state-independent stage of the scoped pipeline. */
+	public <N extends ASTNode> ScopedAstProcessorBuilder<V, T> find(
+			Class<N> nodeType,
+			Predicate<? super N> matcher,
+			BiConsumer<? super N, ReferenceHolder<V, T>> handler,
+			Function<? super N, ? extends ASTNode> nextScope) {
+		Objects.requireNonNull(matcher, "matcher"); //$NON-NLS-1$
+		return find(nodeType, (node, state) -> matcher.test(node), handler, nextScope);
+	}
+
+	/** Registers the first state-aware stage of the scoped pipeline. */
+	public <N extends ASTNode> ScopedAstProcessorBuilder<V, T> find(
+			Class<N> nodeType,
+			BiPredicate<? super N, ReferenceHolder<V, T>> matcher,
+			BiConsumer<? super N, ReferenceHolder<V, T>> handler,
+			Function<? super N, ? extends ASTNode> nextScope) {
+		if (!stages.isEmpty()) {
+			throw new IllegalStateException("find(...) may only register the first stage"); //$NON-NLS-1$
+		}
+		return addStage(nodeType, matcher, consumerHandler(handler), nextScope);
+	}
+
+	/** Registers the first state-independent stage without additional navigation. */
+	public <N extends ASTNode> ScopedAstProcessorBuilder<V, T> find(
+			Class<N> nodeType,
+			Predicate<? super N> matcher,
+			BiConsumer<? super N, ReferenceHolder<V, T>> handler) {
+		return find(nodeType, matcher, handler, Function.identity());
+	}
+
+	/** Registers the first state-aware stage without additional navigation. */
+	public <N extends ASTNode> ScopedAstProcessorBuilder<V, T> find(
+			Class<N> nodeType,
+			BiPredicate<? super N, ReferenceHolder<V, T>> matcher,
+			BiConsumer<? super N, ReferenceHolder<V, T>> handler) {
+		return find(nodeType, matcher, handler, Function.identity());
+	}
+
+	/** Registers a state-independent dependent stage. */
+	public <N extends ASTNode> ScopedAstProcessorBuilder<V, T> then(
+			Class<N> nodeType,
+			Predicate<? super N> matcher,
+			BiConsumer<? super N, ReferenceHolder<V, T>> handler,
+			Function<? super N, ? extends ASTNode> nextScope) {
+		Objects.requireNonNull(matcher, "matcher"); //$NON-NLS-1$
+		return then(nodeType, (node, state) -> matcher.test(node), handler, nextScope);
+	}
+
+	/** Registers a state-aware dependent stage searched in the previous stage's scope. */
+	public <N extends ASTNode> ScopedAstProcessorBuilder<V, T> then(
+			Class<N> nodeType,
+			BiPredicate<? super N, ReferenceHolder<V, T>> matcher,
+			BiConsumer<? super N, ReferenceHolder<V, T>> handler,
+			Function<? super N, ? extends ASTNode> nextScope) {
+		requireFirstStage();
+		return addStage(nodeType, matcher, consumerHandler(handler), nextScope);
+	}
+
+	/** Registers a state-independent dependent terminal stage. */
+	public <N extends ASTNode> ScopedAstProcessorBuilder<V, T> then(
+			Class<N> nodeType,
+			Predicate<? super N> matcher,
+			BiConsumer<? super N, ReferenceHolder<V, T>> handler) {
+		return then(nodeType, matcher, handler, Function.identity());
+	}
+
+	/** Registers a state-aware dependent terminal stage. */
+	public <N extends ASTNode> ScopedAstProcessorBuilder<V, T> then(
+			Class<N> nodeType,
+			BiPredicate<? super N, ReferenceHolder<V, T>> matcher,
+			BiConsumer<? super N, ReferenceHolder<V, T>> handler) {
+		return then(nodeType, matcher, handler, Function.identity());
+	}
+
+	/** Registers the first state-independent stage with child-traversal control. */
+	public <N extends ASTNode> ScopedAstProcessorBuilder<V, T> findWithTraversal(
+			Class<N> nodeType,
+			Predicate<? super N> matcher,
+			BiFunction<? super N, ReferenceHolder<V, T>, TraversalDecision> handler,
+			Function<? super N, ? extends ASTNode> nextScope) {
+		Objects.requireNonNull(matcher, "matcher"); //$NON-NLS-1$
+		return findWithTraversal(nodeType, (node, state) -> matcher.test(node), handler, nextScope);
+	}
+
+	/** Registers the first state-aware stage with child-traversal control. */
+	public <N extends ASTNode> ScopedAstProcessorBuilder<V, T> findWithTraversal(
+			Class<N> nodeType,
+			BiPredicate<? super N, ReferenceHolder<V, T>> matcher,
+			BiFunction<? super N, ReferenceHolder<V, T>, TraversalDecision> handler,
+			Function<? super N, ? extends ASTNode> nextScope) {
+		if (!stages.isEmpty()) {
+			throw new IllegalStateException("findWithTraversal(...) may only register the first stage"); //$NON-NLS-1$
+		}
+		return addStage(nodeType, matcher, handler, nextScope);
+	}
+
+	/** Registers a state-independent dependent stage with traversal control. */
+	public <N extends ASTNode> ScopedAstProcessorBuilder<V, T> thenWithTraversal(
+			Class<N> nodeType,
+			Predicate<? super N> matcher,
+			BiFunction<? super N, ReferenceHolder<V, T>, TraversalDecision> handler,
+			Function<? super N, ? extends ASTNode> nextScope) {
+		Objects.requireNonNull(matcher, "matcher"); //$NON-NLS-1$
+		return thenWithTraversal(nodeType, (node, state) -> matcher.test(node), handler, nextScope);
+	}
+
+	/** Registers a state-aware dependent stage with traversal control. */
+	public <N extends ASTNode> ScopedAstProcessorBuilder<V, T> thenWithTraversal(
+			Class<N> nodeType,
+			BiPredicate<? super N, ReferenceHolder<V, T>> matcher,
+			BiFunction<? super N, ReferenceHolder<V, T>, TraversalDecision> handler,
+			Function<? super N, ? extends ASTNode> nextScope) {
+		requireFirstStage();
+		return addStage(nodeType, matcher, handler, nextScope);
+	}
+
+	/** Applies the same initial exclusion set to every stage traversal. */
+	public ScopedAstProcessorBuilder<V, T> excluding(Set<? extends ASTNode> nodes) {
+		excludedNodes= Set.copyOf(Objects.requireNonNull(nodes, "nodes")); //$NON-NLS-1$
+		return this;
+	}
+
+	/** Executes the scoped pipeline against {@code root}. */
+	public void build(ASTNode root) {
+		Objects.requireNonNull(root, "root"); //$NON-NLS-1$
+		if (stages.isEmpty()) {
+			throw new IllegalStateException("At least one scoped stage is required"); //$NON-NLS-1$
+		}
+		process(root, 0);
+	}
+
+	private void process(ASTNode scope, int stageIndex) {
+		if (scope == null || stageIndex >= stages.size()) {
+			return;
+		}
+
+		Stage<V, T> stage= stages.get(stageIndex);
+		HelperVisitor<ReferenceHolder<V, T>, V, T> visitor=
+				new HelperVisitor<>(new HashSet<>(excludedNodes), holder);
+		visitor.add(stage.visitorType(), (node, data) -> {
+			if (!stage.nodeType().isInstance(node) || !stage.matcher().test(node, data)) {
+				return true;
+			}
+
+			TraversalDecision traversal= stage.handler().apply(node, data);
+			if (stageIndex + 1 < stages.size()) {
+				ASTNode nextScope= stage.nextScope().apply(node);
+				if (nextScope != null) {
+					process(nextScope, stageIndex + 1);
+				}
+			}
+			return traversal == TraversalDecision.DESCEND;
+		});
+		visitor.build(scope);
+	}
+
+	private <N extends ASTNode> ScopedAstProcessorBuilder<V, T> addStage(
+			Class<N> nodeType,
+			BiPredicate<? super N, ReferenceHolder<V, T>> matcher,
+			BiFunction<? super N, ReferenceHolder<V, T>, TraversalDecision> handler,
+			Function<? super N, ? extends ASTNode> nextScope) {
+		Objects.requireNonNull(nodeType, "nodeType"); //$NON-NLS-1$
+		Objects.requireNonNull(matcher, "matcher"); //$NON-NLS-1$
+		Objects.requireNonNull(handler, "handler"); //$NON-NLS-1$
+		Objects.requireNonNull(nextScope, "nextScope"); //$NON-NLS-1$
+		VisitorEnum visitorType= AstProcessing.visitorType(nodeType);
+		stages.add(new Stage<>(
+				nodeType,
+				visitorType,
+				(node, state) -> matcher.test(nodeType.cast(node), state),
+				(node, data) -> Objects.requireNonNull(
+						handler.apply(nodeType.cast(node), data), "traversalDecision"), //$NON-NLS-1$
+				node -> nextScope.apply(nodeType.cast(node))));
+		return this;
+	}
+
+	private static <N extends ASTNode, V, T>
+			BiFunction<N, ReferenceHolder<V, T>, TraversalDecision> consumerHandler(
+					BiConsumer<? super N, ReferenceHolder<V, T>> handler) {
+		Objects.requireNonNull(handler, "handler"); //$NON-NLS-1$
+		return (node, holder) -> {
+			handler.accept(node, holder);
+			return TraversalDecision.DESCEND;
+		};
+	}
+
+	private void requireFirstStage() {
+		if (stages.isEmpty()) {
+			throw new IllegalStateException("then(...) requires a preceding find(...) stage"); //$NON-NLS-1$
+		}
+	}
+
+	private record Stage<V, T>(
+			Class<? extends ASTNode> nodeType,
+			VisitorEnum visitorType,
+			BiPredicate<ASTNode, ReferenceHolder<V, T>> matcher,
+			BiFunction<ASTNode, ReferenceHolder<V, T>, TraversalDecision> handler,
+			Function<ASTNode, ? extends ASTNode> nextScope) {
+	}
+}

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/internal/common/ExplicitAstProcessingTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/internal/common/ExplicitAstProcessingTest.java
@@ -1,0 +1,262 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.ArrayAccess;
+import org.eclipse.jdt.core.dom.Assignment;
+import org.eclipse.jdt.core.dom.Block;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.FieldDeclaration;
+import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.Statement;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.junit.jupiter.api.Test;
+
+class ExplicitAstProcessingTest {
+
+	@Test
+	void scopedPipelineNavigatesFromInvocationToFollowingArrayAccess() {
+		CompilationUnit unit= parse("""
+			import java.util.Arrays;
+			class Sample {
+				void append(String value) {
+					String[] values = new String[0];
+					values = Arrays.copyOf(values, values.length + 1);
+					values[values.length - 1] = value;
+				}
+			}
+			""");
+		AtomicInteger matches= new AtomicInteger();
+
+		AstProcessing.scoped(ReferenceHolder.<String, Object>create())
+				.find(MethodInvocation.class,
+						invocation -> "copyOf".equals(invocation.getName().getIdentifier()), //$NON-NLS-1$
+						(invocation, holder) -> holder.put("growth", invocation), //$NON-NLS-1$
+						ExplicitAstProcessingTest::followingStatement)
+				.then(ArrayAccess.class,
+						access -> true,
+						(access, holder) -> matches.incrementAndGet())
+				.build(unit);
+
+		assertEquals(1, matches.get());
+	}
+
+	@Test
+	void scopedPipelineAllowsRepeatedNodeTypes() {
+		CompilationUnit unit= parse("""
+			class Sample {
+				void update(int first, int second) {
+					int a;
+					int b;
+					a = first;
+					b = second;
+				}
+			}
+			""");
+		AtomicInteger matches= new AtomicInteger();
+
+		AstProcessing.scoped(ReferenceHolder.<String, Object>create())
+				.find(Assignment.class,
+						assignment -> hasLeftHandName(assignment, "a"), //$NON-NLS-1$
+						(assignment, holder) -> { },
+						ExplicitAstProcessingTest::followingStatement)
+				.then(Assignment.class,
+						assignment -> hasLeftHandName(assignment, "b"), //$NON-NLS-1$
+						(assignment, holder) -> matches.incrementAndGet())
+				.build(unit);
+
+		assertEquals(1, matches.get());
+	}
+
+	@Test
+	void failedScopedMatcherDoesNotAdvance() {
+		CompilationUnit unit= parse("""
+			class Sample {
+				void run() {
+					int a;
+					int b;
+					a = 1;
+					b = 2;
+				}
+			}
+			""");
+		AtomicInteger laterStageCalls= new AtomicInteger();
+
+		AstProcessing.scoped(ReferenceHolder.<String, Object>create())
+				.find(Assignment.class,
+						assignment -> false,
+						(assignment, holder) -> { },
+						ExplicitAstProcessingTest::followingStatement)
+				.then(Assignment.class,
+						assignment -> true,
+						(assignment, holder) -> laterStageCalls.incrementAndGet())
+				.build(unit);
+
+		assertEquals(0, laterStageCalls.get());
+	}
+
+	@Test
+	void nullNavigationEndsOnlyThatScopedBranch() {
+		CompilationUnit unit= parse("""
+			class Sample {
+				void run() {
+					int a;
+					a = 1;
+				}
+			}
+			""");
+		AtomicInteger laterStageCalls= new AtomicInteger();
+
+		AstProcessing.scoped(ReferenceHolder.<String, Object>create())
+				.find(Assignment.class,
+						assignment -> true,
+						(assignment, holder) -> { },
+						assignment -> null)
+				.then(Assignment.class,
+						assignment -> true,
+						(assignment, holder) -> laterStageCalls.incrementAndGet())
+				.build(unit);
+
+		assertEquals(0, laterStageCalls.get());
+	}
+
+	@Test
+	void everyFirstStageMatchGetsItsOwnScopedContinuation() {
+		CompilationUnit unit= parse("""
+			import java.util.Arrays;
+			class Sample {
+				void appendFirst(String value) {
+					String[] first = new String[0];
+					first = Arrays.copyOf(first, first.length + 1);
+					first[first.length - 1] = value;
+				}
+				void appendSecond(String value) {
+					String[] second = new String[0];
+					second = Arrays.copyOf(second, second.length + 1);
+					second[second.length - 1] = value;
+				}
+			}
+			""");
+		AtomicInteger continuations= new AtomicInteger();
+
+		AstProcessing.scoped(ReferenceHolder.<String, Object>create())
+				.find(MethodInvocation.class,
+						invocation -> "copyOf".equals(invocation.getName().getIdentifier()), //$NON-NLS-1$
+						(invocation, holder) -> { },
+						ExplicitAstProcessingTest::followingStatement)
+				.then(ArrayAccess.class,
+						access -> true,
+						(access, holder) -> continuations.incrementAndGet())
+				.build(unit);
+
+		assertEquals(2, continuations.get());
+	}
+
+	@Test
+	void independentVisitorsEachInspectTheCompleteRoot() {
+		CompilationUnit unit= parse("""
+			class Sample {
+				int first;
+				int second;
+			}
+			""");
+		AtomicInteger types= new AtomicInteger();
+		AtomicInteger fields= new AtomicInteger();
+
+		AstProcessing.independent(ReferenceHolder.<String, Object>create())
+				.on(TypeDeclaration.class, (type, holder) -> {
+					types.incrementAndGet();
+					return true;
+				})
+				.on(FieldDeclaration.class, (field, holder) -> {
+					fields.incrementAndGet();
+					return true;
+				})
+				.build(unit);
+
+		assertEquals(1, types.get());
+		assertEquals(2, fields.get());
+	}
+
+	@Test
+	void independentVisitorsAllowRepeatedNodeTypes() {
+		CompilationUnit unit= parse("""
+			class Sample {
+				void run() {
+					System.out.println("one");
+					System.out.println("two");
+				}
+			}
+			""");
+		AtomicInteger firstVisitor= new AtomicInteger();
+		AtomicInteger secondVisitor= new AtomicInteger();
+
+		AstProcessing.independent(ReferenceHolder.<String, Object>create())
+				.on(MethodInvocation.class, (invocation, holder) -> {
+					firstVisitor.incrementAndGet();
+					return true;
+				})
+				.on(MethodInvocation.class, (invocation, holder) -> {
+					secondVisitor.incrementAndGet();
+					return true;
+				})
+				.build(unit);
+
+		assertEquals(2, firstVisitor.get());
+		assertEquals(2, secondVisitor.get());
+	}
+
+	private static boolean hasLeftHandName(Assignment assignment, String expectedName) {
+		return assignment.getLeftHandSide() instanceof SimpleName name
+				&& expectedName.equals(name.getIdentifier());
+	}
+
+	private static ASTNode followingStatement(ASTNode node) {
+		Statement statement= containingStatement(node);
+		if (statement == null || !(statement.getParent() instanceof Block block)) {
+			return null;
+		}
+		List<?> statements= block.statements();
+		int index= statements.indexOf(statement);
+		return index >= 0 && index + 1 < statements.size()
+				? (ASTNode) statements.get(index + 1)
+				: null;
+	}
+
+	private static Statement containingStatement(ASTNode node) {
+		ASTNode current= node;
+		while (current != null && !(current instanceof Statement)) {
+			current= current.getParent();
+		}
+		return (Statement) current;
+	}
+
+	private static CompilationUnit parse(String source) {
+		ASTParser parser= ASTParser.newParser(AST.getJLSLatest());
+		parser.setSource(source.toCharArray());
+		parser.setKind(ASTParser.K_COMPILATION_UNIT);
+		parser.setResolveBindings(true);
+		parser.setBindingsRecovery(true);
+		parser.setStatementsRecovery(true);
+		parser.setUnitName("Sample.java"); //$NON-NLS-1$
+		parser.setEnvironment(new String[0], new String[0], new String[0], true);
+		return (CompilationUnit) parser.createAST(null);
+	}
+}

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/internal/common/ScopedAstProcessingSemanticsTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/internal/common/ScopedAstProcessingSemanticsTest.java
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.sandbox.jdt.internal.common.ScopedAstProcessorBuilder.TraversalDecision.SKIP_CHILDREN;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.Assignment;
+import org.eclipse.jdt.core.dom.Block;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.Statement;
+import org.junit.jupiter.api.Test;
+
+class ScopedAstProcessingSemanticsTest {
+
+	@Test
+	void childTraversalDecisionDoesNotControlPipelineAdvancement() {
+		CompilationUnit unit= parseAssignments();
+		AtomicInteger laterStageCalls= new AtomicInteger();
+
+		AstProcessing.scoped(ReferenceHolder.<String, Object>create())
+				.findWithTraversal(Assignment.class,
+						assignment -> hasLeftHandName(assignment, "a"), //$NON-NLS-1$
+						(assignment, holder) -> SKIP_CHILDREN,
+						ScopedAstProcessingSemanticsTest::followingStatement)
+				.then(Assignment.class,
+						assignment -> hasLeftHandName(assignment, "b"), //$NON-NLS-1$
+						(assignment, holder) -> laterStageCalls.incrementAndGet())
+				.build(unit);
+
+		assertEquals(1, laterStageCalls.get());
+	}
+
+	@Test
+	void laterMatcherCanReadFactsFromEarlierStage() {
+		CompilationUnit unit= parseAssignments();
+		ReferenceHolder<String, Object> state= ReferenceHolder.create();
+		AtomicInteger matches= new AtomicInteger();
+
+		AstProcessing.scoped(state)
+				.find(Assignment.class,
+						assignment -> hasLeftHandName(assignment, "a"), //$NON-NLS-1$
+						(assignment, holder) -> holder.put("nextName", "b"), //$NON-NLS-1$ //$NON-NLS-2$
+						ScopedAstProcessingSemanticsTest::followingStatement)
+				.then(Assignment.class,
+						(assignment, holder) -> hasLeftHandName(
+								assignment, (String) holder.get("nextName")), //$NON-NLS-1$
+						(assignment, holder) -> matches.incrementAndGet())
+				.build(unit);
+
+		assertEquals(1, matches.get());
+	}
+
+	private static CompilationUnit parseAssignments() {
+		return parse("""
+			class Sample {
+				void update(int first, int second) {
+					int a;
+					int b;
+					a = first;
+					b = second;
+				}
+			}
+			""");
+	}
+
+	private static boolean hasLeftHandName(Assignment assignment, String expectedName) {
+		return assignment.getLeftHandSide() instanceof SimpleName name
+				&& expectedName.equals(name.getIdentifier());
+	}
+
+	private static ASTNode followingStatement(ASTNode node) {
+		Statement statement= containingStatement(node);
+		if (statement == null || !(statement.getParent() instanceof Block block)) {
+			return null;
+		}
+		List<?> statements= block.statements();
+		int index= statements.indexOf(statement);
+		return index >= 0 && index + 1 < statements.size()
+				? (ASTNode) statements.get(index + 1)
+				: null;
+	}
+
+	private static Statement containingStatement(ASTNode node) {
+		ASTNode current= node;
+		while (current != null && !(current instanceof Statement)) {
+			current= current.getParent();
+		}
+		return (Statement) current;
+	}
+
+	private static CompilationUnit parse(String source) {
+		ASTParser parser= ASTParser.newParser(AST.getJLSLatest());
+		parser.setSource(source.toCharArray());
+		parser.setKind(ASTParser.K_COMPILATION_UNIT);
+		parser.setResolveBindings(true);
+		parser.setBindingsRecovery(true);
+		parser.setStatementsRecovery(true);
+		parser.setUnitName("Sample.java"); //$NON-NLS-1$
+		parser.setEnvironment(new String[0], new String[0], new String[0], true);
+		return (CompilationUnit) parser.createAST(null);
+	}
+}


### PR DESCRIPTION
## Summary

Implements the first compatibility-safe slice of #1384 on top of merged PR #1383.

- adds `AstProcessing.scoped(...)` for ordered semantic pipelines;
- adds `AstProcessing.independent(...)` for visitors that each inspect the complete root;
- stores pipeline stages in order, allowing repeated AST node types;
- separates semantic matching, fact collection, navigation and child traversal;
- ends a scoped branch when a stage finds no match or navigation returns no scope;
- lets later matchers read facts placed in the shared `ReferenceHolder` by earlier stages;
- keeps the existing `ASTProcessor` and `AstProcessorBuilder` unchanged for compatibility;
- migrates `AppendOnlyArraySeedDetector` away from the mixed builder/`processor()` API.

## Example

```java
AstProcessing.scoped(state)
    .find(MethodInvocation.class,
        this::isGrowth,
        this::rememberGrowth,
        this::followingStatement)
    .then(ArrayAccess.class,
        this::isTailWrite,
        this::recordCandidate)
    .build(compilationUnit);
```

Independent visitors use a visibly different entry point:

```java
AstProcessing.independent(holder)
    .on(TypeDeclaration.class, this::inspectType)
    .on(FieldDeclaration.class, this::inspectField)
    .build(compilationUnit);
```

## Tests

Covers:

- invocation → following statement → array access;
- repeated `Assignment` stages;
- no advancement after a failed matcher;
- null navigation ending one branch;
- isolated continuation for every first-stage match;
- independent full-root visitors;
- repeated node types in independent mode;
- matcher access to prior-stage facts;
- separation of child traversal from pipeline advancement.

## Branch hygiene

After #1383 was squash-merged, this branch was rebuilt directly on current `main`. The PR now contains exactly the six files belonging to this API slice.

Refs #1384