### PR TITLE
Classify local array usage by binding

### DIFF
--- a/sandbox_common_core/bnd.bnd
+++ b/sandbox_common_core/bnd.bnd
@@ -4,6 +4,8 @@ Bundle-Name: Sandbox Common Core
 Bundle-Vendor: Carsten Hammer
 
 Export-Package: org.sandbox.jdt.cleanup.multifile.api,\
+ org.sandbox.jdt.container.api,\
+ org.sandbox.jdt.container.analysis,\
  org.sandbox.jdt.internal.common,\
  org.sandbox.jdt.triggerpattern.api,\
  org.sandbox.jdt.triggerpattern.internal,\

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/AppendOnlyArraySeedDetector.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/AppendOnlyArraySeedDetector.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.sandbox.jdt.container.analysis;
 
-import static org.sandbox.jdt.container.analysis.ContainerAstFacts.assignment;
 import static org.sandbox.jdt.container.analysis.ContainerAstFacts.expressionStatement;
 import static org.sandbox.jdt.container.analysis.ContainerAstFacts.isArrayLength;
 import static org.sandbox.jdt.container.analysis.ContainerAstFacts.isOne;
@@ -20,8 +19,9 @@ import static org.sandbox.jdt.container.analysis.ContainerAstFacts.unwrap;
 import static org.sandbox.jdt.container.analysis.ContainerAstFacts.variableBinding;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -31,11 +31,12 @@ import org.eclipse.jdt.core.dom.Assignment;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.ExpressionStatement;
-import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.IVariableBinding;
 import org.eclipse.jdt.core.dom.InfixExpression;
 import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.ParenthesizedExpression;
+import org.eclipse.jdt.core.dom.Statement;
 import org.sandbox.jdt.container.api.ContainerShape;
 import org.sandbox.jdt.container.api.ContainerUsageProfile;
 import org.sandbox.jdt.container.api.ContainerUsageProfile.AliasingContract;
@@ -50,12 +51,16 @@ import org.sandbox.jdt.container.api.ContainerUsageProfile.OrderRequirement;
 import org.sandbox.jdt.container.api.ContainerUsageProfile.UniquenessRequirement;
 import org.sandbox.jdt.container.api.UsageEvidence;
 import org.sandbox.jdt.container.api.UsageEvidence.Kind;
-import org.sandbox.jdt.internal.common.AstProcessorBuilder;
+import org.sandbox.jdt.internal.common.ASTProcessor;
 import org.sandbox.jdt.internal.common.ReferenceHolder;
 
 /**
  * Finds local seeds where a reference array is grown by one element and the new tail
  * slot is assigned immediately afterwards.
+ *
+ * <p>The implementation uses the scoped {@link ASTProcessor} chain deliberately:
+ * after a matching {@link Arrays#copyOf(Object[], int)} invocation, the next stage
+ * searches only the immediately following statement for the corresponding tail write.</p>
  *
  * <p>This detector deliberately stops at {@link AnalysisCompleteness#LOCAL_SEED}.
  * It does not claim that all array uses are append-only, that aliases do not escape or
@@ -63,6 +68,8 @@ import org.sandbox.jdt.internal.common.ReferenceHolder;
  * usage and multi-file planning stages.</p>
  */
 public final class AppendOnlyArraySeedDetector {
+
+	private static final int CURRENT_GROWTH= 0;
 
 	/**
 	 * Finds deterministic, source-ordered append-only array seeds.
@@ -72,44 +79,46 @@ public final class AppendOnlyArraySeedDetector {
 	 */
 	public List<ContainerUsageProfile> findSeeds(CompilationUnit compilationUnit) {
 		Objects.requireNonNull(compilationUnit, "compilationUnit"); //$NON-NLS-1$
-		ReferenceHolder<Integer, ContainerUsageProfile> profiles= ReferenceHolder.createIndexed();
 
-		AstProcessorBuilder.with(profiles)
-				.onAssignment((candidate, holder) -> {
-					detectSeed(candidate).ifPresent(profile ->
-						holder.put(profile.identity().sourceStart(), profile));
-					return true;
-				})
+		List<ContainerUsageProfile> profiles= new ArrayList<>();
+		ReferenceHolder<Integer, GrowthSeed> state= ReferenceHolder.createIndexed();
+		ASTProcessor<ReferenceHolder<Integer, GrowthSeed>, Integer, GrowthSeed> processor=
+				new ASTProcessor<>(state, new HashSet<>());
+
+		processor
+				.callMethodInvocationVisitor(Arrays.class, "copyOf", //$NON-NLS-1$
+						AppendOnlyArraySeedDetector::rememberGrowth,
+						AppendOnlyArraySeedDetector::followingStatementScope)
+				.callArrayAccessVisitor((node, holder) ->
+						collectTailWrite((ArrayAccess) node, holder, profiles))
 				.build(compilationUnit);
 
-		return profiles.entrySet().stream()
-				.sorted(Map.Entry.comparingByKey())
-				.map(Map.Entry::getValue)
-				.toList();
+		return List.copyOf(profiles);
 	}
 
-	private Optional<ContainerUsageProfile> detectSeed(Assignment growthAssignment) {
-		if (growthAssignment.getOperator() != Assignment.Operator.ASSIGN) {
+	private static boolean rememberGrowth(MethodInvocation copyOf,
+			ReferenceHolder<Integer, GrowthSeed> state) {
+		state.remove(CURRENT_GROWTH);
+		growthSeed(copyOf).ifPresent(seed -> state.put(CURRENT_GROWTH, seed));
+		return false;
+	}
+
+	private static Optional<GrowthSeed> growthSeed(MethodInvocation copyOf) {
+		if (copyOf.arguments().size() != 2) {
+			return Optional.empty();
+		}
+
+		Assignment growthAssignment= enclosingAssignment(copyOf);
+		if (growthAssignment == null
+				|| growthAssignment.getOperator() != Assignment.Operator.ASSIGN
+				|| unwrap(growthAssignment.getRightHandSide()) != copyOf) {
 			return Optional.empty();
 		}
 
 		Expression array= unwrap(growthAssignment.getLeftHandSide());
-		MethodInvocation copyOf= methodInvocation(growthAssignment.getRightHandSide());
-		if (copyOf == null || !isArraysCopyOf(copyOf) || copyOf.arguments().size() != 2) {
-			return Optional.empty();
-		}
-
 		Expression sourceArray= (Expression) copyOf.arguments().get(0);
 		Expression requestedLength= (Expression) copyOf.arguments().get(1);
 		if (!sameVariable(array, sourceArray) || !isLengthPlusOne(requestedLength, array)) {
-			return Optional.empty();
-		}
-
-		ExpressionStatement growthStatement= expressionStatement(growthAssignment);
-		Assignment appendAssignment= growthStatement == null
-				? null
-				: assignment(nextStatement(growthStatement));
-		if (!isTailWrite(appendAssignment, array)) {
 			return Optional.empty();
 		}
 
@@ -121,27 +130,61 @@ public final class AppendOnlyArraySeedDetector {
 			return Optional.empty();
 		}
 
+		return Optional.of(new GrowthSeed(array, growthAssignment, binding, elementDomain));
+	}
+
+	private static ASTNode followingStatementScope(ASTNode node) {
+		MethodInvocation copyOf= (MethodInvocation) node;
+		Assignment assignment= enclosingAssignment(copyOf);
+		ExpressionStatement statement= assignment == null ? null : expressionStatement(assignment);
+		Statement next= statement == null ? null : nextStatement(statement);
+		return next != null ? next : copyOf;
+	}
+
+	private static boolean collectTailWrite(ArrayAccess arrayAccess,
+			ReferenceHolder<Integer, GrowthSeed> state,
+			List<ContainerUsageProfile> profiles) {
+		GrowthSeed seed= state.get(CURRENT_GROWTH);
+		if (seed == null) {
+			return true;
+		}
+
+		Assignment appendAssignment= enclosingAssignment(arrayAccess);
+		if (appendAssignment == null
+				|| unwrap(appendAssignment.getLeftHandSide()) != arrayAccess
+				|| !sameVariable(seed.array(), arrayAccess.getArray())
+				|| !isLengthMinusOne(arrayAccess.getIndex(), seed.array())) {
+			return true;
+		}
+
+		profiles.add(createProfile(seed, appendAssignment));
+		state.remove(CURRENT_GROWTH);
+		return false;
+	}
+
+	private static ContainerUsageProfile createProfile(GrowthSeed seed, Assignment appendAssignment) {
 		List<UsageEvidence> evidence= new ArrayList<>();
 		evidence.add(evidence(Kind.ARRAY_GROWTH,
-				"Array capacity is increased by one element", growthAssignment)); //$NON-NLS-1$
+				"Array capacity is increased by one element", seed.growthAssignment())); //$NON-NLS-1$
 		evidence.add(evidence(Kind.APPEND_WRITE,
 				"The immediately following write targets the new tail slot", appendAssignment)); //$NON-NLS-1$
-		if (elementDomain == ElementDomain.REFERENCE || elementDomain == ElementDomain.ENUM) {
+		if (seed.elementDomain() == ElementDomain.REFERENCE
+				|| seed.elementDomain() == ElementDomain.ENUM) {
 			evidence.add(evidence(Kind.REFERENCE_COMPONENT,
-					"The resolved array component is a reference type", array)); //$NON-NLS-1$
+					"The resolved array component is a reference type", seed.array())); //$NON-NLS-1$
 		} else {
 			evidence.add(evidence(Kind.UNRESOLVED_BINDING,
-					"The array component type still requires binding validation", array)); //$NON-NLS-1$
+					"The array component type still requires binding validation", seed.array())); //$NON-NLS-1$
 		}
 
 		ContainerIdentity identity= new ContainerIdentity(
-				binding.map(value -> value.getVariableDeclaration().getKey()).orElse(""), //$NON-NLS-1$
-				array.toString(), array.getStartPosition(), array.getLength());
+				seed.binding().map(value -> value.getVariableDeclaration().getKey()).orElse(""), //$NON-NLS-1$
+				seed.array().toString(), seed.array().getStartPosition(), seed.array().getLength());
 
-		return Optional.of(new ContainerUsageProfile(
+		return new ContainerUsageProfile(
 				identity,
 				ContainerShape.ARRAY,
-				elementDomain,
+				seed.elementDomain(),
 				ContainerUsageProfile.AccessProfile.appendOnlyArraySeed(),
 				OrderRequirement.UNKNOWN,
 				UniquenessRequirement.UNKNOWN,
@@ -151,7 +194,15 @@ public final class AppendOnlyArraySeedDetector {
 				EscapeLevel.UNKNOWN,
 				ConcurrencyProfile.unknown(),
 				AnalysisCompleteness.LOCAL_SEED,
-				evidence));
+				evidence);
+	}
+
+	private static Assignment enclosingAssignment(ASTNode node) {
+		ASTNode current= node;
+		while (current.getParent() instanceof ParenthesizedExpression) {
+			current= current.getParent();
+		}
+		return current.getParent() instanceof Assignment assignment ? assignment : null;
 	}
 
 	private static UsageEvidence evidence(Kind kind, String summary, ASTNode node) {
@@ -159,10 +210,7 @@ public final class AppendOnlyArraySeedDetector {
 	}
 
 	private static ElementDomain elementDomain(ITypeBinding arrayType) {
-		if (arrayType == null) {
-			return ElementDomain.UNKNOWN;
-		}
-		if (!arrayType.isArray()) {
+		if (arrayType == null || !arrayType.isArray()) {
 			return ElementDomain.UNKNOWN;
 		}
 		ITypeBinding componentType= arrayType.getComponentType();
@@ -173,41 +221,6 @@ public final class AppendOnlyArraySeedDetector {
 			return ElementDomain.PRIMITIVE;
 		}
 		return componentType.isEnum() ? ElementDomain.ENUM : ElementDomain.REFERENCE;
-	}
-
-	private static boolean isTailWrite(Assignment appendAssignment, Expression array) {
-		if (appendAssignment == null || appendAssignment.getOperator() != Assignment.Operator.ASSIGN) {
-			return false;
-		}
-		Expression leftHandSide= unwrap(appendAssignment.getLeftHandSide());
-		if (!(leftHandSide instanceof ArrayAccess arrayAccess)) {
-			return false;
-		}
-		return sameVariable(array, arrayAccess.getArray())
-				&& isLengthMinusOne(arrayAccess.getIndex(), array);
-	}
-
-	private static MethodInvocation methodInvocation(Expression expression) {
-		Expression unwrapped= unwrap(expression);
-		return unwrapped instanceof MethodInvocation invocation ? invocation : null;
-	}
-
-	private static boolean isArraysCopyOf(MethodInvocation invocation) {
-		if (!"copyOf".equals(invocation.getName().getIdentifier())) { //$NON-NLS-1$
-			return false;
-		}
-
-		IMethodBinding binding= invocation.resolveMethodBinding();
-		if (binding != null && binding.getDeclaringClass() != null) {
-			return "java.util.Arrays".equals(binding.getDeclaringClass().getErasure().getQualifiedName()); //$NON-NLS-1$
-		}
-
-		Expression expression= invocation.getExpression();
-		if (expression == null) {
-			return false;
-		}
-		String owner= expression.toString();
-		return "Arrays".equals(owner) || "java.util.Arrays".equals(owner); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
 	private static boolean isLengthPlusOne(Expression expression, Expression array) {
@@ -229,5 +242,19 @@ public final class AppendOnlyArraySeedDetector {
 			return false;
 		}
 		return isArrayLength(infix.getLeftOperand(), array) && isOne(infix.getRightOperand());
+	}
+
+	private record GrowthSeed(
+			Expression array,
+			Assignment growthAssignment,
+			Optional<IVariableBinding> binding,
+			ElementDomain elementDomain) {
+
+		private GrowthSeed {
+			Objects.requireNonNull(array, "array"); //$NON-NLS-1$
+			Objects.requireNonNull(growthAssignment, "growthAssignment"); //$NON-NLS-1$
+			Objects.requireNonNull(binding, "binding"); //$NON-NLS-1$
+			Objects.requireNonNull(elementDomain, "elementDomain"); //$NON-NLS-1$
+		}
 	}
 }

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/AppendOnlyArraySeedDetector.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/AppendOnlyArraySeedDetector.java
@@ -1,0 +1,315 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.container.analysis;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.jdt.core.dom.ASTMatcher;
+import org.eclipse.jdt.core.dom.Assignment;
+import org.eclipse.jdt.core.dom.Block;
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.ExpressionStatement;
+import org.eclipse.jdt.core.dom.FieldAccess;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.IVariableBinding;
+import org.eclipse.jdt.core.dom.InfixExpression;
+import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.NumberLiteral;
+import org.eclipse.jdt.core.dom.ParenthesizedExpression;
+import org.eclipse.jdt.core.dom.QualifiedName;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.Statement;
+import org.eclipse.jdt.core.dom.SuperFieldAccess;
+import org.eclipse.jdt.core.dom.ArrayAccess;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.sandbox.jdt.container.api.ContainerShape;
+import org.sandbox.jdt.container.api.ContainerUsageProfile;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.AliasingContract;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.AnalysisCompleteness;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.ConcurrencyContract;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.ContainerIdentity;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.ElementDomain;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.EscapeLevel;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.MutationLifecycle;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.NullContract;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.OrderRequirement;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.UniquenessRequirement;
+import org.sandbox.jdt.container.api.UsageEvidence;
+import org.sandbox.jdt.container.api.UsageEvidence.Kind;
+import org.sandbox.jdt.internal.common.AstProcessorBuilder;
+import org.sandbox.jdt.internal.common.ReferenceHolder;
+
+/**
+ * Finds local seeds where a reference array is grown by one element and the new tail
+ * slot is assigned immediately afterwards.
+ *
+ * <p>This detector deliberately stops at {@link AnalysisCompleteness#LOCAL_SEED}.
+ * It does not claim that all array uses are append-only, that aliases do not escape or
+ * that method signatures may already be migrated. Those proofs belong to the later
+ * usage and multi-file planning stages.</p>
+ */
+public final class AppendOnlyArraySeedDetector {
+
+	/**
+	 * Finds deterministic, source-ordered append-only array seeds.
+	 *
+	 * @param compilationUnit compilation unit to inspect
+	 * @return immutable list of local usage profiles
+	 */
+	public List<ContainerUsageProfile> findSeeds(CompilationUnit compilationUnit) {
+		Objects.requireNonNull(compilationUnit, "compilationUnit"); //$NON-NLS-1$
+		ReferenceHolder<Integer, ContainerUsageProfile> profiles= ReferenceHolder.createIndexed();
+
+		AstProcessorBuilder.with(profiles)
+				.onAssignment((assignment, holder) -> {
+					detectSeed(assignment).ifPresent(profile ->
+						holder.put(profile.identity().sourceStart(), profile));
+					return true;
+				})
+				.build(compilationUnit);
+
+		return profiles.entrySet().stream()
+				.sorted(Map.Entry.comparingByKey())
+				.map(Map.Entry::getValue)
+				.toList();
+	}
+
+	private Optional<ContainerUsageProfile> detectSeed(Assignment growthAssignment) {
+		if (growthAssignment.getOperator() != Assignment.Operator.ASSIGN) {
+			return Optional.empty();
+		}
+
+		Expression array= unwrap(growthAssignment.getLeftHandSide());
+		MethodInvocation copyOf= asMethodInvocation(growthAssignment.getRightHandSide());
+		if (copyOf == null || !isArraysCopyOf(copyOf) || copyOf.arguments().size() != 2) {
+			return Optional.empty();
+		}
+
+		Expression sourceArray= (Expression) copyOf.arguments().get(0);
+		Expression requestedLength= (Expression) copyOf.arguments().get(1);
+		if (!sameVariable(array, sourceArray) || !isLengthPlusOne(requestedLength, array)) {
+			return Optional.empty();
+		}
+
+		ExpressionStatement growthStatement= asExpressionStatement(growthAssignment);
+		Assignment appendAssignment= growthStatement == null
+				? null
+				: asAssignment(nextStatement(growthStatement));
+		if (!isTailWrite(appendAssignment, array)) {
+			return Optional.empty();
+		}
+
+		Optional<IVariableBinding> variableBinding= resolveVariableBinding(array);
+		ITypeBinding arrayType= variableBinding.map(IVariableBinding::getType)
+				.orElseGet(array::resolveTypeBinding);
+		ElementDomain elementDomain= elementDomain(arrayType);
+		if (elementDomain == ElementDomain.PRIMITIVE) {
+			return Optional.empty();
+		}
+
+		List<UsageEvidence> evidence= new ArrayList<>();
+		evidence.add(evidence(Kind.ARRAY_GROWTH,
+				"Array capacity is increased by one element", growthAssignment)); //$NON-NLS-1$
+		evidence.add(evidence(Kind.APPEND_WRITE,
+				"The immediately following write targets the new tail slot", appendAssignment)); //$NON-NLS-1$
+		if (elementDomain == ElementDomain.REFERENCE || elementDomain == ElementDomain.ENUM) {
+			evidence.add(evidence(Kind.REFERENCE_COMPONENT,
+					"The resolved array component is a reference type", array)); //$NON-NLS-1$
+		} else {
+			evidence.add(evidence(Kind.UNRESOLVED_BINDING,
+					"The array component type still requires binding validation", array)); //$NON-NLS-1$
+		}
+
+		ContainerIdentity identity= new ContainerIdentity(
+				variableBinding.map(binding -> binding.getVariableDeclaration().getKey()).orElse(""), //$NON-NLS-1$
+				array.toString(), array.getStartPosition(), array.getLength());
+
+		return Optional.of(new ContainerUsageProfile(
+				identity,
+				ContainerShape.ARRAY,
+				elementDomain,
+				ContainerUsageProfile.AccessProfile.appendOnlyArraySeed(),
+				OrderRequirement.UNKNOWN,
+				UniquenessRequirement.UNKNOWN,
+				MutationLifecycle.UNKNOWN,
+				NullContract.UNKNOWN,
+				AliasingContract.UNKNOWN,
+				EscapeLevel.UNKNOWN,
+				ConcurrencyContract.UNKNOWN,
+				AnalysisCompleteness.LOCAL_SEED,
+				evidence));
+	}
+
+	private static UsageEvidence evidence(Kind kind, String summary, org.eclipse.jdt.core.dom.ASTNode node) {
+		return new UsageEvidence(kind, summary, node.getStartPosition(), node.getLength());
+	}
+
+	private static ElementDomain elementDomain(ITypeBinding arrayType) {
+		if (arrayType == null) {
+			return ElementDomain.UNKNOWN;
+		}
+		if (!arrayType.isArray()) {
+			return ElementDomain.PRIMITIVE;
+		}
+		ITypeBinding componentType= arrayType.getComponentType();
+		if (componentType == null) {
+			return ElementDomain.UNKNOWN;
+		}
+		if (componentType.isPrimitive()) {
+			return ElementDomain.PRIMITIVE;
+		}
+		return componentType.isEnum() ? ElementDomain.ENUM : ElementDomain.REFERENCE;
+	}
+
+	private static boolean isTailWrite(Assignment assignment, Expression array) {
+		if (assignment == null || assignment.getOperator() != Assignment.Operator.ASSIGN) {
+			return false;
+		}
+		Expression leftHandSide= unwrap(assignment.getLeftHandSide());
+		if (!(leftHandSide instanceof ArrayAccess arrayAccess)) {
+			return false;
+		}
+		return sameVariable(array, arrayAccess.getArray())
+				&& isLengthMinusOne(arrayAccess.getIndex(), array);
+	}
+
+	private static MethodInvocation asMethodInvocation(Expression expression) {
+		Expression unwrapped= unwrap(expression);
+		return unwrapped instanceof MethodInvocation invocation ? invocation : null;
+	}
+
+	private static ExpressionStatement asExpressionStatement(Assignment assignment) {
+		return assignment.getParent() instanceof ExpressionStatement statement ? statement : null;
+	}
+
+	private static Assignment asAssignment(Statement statement) {
+		if (!(statement instanceof ExpressionStatement expressionStatement)) {
+			return null;
+		}
+		Expression expression= unwrap(expressionStatement.getExpression());
+		return expression instanceof Assignment assignment ? assignment : null;
+	}
+
+	private static Statement nextStatement(Statement statement) {
+		if (!(statement.getParent() instanceof Block block)) {
+			return null;
+		}
+		List<?> statements= block.statements();
+		int index= statements.indexOf(statement);
+		return index >= 0 && index + 1 < statements.size()
+				? (Statement) statements.get(index + 1)
+				: null;
+	}
+
+	private static boolean isArraysCopyOf(MethodInvocation invocation) {
+		if (!"copyOf".equals(invocation.getName().getIdentifier())) { //$NON-NLS-1$
+			return false;
+		}
+
+		IMethodBinding binding= invocation.resolveMethodBinding();
+		if (binding != null && binding.getDeclaringClass() != null) {
+			return "java.util.Arrays".equals(binding.getDeclaringClass().getErasure().getQualifiedName()); //$NON-NLS-1$
+		}
+
+		Expression expression= invocation.getExpression();
+		if (expression == null) {
+			return false;
+		}
+		String owner= expression.toString();
+		return "Arrays".equals(owner) || "java.util.Arrays".equals(owner); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	private static boolean isLengthPlusOne(Expression expression, Expression array) {
+		Expression unwrapped= unwrap(expression);
+		if (!(unwrapped instanceof InfixExpression infix)
+				|| infix.getOperator() != InfixExpression.Operator.PLUS
+				|| !infix.extendedOperands().isEmpty()) {
+			return false;
+		}
+		return isArrayLength(infix.getLeftOperand(), array) && isOne(infix.getRightOperand())
+				|| isOne(infix.getLeftOperand()) && isArrayLength(infix.getRightOperand(), array);
+	}
+
+	private static boolean isLengthMinusOne(Expression expression, Expression array) {
+		Expression unwrapped= unwrap(expression);
+		if (!(unwrapped instanceof InfixExpression infix)
+				|| infix.getOperator() != InfixExpression.Operator.MINUS
+				|| !infix.extendedOperands().isEmpty()) {
+			return false;
+		}
+		return isArrayLength(infix.getLeftOperand(), array) && isOne(infix.getRightOperand());
+	}
+
+	private static boolean isArrayLength(Expression expression, Expression array) {
+		Expression unwrapped= unwrap(expression);
+		if (unwrapped instanceof QualifiedName qualifiedName) {
+			return "length".equals(qualifiedName.getName().getIdentifier()) //$NON-NLS-1$
+					&& sameVariable(array, qualifiedName.getQualifier());
+		}
+		if (unwrapped instanceof FieldAccess fieldAccess) {
+			return "length".equals(fieldAccess.getName().getIdentifier()) //$NON-NLS-1$
+					&& sameVariable(array, fieldAccess.getExpression());
+		}
+		return false;
+	}
+
+	private static boolean isOne(Expression expression) {
+		Expression unwrapped= unwrap(expression);
+		Object constant= unwrapped.resolveConstantExpressionValue();
+		if (constant instanceof Number number) {
+			return number.longValue() == 1L;
+		}
+		return unwrapped instanceof NumberLiteral literal && "1".equals(literal.getToken()); //$NON-NLS-1$
+	}
+
+	private static boolean sameVariable(Expression first, Expression second) {
+		Expression left= unwrap(first);
+		Expression right= unwrap(second);
+		Optional<IVariableBinding> leftBinding= resolveVariableBinding(left);
+		Optional<IVariableBinding> rightBinding= resolveVariableBinding(right);
+		if (leftBinding.isPresent() && rightBinding.isPresent()) {
+			return leftBinding.get().getVariableDeclaration()
+					.isEqualTo(rightBinding.get().getVariableDeclaration());
+		}
+		return left.subtreeMatch(new ASTMatcher(true), right);
+	}
+
+	private static Optional<IVariableBinding> resolveVariableBinding(Expression expression) {
+		Expression unwrapped= unwrap(expression);
+		IBinding binding= null;
+		if (unwrapped instanceof SimpleName simpleName) {
+			binding= simpleName.resolveBinding();
+		} else if (unwrapped instanceof QualifiedName qualifiedName) {
+			binding= qualifiedName.resolveBinding();
+		} else if (unwrapped instanceof FieldAccess fieldAccess) {
+			binding= fieldAccess.resolveFieldBinding();
+		} else if (unwrapped instanceof SuperFieldAccess superFieldAccess) {
+			binding= superFieldAccess.resolveFieldBinding();
+		}
+		return binding instanceof IVariableBinding variableBinding
+				? Optional.of(variableBinding)
+				: Optional.empty();
+	}
+
+	private static Expression unwrap(Expression expression) {
+		Expression result= expression;
+		while (result instanceof ParenthesizedExpression parenthesized) {
+			result= parenthesized.getExpression();
+		}
+		return result;
+	}
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/AppendOnlyArraySeedDetector.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/AppendOnlyArraySeedDetector.java
@@ -19,8 +19,6 @@ import static org.sandbox.jdt.container.analysis.ContainerAstFacts.unwrap;
 import static org.sandbox.jdt.container.analysis.ContainerAstFacts.variableBinding;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -31,6 +29,7 @@ import org.eclipse.jdt.core.dom.Assignment;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.ExpressionStatement;
+import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.IVariableBinding;
 import org.eclipse.jdt.core.dom.InfixExpression;
@@ -51,16 +50,16 @@ import org.sandbox.jdt.container.api.ContainerUsageProfile.OrderRequirement;
 import org.sandbox.jdt.container.api.ContainerUsageProfile.UniquenessRequirement;
 import org.sandbox.jdt.container.api.UsageEvidence;
 import org.sandbox.jdt.container.api.UsageEvidence.Kind;
-import org.sandbox.jdt.internal.common.ASTProcessor;
+import org.sandbox.jdt.internal.common.AstProcessing;
 import org.sandbox.jdt.internal.common.ReferenceHolder;
 
 /**
  * Finds local seeds where a reference array is grown by one element and the new tail
  * slot is assigned immediately afterwards.
  *
- * <p>The implementation uses the scoped {@link ASTProcessor} chain deliberately:
- * after a matching {@link Arrays#copyOf(Object[], int)} invocation, the next stage
- * searches only the immediately following statement for the corresponding tail write.</p>
+ * <p>The implementation uses an explicit scoped AST pipeline: after a semantically
+ * matching {@code java.util.Arrays.copyOf(...)} invocation, the next stage searches
+ * only the immediately following statement for the corresponding tail write.</p>
  *
  * <p>This detector deliberately stops at {@link AnalysisCompleteness#LOCAL_SEED}.
  * It does not claim that all array uses are append-only, that aliases do not escape or
@@ -82,29 +81,23 @@ public final class AppendOnlyArraySeedDetector {
 
 		List<ContainerUsageProfile> profiles= new ArrayList<>();
 		ReferenceHolder<Integer, GrowthSeed> state= ReferenceHolder.createIndexed();
-		ASTProcessor<ReferenceHolder<Integer, GrowthSeed>, Integer, GrowthSeed> processor=
-				new ASTProcessor<>(state, new HashSet<>());
 
-		processor
-				.callMethodInvocationVisitor(Arrays.class, "copyOf", //$NON-NLS-1$
-						AppendOnlyArraySeedDetector::rememberGrowth,
+		AstProcessing.scoped(state)
+				.find(MethodInvocation.class,
+						(copyOf, holder) -> growthSeed(copyOf).isPresent(),
+						(copyOf, holder) -> holder.put(
+								CURRENT_GROWTH, growthSeed(copyOf).orElseThrow()),
 						AppendOnlyArraySeedDetector::followingStatementScope)
-				.callArrayAccessVisitor((node, holder) ->
-						collectTailWrite((ArrayAccess) node, holder, profiles))
+				.then(ArrayAccess.class,
+						AppendOnlyArraySeedDetector::isTailWrite,
+						(arrayAccess, holder) -> collectTailWrite(arrayAccess, holder, profiles))
 				.build(compilationUnit);
 
 		return List.copyOf(profiles);
 	}
 
-	private static boolean rememberGrowth(MethodInvocation copyOf,
-			ReferenceHolder<Integer, GrowthSeed> state) {
-		state.remove(CURRENT_GROWTH);
-		growthSeed(copyOf).ifPresent(seed -> state.put(CURRENT_GROWTH, seed));
-		return false;
-	}
-
 	private static Optional<GrowthSeed> growthSeed(MethodInvocation copyOf) {
-		if (copyOf.arguments().size() != 2) {
+		if (!isArraysCopyOf(copyOf) || copyOf.arguments().size() != 2) {
 			return Optional.empty();
 		}
 
@@ -133,33 +126,47 @@ public final class AppendOnlyArraySeedDetector {
 		return Optional.of(new GrowthSeed(array, growthAssignment, binding, elementDomain));
 	}
 
-	private static ASTNode followingStatementScope(ASTNode node) {
-		MethodInvocation copyOf= (MethodInvocation) node;
-		Assignment assignment= enclosingAssignment(copyOf);
-		ExpressionStatement statement= assignment == null ? null : expressionStatement(assignment);
-		Statement next= statement == null ? null : nextStatement(statement);
-		return next != null ? next : copyOf;
+	private static boolean isArraysCopyOf(MethodInvocation invocation) {
+		if (!"copyOf".equals(invocation.getName().getIdentifier())) { //$NON-NLS-1$
+			return false;
+		}
+		IMethodBinding binding= invocation.resolveMethodBinding();
+		if (binding != null && binding.getDeclaringClass() != null) {
+			return "java.util.Arrays".equals( //$NON-NLS-1$
+					binding.getDeclaringClass().getErasure().getQualifiedName());
+		}
+		Expression owner= invocation.getExpression();
+		return owner != null && ("Arrays".equals(owner.toString()) //$NON-NLS-1$
+				|| "java.util.Arrays".equals(owner.toString())); //$NON-NLS-1$
 	}
 
-	private static boolean collectTailWrite(ArrayAccess arrayAccess,
-			ReferenceHolder<Integer, GrowthSeed> state,
-			List<ContainerUsageProfile> profiles) {
+	private static ASTNode followingStatementScope(MethodInvocation copyOf) {
+		Assignment assignment= enclosingAssignment(copyOf);
+		ExpressionStatement statement= assignment == null ? null : expressionStatement(assignment);
+		return statement == null ? null : nextStatement(statement);
+	}
+
+	private static boolean isTailWrite(ArrayAccess arrayAccess,
+			ReferenceHolder<Integer, GrowthSeed> state) {
 		GrowthSeed seed= state.get(CURRENT_GROWTH);
 		if (seed == null) {
-			return true;
+			return false;
 		}
-
 		Assignment appendAssignment= enclosingAssignment(arrayAccess);
-		if (appendAssignment == null
-				|| unwrap(appendAssignment.getLeftHandSide()) != arrayAccess
-				|| !sameVariable(seed.array(), arrayAccess.getArray())
-				|| !isLengthMinusOne(arrayAccess.getIndex(), seed.array())) {
-			return true;
-		}
+		return appendAssignment != null
+				&& unwrap(appendAssignment.getLeftHandSide()) == arrayAccess
+				&& sameVariable(seed.array(), arrayAccess.getArray())
+				&& isLengthMinusOne(arrayAccess.getIndex(), seed.array());
+	}
 
-		profiles.add(createProfile(seed, appendAssignment));
-		state.remove(CURRENT_GROWTH);
-		return false;
+	private static void collectTailWrite(ArrayAccess arrayAccess,
+			ReferenceHolder<Integer, GrowthSeed> state,
+			List<ContainerUsageProfile> profiles) {
+		GrowthSeed seed= state.remove(CURRENT_GROWTH);
+		Assignment appendAssignment= enclosingAssignment(arrayAccess);
+		if (seed != null && appendAssignment != null) {
+			profiles.add(createProfile(seed, appendAssignment));
+		}
 	}
 
 	private static ContainerUsageProfile createProfile(GrowthSeed seed, Assignment appendAssignment) {

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/AppendOnlyArraySeedDetector.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/AppendOnlyArraySeedDetector.java
@@ -10,32 +10,32 @@
  *******************************************************************************/
 package org.sandbox.jdt.container.analysis;
 
+import static org.sandbox.jdt.container.analysis.ContainerAstFacts.assignment;
+import static org.sandbox.jdt.container.analysis.ContainerAstFacts.expressionStatement;
+import static org.sandbox.jdt.container.analysis.ContainerAstFacts.isArrayLength;
+import static org.sandbox.jdt.container.analysis.ContainerAstFacts.isOne;
+import static org.sandbox.jdt.container.analysis.ContainerAstFacts.nextStatement;
+import static org.sandbox.jdt.container.analysis.ContainerAstFacts.sameVariable;
+import static org.sandbox.jdt.container.analysis.ContainerAstFacts.unwrap;
+import static org.sandbox.jdt.container.analysis.ContainerAstFacts.variableBinding;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.eclipse.jdt.core.dom.ASTMatcher;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ArrayAccess;
 import org.eclipse.jdt.core.dom.Assignment;
-import org.eclipse.jdt.core.dom.Block;
+import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.ExpressionStatement;
-import org.eclipse.jdt.core.dom.FieldAccess;
-import org.eclipse.jdt.core.dom.IBinding;
 import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.IVariableBinding;
 import org.eclipse.jdt.core.dom.InfixExpression;
 import org.eclipse.jdt.core.dom.MethodInvocation;
-import org.eclipse.jdt.core.dom.NumberLiteral;
-import org.eclipse.jdt.core.dom.ParenthesizedExpression;
-import org.eclipse.jdt.core.dom.QualifiedName;
-import org.eclipse.jdt.core.dom.SimpleName;
-import org.eclipse.jdt.core.dom.Statement;
-import org.eclipse.jdt.core.dom.SuperFieldAccess;
-import org.eclipse.jdt.core.dom.ArrayAccess;
-import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.sandbox.jdt.container.api.ContainerShape;
 import org.sandbox.jdt.container.api.ContainerUsageProfile;
 import org.sandbox.jdt.container.api.ContainerUsageProfile.AliasingContract;
@@ -75,8 +75,8 @@ public final class AppendOnlyArraySeedDetector {
 		ReferenceHolder<Integer, ContainerUsageProfile> profiles= ReferenceHolder.createIndexed();
 
 		AstProcessorBuilder.with(profiles)
-				.onAssignment((assignment, holder) -> {
-					detectSeed(assignment).ifPresent(profile ->
+				.onAssignment((candidate, holder) -> {
+					detectSeed(candidate).ifPresent(profile ->
 						holder.put(profile.identity().sourceStart(), profile));
 					return true;
 				})
@@ -94,7 +94,7 @@ public final class AppendOnlyArraySeedDetector {
 		}
 
 		Expression array= unwrap(growthAssignment.getLeftHandSide());
-		MethodInvocation copyOf= asMethodInvocation(growthAssignment.getRightHandSide());
+		MethodInvocation copyOf= methodInvocation(growthAssignment.getRightHandSide());
 		if (copyOf == null || !isArraysCopyOf(copyOf) || copyOf.arguments().size() != 2) {
 			return Optional.empty();
 		}
@@ -105,16 +105,16 @@ public final class AppendOnlyArraySeedDetector {
 			return Optional.empty();
 		}
 
-		ExpressionStatement growthStatement= asExpressionStatement(growthAssignment);
+		ExpressionStatement growthStatement= expressionStatement(growthAssignment);
 		Assignment appendAssignment= growthStatement == null
 				? null
-				: asAssignment(nextStatement(growthStatement));
+				: assignment(nextStatement(growthStatement));
 		if (!isTailWrite(appendAssignment, array)) {
 			return Optional.empty();
 		}
 
-		Optional<IVariableBinding> variableBinding= resolveVariableBinding(array);
-		ITypeBinding arrayType= variableBinding.map(IVariableBinding::getType)
+		Optional<IVariableBinding> binding= variableBinding(array);
+		ITypeBinding arrayType= binding.map(IVariableBinding::getType)
 				.orElseGet(array::resolveTypeBinding);
 		ElementDomain elementDomain= elementDomain(arrayType);
 		if (elementDomain == ElementDomain.PRIMITIVE) {
@@ -135,7 +135,7 @@ public final class AppendOnlyArraySeedDetector {
 		}
 
 		ContainerIdentity identity= new ContainerIdentity(
-				variableBinding.map(binding -> binding.getVariableDeclaration().getKey()).orElse(""), //$NON-NLS-1$
+				binding.map(value -> value.getVariableDeclaration().getKey()).orElse(""), //$NON-NLS-1$
 				array.toString(), array.getStartPosition(), array.getLength());
 
 		return Optional.of(new ContainerUsageProfile(
@@ -154,7 +154,7 @@ public final class AppendOnlyArraySeedDetector {
 				evidence));
 	}
 
-	private static UsageEvidence evidence(Kind kind, String summary, org.eclipse.jdt.core.dom.ASTNode node) {
+	private static UsageEvidence evidence(Kind kind, String summary, ASTNode node) {
 		return new UsageEvidence(kind, summary, node.getStartPosition(), node.getLength());
 	}
 
@@ -163,7 +163,7 @@ public final class AppendOnlyArraySeedDetector {
 			return ElementDomain.UNKNOWN;
 		}
 		if (!arrayType.isArray()) {
-			return ElementDomain.PRIMITIVE;
+			return ElementDomain.UNKNOWN;
 		}
 		ITypeBinding componentType= arrayType.getComponentType();
 		if (componentType == null) {
@@ -175,11 +175,11 @@ public final class AppendOnlyArraySeedDetector {
 		return componentType.isEnum() ? ElementDomain.ENUM : ElementDomain.REFERENCE;
 	}
 
-	private static boolean isTailWrite(Assignment assignment, Expression array) {
-		if (assignment == null || assignment.getOperator() != Assignment.Operator.ASSIGN) {
+	private static boolean isTailWrite(Assignment appendAssignment, Expression array) {
+		if (appendAssignment == null || appendAssignment.getOperator() != Assignment.Operator.ASSIGN) {
 			return false;
 		}
-		Expression leftHandSide= unwrap(assignment.getLeftHandSide());
+		Expression leftHandSide= unwrap(appendAssignment.getLeftHandSide());
 		if (!(leftHandSide instanceof ArrayAccess arrayAccess)) {
 			return false;
 		}
@@ -187,32 +187,9 @@ public final class AppendOnlyArraySeedDetector {
 				&& isLengthMinusOne(arrayAccess.getIndex(), array);
 	}
 
-	private static MethodInvocation asMethodInvocation(Expression expression) {
+	private static MethodInvocation methodInvocation(Expression expression) {
 		Expression unwrapped= unwrap(expression);
 		return unwrapped instanceof MethodInvocation invocation ? invocation : null;
-	}
-
-	private static ExpressionStatement asExpressionStatement(Assignment assignment) {
-		return assignment.getParent() instanceof ExpressionStatement statement ? statement : null;
-	}
-
-	private static Assignment asAssignment(Statement statement) {
-		if (!(statement instanceof ExpressionStatement expressionStatement)) {
-			return null;
-		}
-		Expression expression= unwrap(expressionStatement.getExpression());
-		return expression instanceof Assignment assignment ? assignment : null;
-	}
-
-	private static Statement nextStatement(Statement statement) {
-		if (!(statement.getParent() instanceof Block block)) {
-			return null;
-		}
-		List<?> statements= block.statements();
-		int index= statements.indexOf(statement);
-		return index >= 0 && index + 1 < statements.size()
-				? (Statement) statements.get(index + 1)
-				: null;
 	}
 
 	private static boolean isArraysCopyOf(MethodInvocation invocation) {
@@ -252,64 +229,5 @@ public final class AppendOnlyArraySeedDetector {
 			return false;
 		}
 		return isArrayLength(infix.getLeftOperand(), array) && isOne(infix.getRightOperand());
-	}
-
-	private static boolean isArrayLength(Expression expression, Expression array) {
-		Expression unwrapped= unwrap(expression);
-		if (unwrapped instanceof QualifiedName qualifiedName) {
-			return "length".equals(qualifiedName.getName().getIdentifier()) //$NON-NLS-1$
-					&& sameVariable(array, qualifiedName.getQualifier());
-		}
-		if (unwrapped instanceof FieldAccess fieldAccess) {
-			return "length".equals(fieldAccess.getName().getIdentifier()) //$NON-NLS-1$
-					&& sameVariable(array, fieldAccess.getExpression());
-		}
-		return false;
-	}
-
-	private static boolean isOne(Expression expression) {
-		Expression unwrapped= unwrap(expression);
-		Object constant= unwrapped.resolveConstantExpressionValue();
-		if (constant instanceof Number number) {
-			return number.longValue() == 1L;
-		}
-		return unwrapped instanceof NumberLiteral literal && "1".equals(literal.getToken()); //$NON-NLS-1$
-	}
-
-	private static boolean sameVariable(Expression first, Expression second) {
-		Expression left= unwrap(first);
-		Expression right= unwrap(second);
-		Optional<IVariableBinding> leftBinding= resolveVariableBinding(left);
-		Optional<IVariableBinding> rightBinding= resolveVariableBinding(right);
-		if (leftBinding.isPresent() && rightBinding.isPresent()) {
-			return leftBinding.get().getVariableDeclaration()
-					.isEqualTo(rightBinding.get().getVariableDeclaration());
-		}
-		return left.subtreeMatch(new ASTMatcher(true), right);
-	}
-
-	private static Optional<IVariableBinding> resolveVariableBinding(Expression expression) {
-		Expression unwrapped= unwrap(expression);
-		IBinding binding= null;
-		if (unwrapped instanceof SimpleName simpleName) {
-			binding= simpleName.resolveBinding();
-		} else if (unwrapped instanceof QualifiedName qualifiedName) {
-			binding= qualifiedName.resolveBinding();
-		} else if (unwrapped instanceof FieldAccess fieldAccess) {
-			binding= fieldAccess.resolveFieldBinding();
-		} else if (unwrapped instanceof SuperFieldAccess superFieldAccess) {
-			binding= superFieldAccess.resolveFieldBinding();
-		}
-		return binding instanceof IVariableBinding variableBinding
-				? Optional.of(variableBinding)
-				: Optional.empty();
-	}
-
-	private static Expression unwrap(Expression expression) {
-		Expression result= expression;
-		while (result instanceof ParenthesizedExpression parenthesized) {
-			result= parenthesized.getExpression();
-		}
-		return result;
 	}
 }

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/AppendOnlyArraySeedDetector.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/AppendOnlyArraySeedDetector.java
@@ -40,7 +40,7 @@ import org.sandbox.jdt.container.api.ContainerShape;
 import org.sandbox.jdt.container.api.ContainerUsageProfile;
 import org.sandbox.jdt.container.api.ContainerUsageProfile.AliasingContract;
 import org.sandbox.jdt.container.api.ContainerUsageProfile.AnalysisCompleteness;
-import org.sandbox.jdt.container.api.ContainerUsageProfile.ConcurrencyContract;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.ConcurrencyProfile;
 import org.sandbox.jdt.container.api.ContainerUsageProfile.ContainerIdentity;
 import org.sandbox.jdt.container.api.ContainerUsageProfile.ElementDomain;
 import org.sandbox.jdt.container.api.ContainerUsageProfile.EscapeLevel;
@@ -149,7 +149,7 @@ public final class AppendOnlyArraySeedDetector {
 				NullContract.UNKNOWN,
 				AliasingContract.UNKNOWN,
 				EscapeLevel.UNKNOWN,
-				ConcurrencyContract.UNKNOWN,
+				ConcurrencyProfile.unknown(),
 				AnalysisCompleteness.LOCAL_SEED,
 				evidence));
 	}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/ContainerAstFacts.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/ContainerAstFacts.java
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.container.analysis;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.jdt.core.dom.ASTMatcher;
+import org.eclipse.jdt.core.dom.Assignment;
+import org.eclipse.jdt.core.dom.Block;
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.ExpressionStatement;
+import org.eclipse.jdt.core.dom.FieldAccess;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.IVariableBinding;
+import org.eclipse.jdt.core.dom.NumberLiteral;
+import org.eclipse.jdt.core.dom.ParenthesizedExpression;
+import org.eclipse.jdt.core.dom.QualifiedName;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.Statement;
+import org.eclipse.jdt.core.dom.SuperFieldAccess;
+
+/** Shared, side-effect-free AST facts used by semantic container detectors. */
+final class ContainerAstFacts {
+
+	private ContainerAstFacts() {
+		// Static utility.
+	}
+
+	static Expression unwrap(Expression expression) {
+		Expression result= expression;
+		while (result instanceof ParenthesizedExpression parenthesized) {
+			result= parenthesized.getExpression();
+		}
+		return result;
+	}
+
+	static ExpressionStatement expressionStatement(Assignment assignment) {
+		return assignment.getParent() instanceof ExpressionStatement statement ? statement : null;
+	}
+
+	static Assignment assignment(Statement statement) {
+		if (!(statement instanceof ExpressionStatement expressionStatement)) {
+			return null;
+		}
+		Expression expression= unwrap(expressionStatement.getExpression());
+		return expression instanceof Assignment assignment ? assignment : null;
+	}
+
+	static Statement nextStatement(Statement statement) {
+		if (!(statement.getParent() instanceof Block block)) {
+			return null;
+		}
+		List<?> statements= block.statements();
+		int index= statements.indexOf(statement);
+		return index >= 0 && index + 1 < statements.size()
+				? (Statement) statements.get(index + 1)
+				: null;
+	}
+
+	static boolean isArrayLength(Expression expression, Expression array) {
+		Expression unwrapped= unwrap(expression);
+		if (unwrapped instanceof QualifiedName qualifiedName) {
+			return "length".equals(qualifiedName.getName().getIdentifier()) //$NON-NLS-1$
+					&& sameVariable(array, qualifiedName.getQualifier());
+		}
+		if (unwrapped instanceof FieldAccess fieldAccess) {
+			return "length".equals(fieldAccess.getName().getIdentifier()) //$NON-NLS-1$
+					&& sameVariable(array, fieldAccess.getExpression());
+		}
+		return false;
+	}
+
+	static boolean isOne(Expression expression) {
+		Expression unwrapped= unwrap(expression);
+		Object constant= unwrapped.resolveConstantExpressionValue();
+		if (constant instanceof Number number) {
+			return number.longValue() == 1L;
+		}
+		return unwrapped instanceof NumberLiteral literal && "1".equals(literal.getToken()); //$NON-NLS-1$
+	}
+
+	static boolean sameVariable(Expression first, Expression second) {
+		Expression left= unwrap(first);
+		Expression right= unwrap(second);
+		Optional<IVariableBinding> leftBinding= variableBinding(left);
+		Optional<IVariableBinding> rightBinding= variableBinding(right);
+		if (leftBinding.isPresent() && rightBinding.isPresent()) {
+			return leftBinding.get().getVariableDeclaration()
+					.isEqualTo(rightBinding.get().getVariableDeclaration());
+		}
+		return left.subtreeMatch(new ASTMatcher(true), right);
+	}
+
+	static Optional<IVariableBinding> variableBinding(Expression expression) {
+		Expression unwrapped= unwrap(expression);
+		IBinding binding= null;
+		if (unwrapped instanceof SimpleName simpleName) {
+			binding= simpleName.resolveBinding();
+		} else if (unwrapped instanceof QualifiedName qualifiedName) {
+			binding= qualifiedName.resolveBinding();
+		} else if (unwrapped instanceof FieldAccess fieldAccess) {
+			binding= fieldAccess.resolveFieldBinding();
+		} else if (unwrapped instanceof SuperFieldAccess superFieldAccess) {
+			binding= superFieldAccess.resolveFieldBinding();
+		}
+		return binding instanceof IVariableBinding variableBinding
+				? Optional.of(variableBinding)
+				: Optional.empty();
+	}
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/LocalArrayUsageAnalyzer.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/LocalArrayUsageAnalyzer.java
@@ -1,0 +1,442 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.container.analysis;
+
+import static org.sandbox.jdt.container.analysis.ContainerAstFacts.isArrayLength;
+import static org.sandbox.jdt.container.analysis.ContainerAstFacts.isOne;
+import static org.sandbox.jdt.container.analysis.ContainerAstFacts.sameVariable;
+import static org.sandbox.jdt.container.analysis.ContainerAstFacts.unwrap;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ArrayAccess;
+import org.eclipse.jdt.core.dom.Assignment;
+import org.eclipse.jdt.core.dom.CastExpression;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.EnhancedForStatement;
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.FieldAccess;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.IVariableBinding;
+import org.eclipse.jdt.core.dom.InfixExpression;
+import org.eclipse.jdt.core.dom.InstanceofExpression;
+import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.ParenthesizedExpression;
+import org.eclipse.jdt.core.dom.QualifiedName;
+import org.eclipse.jdt.core.dom.ReturnStatement;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
+import org.eclipse.jdt.core.dom.SuperFieldAccess;
+import org.eclipse.jdt.core.dom.SynchronizedStatement;
+import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+import org.sandbox.jdt.container.api.ContainerShape;
+import org.sandbox.jdt.container.api.ContainerUsageProfile;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.AccessProfile;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.AliasingContract;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.AnalysisCompleteness;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.EscapeLevel;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.MutationLifecycle;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.OrderRequirement;
+import org.sandbox.jdt.container.api.UsageEvidence;
+import org.sandbox.jdt.container.api.UsageEvidence.Kind;
+import org.sandbox.jdt.internal.common.AstProcessing;
+import org.sandbox.jdt.internal.common.ReferenceHolder;
+
+/**
+ * Classifies every binding-resolved use of one array candidate inside a compilation
+ * unit.
+ *
+ * <p>The first implementation intentionally supports a narrow, explainable set of
+ * uses: declarations, recognised array growth, tail append, {@code length}, indexed
+ * read/write and enhanced-for iteration. Any other use is retained as source-backed
+ * rejection evidence. This fail-closed boundary prevents a local seed from becoming
+ * an executable migration candidate merely because most uses looked familiar.</p>
+ */
+public final class LocalArrayUsageAnalyzer {
+
+	/** Analyzes one seed profile in the supplied compilation unit. */
+	public ContainerUsageProfile analyze(
+			CompilationUnit compilationUnit,
+			ContainerUsageProfile seed) {
+		Objects.requireNonNull(compilationUnit, "compilationUnit"); //$NON-NLS-1$
+		Objects.requireNonNull(seed, "seed"); //$NON-NLS-1$
+		if (seed.currentShape() != ContainerShape.ARRAY) {
+			throw new IllegalArgumentException("LocalArrayUsageAnalyzer requires an array profile"); //$NON-NLS-1$
+		}
+
+		Accumulator accumulator= new Accumulator(seed);
+		if (!seed.identity().hasResolvedBinding()) {
+			accumulator.reject(Kind.UNRESOLVED_BINDING,
+					"Local usage analysis requires a resolved variable binding", //$NON-NLS-1$
+					seed.identity().sourceStart(), seed.identity().sourceLength());
+			return accumulator.toProfile();
+		}
+
+		ReferenceHolder<String, Object> traversalState= ReferenceHolder.create();
+		AstProcessing.independent(traversalState)
+				.on(SimpleName.class, (name, holder) -> {
+					classifyMatchingReference(name, seed.identity().bindingKey(), accumulator);
+					return true;
+				})
+				.build(compilationUnit);
+
+		if (!accumulator.bindingSeen()) {
+			accumulator.reject(Kind.UNRESOLVED_BINDING,
+					"The candidate binding was not found in the analyzed compilation unit", //$NON-NLS-1$
+					seed.identity().sourceStart(), seed.identity().sourceLength());
+		}
+		return accumulator.toProfile();
+	}
+
+	/** Analyzes profiles in deterministic input order. */
+	public List<ContainerUsageProfile> analyzeAll(
+			CompilationUnit compilationUnit,
+			List<ContainerUsageProfile> seeds) {
+		Objects.requireNonNull(seeds, "seeds"); //$NON-NLS-1$
+		return seeds.stream().map(seed -> analyze(compilationUnit, seed)).toList();
+	}
+
+	private static void classifyMatchingReference(
+			SimpleName name,
+			String targetBindingKey,
+			Accumulator accumulator) {
+		IBinding resolved= name.resolveBinding();
+		if (!(resolved instanceof IVariableBinding variable)
+				|| !targetBindingKey.equals(variable.getVariableDeclaration().getKey())) {
+			return;
+		}
+
+		accumulator.observeBinding(variable.getVariableDeclaration());
+		if (isDeclarationName(name)) {
+			return;
+		}
+
+		Expression reference= completeReferenceExpression(name, targetBindingKey);
+		ASTNode parent= reference.getParent();
+		if (isLengthRead(reference, parent)) {
+			accumulator.lengthRead(reference);
+		} else if (parent instanceof ArrayAccess access && access.getArray() == reference) {
+			classifyArrayAccess(access, reference, accumulator);
+		} else if (parent instanceof EnhancedForStatement enhancedFor
+				&& enhancedFor.getExpression() == reference) {
+			accumulator.encounterIteration(reference);
+		} else if (parent instanceof MethodInvocation invocation) {
+			classifyMethodInvocation(reference, invocation, accumulator);
+		} else if (parent instanceof Assignment assignment) {
+			classifyAssignment(reference, assignment, accumulator);
+		} else if (parent instanceof ReturnStatement) {
+			accumulator.reject(Kind.UNSAFE_ESCAPE,
+					"Array value escapes through a return statement", reference); //$NON-NLS-1$
+		} else if (parent instanceof InfixExpression infix && isIdentityComparison(infix)) {
+			accumulator.reject(Kind.ARRAY_IDENTITY,
+					"Array identity is observed by a reference comparison", reference); //$NON-NLS-1$
+		} else if (parent instanceof SynchronizedStatement synchronizedStatement
+				&& synchronizedStatement.getExpression() == reference) {
+			accumulator.reject(Kind.ARRAY_IDENTITY,
+					"Array identity is used as a synchronization monitor", reference); //$NON-NLS-1$
+		} else if (parent instanceof CastExpression || parent instanceof InstanceofExpression) {
+			accumulator.reject(Kind.ARRAY_IDENTITY,
+					"Runtime array representation is observed by a type operation", reference); //$NON-NLS-1$
+		} else {
+			accumulator.reject(Kind.UNCLASSIFIED_USAGE,
+					"Array use is not yet classified by local container analysis", reference); //$NON-NLS-1$
+		}
+	}
+
+	private static void classifyArrayAccess(
+			ArrayAccess access,
+			Expression reference,
+			Accumulator accumulator) {
+		Assignment assignment= enclosingAssignment(access);
+		if (assignment != null && unwrap(assignment.getLeftHandSide()) == access) {
+			if (isTailAppend(access, reference)) {
+				accumulator.appendObserved();
+			} else {
+				accumulator.indexedWrite(access);
+			}
+		} else {
+			accumulator.indexedRead(access);
+		}
+	}
+
+	private static void classifyMethodInvocation(
+			Expression reference,
+			MethodInvocation invocation,
+			Accumulator accumulator) {
+		if (invocation.arguments().contains(reference)
+				&& isRecognizedCopySource(invocation, reference)) {
+			return;
+		}
+		if (invocation.arguments().contains(reference)) {
+			accumulator.reject(Kind.UNSAFE_ESCAPE,
+					"Array value is passed to another method", reference); //$NON-NLS-1$
+		} else {
+			accumulator.reject(Kind.UNCLASSIFIED_USAGE,
+					"Method invocation observes array-specific behavior", reference); //$NON-NLS-1$
+		}
+	}
+
+	private static void classifyAssignment(
+			Expression reference,
+			Assignment assignment,
+			Accumulator accumulator) {
+		if (assignment.getLeftHandSide() == reference
+				&& isRecognizedGrowthAssignment(assignment, reference)) {
+			return;
+		}
+		if (assignment.getRightHandSide() == reference) {
+			accumulator.reject(Kind.UNSAFE_ESCAPE,
+					"Array value is assigned to another variable or field", reference); //$NON-NLS-1$
+		} else {
+			accumulator.reject(Kind.UNCLASSIFIED_USAGE,
+					"Array reference is reassigned outside the recognised growth pattern", reference); //$NON-NLS-1$
+		}
+	}
+
+	private static boolean isDeclarationName(SimpleName name) {
+		ASTNode parent= name.getParent();
+		return parent instanceof VariableDeclarationFragment fragment && fragment.getName() == name
+				|| parent instanceof SingleVariableDeclaration declaration
+						&& declaration.getName() == name;
+	}
+
+	private static Expression completeReferenceExpression(SimpleName name, String bindingKey) {
+		Expression reference= name;
+		ASTNode parent= reference.getParent();
+		if (parent instanceof QualifiedName qualified
+				&& qualified.getName() == reference
+				&& hasBindingKey(qualified.resolveBinding(), bindingKey)) {
+			reference= qualified;
+		} else if (parent instanceof FieldAccess fieldAccess
+				&& fieldAccess.getName() == reference
+				&& hasBindingKey(fieldAccess.resolveFieldBinding(), bindingKey)) {
+			reference= fieldAccess;
+		} else if (parent instanceof SuperFieldAccess superFieldAccess
+				&& superFieldAccess.getName() == reference
+				&& hasBindingKey(superFieldAccess.resolveFieldBinding(), bindingKey)) {
+			reference= superFieldAccess;
+		}
+		while (reference.getParent() instanceof ParenthesizedExpression parenthesized) {
+			reference= parenthesized;
+		}
+		return reference;
+	}
+
+	private static boolean hasBindingKey(IBinding binding, String bindingKey) {
+		return binding instanceof IVariableBinding variable
+				&& bindingKey.equals(variable.getVariableDeclaration().getKey());
+	}
+
+	private static boolean isLengthRead(Expression reference, ASTNode parent) {
+		if (parent instanceof QualifiedName qualifiedName) {
+			return qualifiedName.getQualifier() == reference
+					&& "length".equals(qualifiedName.getName().getIdentifier()); //$NON-NLS-1$
+		}
+		if (parent instanceof FieldAccess fieldAccess) {
+			return fieldAccess.getExpression() == reference
+					&& "length".equals(fieldAccess.getName().getIdentifier()); //$NON-NLS-1$
+		}
+		return false;
+	}
+
+	private static boolean isRecognizedCopySource(
+			MethodInvocation invocation,
+			Expression reference) {
+		return isArraysCopyOf(invocation)
+				&& !invocation.arguments().isEmpty()
+				&& invocation.arguments().get(0) == reference;
+	}
+
+	private static boolean isRecognizedGrowthAssignment(
+			Assignment assignment,
+			Expression reference) {
+		Expression right= unwrap(assignment.getRightHandSide());
+		if (!(right instanceof MethodInvocation copyOf)
+				|| !isArraysCopyOf(copyOf)
+				|| copyOf.arguments().size() != 2) {
+			return false;
+		}
+		Expression source= (Expression) copyOf.arguments().get(0);
+		Expression length= (Expression) copyOf.arguments().get(1);
+		return sameVariable(reference, source) && isLengthPlusOne(length, reference);
+	}
+
+	private static boolean isArraysCopyOf(MethodInvocation invocation) {
+		if (!"copyOf".equals(invocation.getName().getIdentifier())) { //$NON-NLS-1$
+			return false;
+		}
+		IMethodBinding binding= invocation.resolveMethodBinding();
+		if (binding != null && binding.getDeclaringClass() != null) {
+			return "java.util.Arrays".equals( //$NON-NLS-1$
+					binding.getDeclaringClass().getErasure().getQualifiedName());
+		}
+		Expression owner= invocation.getExpression();
+		return owner != null && ("Arrays".equals(owner.toString()) //$NON-NLS-1$
+				|| "java.util.Arrays".equals(owner.toString())); //$NON-NLS-1$
+	}
+
+	private static boolean isTailAppend(ArrayAccess access, Expression array) {
+		return isLengthMinusOne(access.getIndex(), array);
+	}
+
+	private static boolean isLengthPlusOne(Expression expression, Expression array) {
+		Expression unwrapped= unwrap(expression);
+		if (!(unwrapped instanceof InfixExpression infix)
+				|| infix.getOperator() != InfixExpression.Operator.PLUS
+				|| !infix.extendedOperands().isEmpty()) {
+			return false;
+		}
+		return isArrayLength(infix.getLeftOperand(), array) && isOne(infix.getRightOperand())
+				|| isOne(infix.getLeftOperand()) && isArrayLength(infix.getRightOperand(), array);
+	}
+
+	private static boolean isLengthMinusOne(Expression expression, Expression array) {
+		Expression unwrapped= unwrap(expression);
+		if (!(unwrapped instanceof InfixExpression infix)
+				|| infix.getOperator() != InfixExpression.Operator.MINUS
+				|| !infix.extendedOperands().isEmpty()) {
+			return false;
+		}
+		return isArrayLength(infix.getLeftOperand(), array) && isOne(infix.getRightOperand());
+	}
+
+	private static Assignment enclosingAssignment(ASTNode node) {
+		ASTNode current= node;
+		while (current.getParent() instanceof ParenthesizedExpression) {
+			current= current.getParent();
+		}
+		return current.getParent() instanceof Assignment assignment ? assignment : null;
+	}
+
+	private static boolean isIdentityComparison(InfixExpression expression) {
+		return expression.getOperator() == InfixExpression.Operator.EQUALS
+				|| expression.getOperator() == InfixExpression.Operator.NOT_EQUALS;
+	}
+
+	private static UsageEvidence evidence(Kind kind, String summary, ASTNode node) {
+		return new UsageEvidence(kind, summary, node.getStartPosition(), node.getLength());
+	}
+
+	private static final class Accumulator {
+
+		private final ContainerUsageProfile seed;
+		private final List<UsageEvidence> evidence;
+		private boolean bindingSeen;
+		private boolean field;
+		private boolean parameter;
+		private boolean indexedRead;
+		private boolean indexedWrite;
+		private boolean append;
+		private boolean encounterIteration;
+		private boolean rejected;
+
+		Accumulator(ContainerUsageProfile seed) {
+			this.seed= seed;
+			evidence= new ArrayList<>(seed.evidence());
+			indexedRead= seed.access().indexedRead();
+			indexedWrite= seed.access().indexedWrite();
+			append= seed.access().append();
+		}
+
+		void observeBinding(IVariableBinding binding) {
+			bindingSeen= true;
+			field|= binding.isField();
+			parameter|= binding.isParameter();
+		}
+
+		boolean bindingSeen() {
+			return bindingSeen;
+		}
+
+		void lengthRead(ASTNode node) {
+			evidence.add(LocalArrayUsageAnalyzer.evidence(Kind.ARRAY_LENGTH_READ,
+					"Array length is observed", node)); //$NON-NLS-1$
+		}
+
+		void indexedRead(ASTNode node) {
+			indexedRead= true;
+			evidence.add(LocalArrayUsageAnalyzer.evidence(Kind.INDEXED_READ,
+					"Array element is read by index", node)); //$NON-NLS-1$
+		}
+
+		void indexedWrite(ASTNode node) {
+			indexedWrite= true;
+			evidence.add(LocalArrayUsageAnalyzer.evidence(Kind.INDEXED_WRITE,
+					"Existing array position is written by index", node)); //$NON-NLS-1$
+		}
+
+		void appendObserved() {
+			append= true;
+		}
+
+		void encounterIteration(ASTNode node) {
+			encounterIteration= true;
+			evidence.add(LocalArrayUsageAnalyzer.evidence(Kind.ENCOUNTER_ITERATION,
+					"Array is traversed in encounter order", node)); //$NON-NLS-1$
+		}
+
+		void reject(Kind kind, String summary, ASTNode node) {
+			reject(kind, summary, node.getStartPosition(), node.getLength());
+		}
+
+		void reject(Kind kind, String summary, int start, int length) {
+			rejected= true;
+			evidence.add(new UsageEvidence(kind, summary, start, length));
+		}
+
+		ContainerUsageProfile toProfile() {
+			AnalysisCompleteness completeness= rejected
+					? AnalysisCompleteness.REJECTED
+					: AnalysisCompleteness.LOCAL_USAGE_COMPLETE;
+			if (!rejected) {
+				evidence.add(new UsageEvidence(Kind.LOCAL_USAGE_COMPLETE,
+						"Every local use of the array binding was classified", //$NON-NLS-1$
+						seed.identity().sourceStart(), seed.identity().sourceLength()));
+			}
+
+			OrderRequirement order= indexedRead || indexedWrite
+					? OrderRequirement.POSITIONAL
+					: encounterIteration ? OrderRequirement.ENCOUNTER : seed.orderRequirement();
+			EscapeLevel escape= field
+					? EscapeLevel.FIELD
+					: parameter ? EscapeLevel.METHOD_BOUNDARY : EscapeLevel.LOCAL;
+			AliasingContract aliasing= rejected
+					? AliasingContract.UNKNOWN
+					: AliasingContract.NO_OBSERVED_ALIAS;
+
+			return new ContainerUsageProfile(
+					seed.identity(),
+					seed.currentShape(),
+					seed.elementDomain(),
+					new AccessProfile(
+							indexedRead,
+							indexedWrite,
+							append,
+							false,
+							false,
+							seed.access().membershipQuery(),
+							seed.access().keyLookup()),
+					order,
+					seed.uniquenessRequirement(),
+					MutationLifecycle.CONTINUOUSLY_MUTABLE,
+					seed.nullContract(),
+					aliasing,
+					escape,
+					seed.concurrency(),
+					completeness,
+					evidence);
+		}
+	}
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/LocalArrayUsageAnalyzer.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/LocalArrayUsageAnalyzer.java
@@ -136,6 +136,10 @@ public final class LocalArrayUsageAnalyzer {
 			classifyMethodInvocation(reference, invocation, accumulator);
 		} else if (parent instanceof Assignment assignment) {
 			classifyAssignment(reference, assignment, accumulator);
+		} else if (parent instanceof VariableDeclarationFragment fragment
+				&& fragment.getInitializer() == reference) {
+			accumulator.reject(Kind.UNSAFE_ESCAPE,
+					"Array value is assigned to another local variable", reference); //$NON-NLS-1$
 		} else if (parent instanceof ReturnStatement) {
 			accumulator.reject(Kind.UNSAFE_ESCAPE,
 					"Array value escapes through a return statement", reference); //$NON-NLS-1$
@@ -338,6 +342,7 @@ public final class LocalArrayUsageAnalyzer {
 		private boolean parameter;
 		private boolean indexedRead;
 		private boolean indexedWrite;
+		private boolean positionalWrite;
 		private boolean append;
 		private boolean encounterIteration;
 		private boolean rejected;
@@ -373,6 +378,7 @@ public final class LocalArrayUsageAnalyzer {
 
 		void indexedWrite(ASTNode node) {
 			indexedWrite= true;
+			positionalWrite= true;
 			evidence.add(LocalArrayUsageAnalyzer.evidence(Kind.INDEXED_WRITE,
 					"Existing array position is written by index", node)); //$NON-NLS-1$
 		}
@@ -406,7 +412,7 @@ public final class LocalArrayUsageAnalyzer {
 						seed.identity().sourceStart(), seed.identity().sourceLength()));
 			}
 
-			OrderRequirement order= indexedRead || indexedWrite
+			OrderRequirement order= indexedRead || positionalWrite
 					? OrderRequirement.POSITIONAL
 					: encounterIteration ? OrderRequirement.ENCOUNTER : seed.orderRequirement();
 			EscapeLevel escape= field

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/api/ContainerShape.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/api/ContainerShape.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.container.api;
+
+/**
+ * Structural representation used by a container before or after a semantic migration.
+ *
+ * <p>The shape describes representation only. Ordering, uniqueness, mutability and
+ * concurrency are modelled separately by {@link ContainerUsageProfile}.</p>
+ */
+public enum ContainerShape {
+	ARRAY,
+	LIST,
+	SET,
+	MAP,
+	DEQUE,
+	SYNCHRONIZED_WRAPPER,
+	CONCURRENT_CONTAINER,
+	CUSTOM_BUFFER
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/api/ContainerUsageProfile.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/api/ContainerUsageProfile.java
@@ -1,0 +1,191 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.container.api;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Immutable semantic description of how one connected container value is used.
+ *
+ * <p>A profile is an analysis result, not yet a rewrite decision. In particular,
+ * {@link AnalysisCompleteness#LOCAL_SEED} means that a useful local motif was found
+ * but project-wide data flow, escape and compatibility checks are still outstanding.</p>
+ *
+ * @param identity stable identity and source anchor of the candidate
+ * @param currentShape current structural representation
+ * @param elementDomain known element-domain category
+ * @param access observed access operations
+ * @param orderRequirement ordering required by observed code
+ * @param uniquenessRequirement uniqueness required by observed code
+ * @param mutationLifecycle observed mutation lifecycle
+ * @param nullContract observed null behaviour
+ * @param aliasingContract observed aliasing behaviour
+ * @param escapeLevel widest known escape boundary
+ * @param concurrencyContract observed concurrency behaviour
+ * @param completeness completeness of the semantic proof
+ * @param evidence source-backed observations supporting the profile
+ */
+public record ContainerUsageProfile(
+		ContainerIdentity identity,
+		ContainerShape currentShape,
+		ElementDomain elementDomain,
+		AccessProfile access,
+		OrderRequirement orderRequirement,
+		UniquenessRequirement uniquenessRequirement,
+		MutationLifecycle mutationLifecycle,
+		NullContract nullContract,
+		AliasingContract aliasingContract,
+		EscapeLevel escapeLevel,
+		ConcurrencyContract concurrencyContract,
+		AnalysisCompleteness completeness,
+		List<UsageEvidence> evidence) {
+
+	public ContainerUsageProfile {
+		Objects.requireNonNull(identity, "identity"); //$NON-NLS-1$
+		Objects.requireNonNull(currentShape, "currentShape"); //$NON-NLS-1$
+		Objects.requireNonNull(elementDomain, "elementDomain"); //$NON-NLS-1$
+		Objects.requireNonNull(access, "access"); //$NON-NLS-1$
+		Objects.requireNonNull(orderRequirement, "orderRequirement"); //$NON-NLS-1$
+		Objects.requireNonNull(uniquenessRequirement, "uniquenessRequirement"); //$NON-NLS-1$
+		Objects.requireNonNull(mutationLifecycle, "mutationLifecycle"); //$NON-NLS-1$
+		Objects.requireNonNull(nullContract, "nullContract"); //$NON-NLS-1$
+		Objects.requireNonNull(aliasingContract, "aliasingContract"); //$NON-NLS-1$
+		Objects.requireNonNull(escapeLevel, "escapeLevel"); //$NON-NLS-1$
+		Objects.requireNonNull(concurrencyContract, "concurrencyContract"); //$NON-NLS-1$
+		Objects.requireNonNull(completeness, "completeness"); //$NON-NLS-1$
+		evidence= List.copyOf(Objects.requireNonNull(evidence, "evidence")); //$NON-NLS-1$
+	}
+
+	/** Returns whether a later planner may treat this profile as a complete flow proof. */
+	public boolean isFlowComplete() {
+		return completeness == AnalysisCompleteness.FLOW_COMPLETE;
+	}
+
+	/** Stable identity of the represented value, independent of retained AST nodes. */
+	public record ContainerIdentity(String bindingKey, String displayName, int sourceStart, int sourceLength) {
+
+		public ContainerIdentity {
+			bindingKey= bindingKey == null ? "" : bindingKey; //$NON-NLS-1$
+			displayName= Objects.requireNonNull(displayName, "displayName").strip(); //$NON-NLS-1$
+			if (displayName.isEmpty()) {
+				throw new IllegalArgumentException("displayName must not be empty"); //$NON-NLS-1$
+			}
+			if (sourceStart < 0) {
+				throw new IllegalArgumentException("sourceStart must not be negative"); //$NON-NLS-1$
+			}
+			if (sourceLength < 0) {
+				throw new IllegalArgumentException("sourceLength must not be negative"); //$NON-NLS-1$
+			}
+		}
+
+		/** Returns whether binding resolution supplied a stable key. */
+		public boolean hasResolvedBinding() {
+			return !bindingKey.isBlank();
+		}
+
+		/** Returns a deterministic identifier suitable for reports and maps. */
+		public String stableId() {
+			return hasResolvedBinding() ? bindingKey : displayName + '@' + sourceStart;
+		}
+	}
+
+	/** Operations observed on the represented value. */
+	public record AccessProfile(
+			boolean indexedRead,
+			boolean indexedWrite,
+			boolean append,
+			boolean positionalInsert,
+			boolean positionalRemove,
+			boolean membershipQuery,
+			boolean keyLookup) {
+
+		/** Initial access facts for a syntactically recognised append-only array seed. */
+		public static AccessProfile appendOnlyArraySeed() {
+			return new AccessProfile(false, true, true, false, false, false, false);
+		}
+
+		/** Returns whether position is already part of the observed contract. */
+		public boolean hasPositionalSemantics() {
+			return indexedRead || positionalInsert || positionalRemove;
+		}
+	}
+
+	public enum ElementDomain {
+		REFERENCE,
+		PRIMITIVE,
+		ENUM,
+		UNKNOWN
+	}
+
+	public enum OrderRequirement {
+		NONE,
+		ENCOUNTER,
+		SORTED,
+		POSITIONAL,
+		UNKNOWN
+	}
+
+	public enum UniquenessRequirement {
+		REQUIRED,
+		DUPLICATES_ALLOWED,
+		UNKNOWN
+	}
+
+	public enum MutationLifecycle {
+		FIXED,
+		BUILD_THEN_FREEZE,
+		CONTINUOUSLY_MUTABLE,
+		SNAPSHOT_PUBLISHED,
+		UNKNOWN
+	}
+
+	public enum NullContract {
+		ALLOWED,
+		REJECTED,
+		NOT_APPLICABLE,
+		UNKNOWN
+	}
+
+	public enum AliasingContract {
+		SHARED_MUTATION,
+		DEFENSIVE_COPY,
+		IDENTITY_OBSERVED,
+		NO_OBSERVED_ALIAS,
+		UNKNOWN
+	}
+
+	public enum EscapeLevel {
+		LOCAL,
+		FIELD,
+		METHOD_BOUNDARY,
+		OVERRIDE_FAMILY,
+		EXTERNAL_OR_BINARY,
+		UNKNOWN
+	}
+
+	public enum ConcurrencyContract {
+		THREAD_CONFINED,
+		LOCK_PROTECTED,
+		COPY_ON_WRITE,
+		CONCURRENT_MEMBERSHIP,
+		PRODUCER_CONSUMER,
+		ATOMIC_DRAIN,
+		UNKNOWN
+	}
+
+	public enum AnalysisCompleteness {
+		LOCAL_SEED,
+		LOCAL_USAGE_COMPLETE,
+		FLOW_COMPLETE,
+		REJECTED
+	}
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/api/ContainerUsageProfile.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/api/ContainerUsageProfile.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * @param nullContract observed null behaviour
  * @param aliasingContract observed aliasing behaviour
  * @param escapeLevel widest known escape boundary
- * @param concurrencyContract observed concurrency behaviour
+ * @param concurrency observed concurrency and publication behaviour
  * @param completeness completeness of the semantic proof
  * @param evidence source-backed observations supporting the profile
  */
@@ -45,7 +45,7 @@ public record ContainerUsageProfile(
 		NullContract nullContract,
 		AliasingContract aliasingContract,
 		EscapeLevel escapeLevel,
-		ConcurrencyContract concurrencyContract,
+		ConcurrencyProfile concurrency,
 		AnalysisCompleteness completeness,
 		List<UsageEvidence> evidence) {
 
@@ -60,7 +60,7 @@ public record ContainerUsageProfile(
 		Objects.requireNonNull(nullContract, "nullContract"); //$NON-NLS-1$
 		Objects.requireNonNull(aliasingContract, "aliasingContract"); //$NON-NLS-1$
 		Objects.requireNonNull(escapeLevel, "escapeLevel"); //$NON-NLS-1$
-		Objects.requireNonNull(concurrencyContract, "concurrencyContract"); //$NON-NLS-1$
+		Objects.requireNonNull(concurrency, "concurrency"); //$NON-NLS-1$
 		Objects.requireNonNull(completeness, "completeness"); //$NON-NLS-1$
 		evidence= List.copyOf(Objects.requireNonNull(evidence, "evidence")); //$NON-NLS-1$
 	}
@@ -119,6 +119,33 @@ public record ContainerUsageProfile(
 		}
 	}
 
+	/** Structured concurrency facts; unknown values are preferable to guessed guarantees. */
+	public record ConcurrencyProfile(
+			ThreadExposure exposure,
+			SynchronizationKind synchronization,
+			IterationSemantics iteration,
+			AtomicityRequirement atomicity,
+			WorkloadShape workload) {
+
+		public ConcurrencyProfile {
+			Objects.requireNonNull(exposure, "exposure"); //$NON-NLS-1$
+			Objects.requireNonNull(synchronization, "synchronization"); //$NON-NLS-1$
+			Objects.requireNonNull(iteration, "iteration"); //$NON-NLS-1$
+			Objects.requireNonNull(atomicity, "atomicity"); //$NON-NLS-1$
+			Objects.requireNonNull(workload, "workload"); //$NON-NLS-1$
+		}
+
+		/** Returns a profile that makes no concurrency claim. */
+		public static ConcurrencyProfile unknown() {
+			return new ConcurrencyProfile(
+					ThreadExposure.UNKNOWN,
+					SynchronizationKind.UNKNOWN,
+					IterationSemantics.UNKNOWN,
+					AtomicityRequirement.UNKNOWN,
+					WorkloadShape.UNKNOWN);
+		}
+	}
+
 	public enum ElementDomain {
 		REFERENCE,
 		PRIMITIVE,
@@ -172,13 +199,51 @@ public record ContainerUsageProfile(
 		UNKNOWN
 	}
 
-	public enum ConcurrencyContract {
+	public enum ThreadExposure {
 		THREAD_CONFINED,
-		LOCK_PROTECTED,
+		PUBLISHED,
+		CALLBACK_SHARED,
+		WORKER_SHARED,
+		UNKNOWN
+	}
+
+	public enum SynchronizationKind {
+		NONE,
+		INTRINSIC_LOCK,
+		EXPLICIT_LOCK,
+		SYNCHRONIZED_WRAPPER,
+		VOLATILE_SNAPSHOT,
+		ATOMIC_REFERENCE,
+		CONCURRENT_COLLECTION,
+		UNKNOWN
+	}
+
+	public enum IterationSemantics {
+		LIVE,
+		EXTERNALLY_LOCKED,
+		WEAKLY_CONSISTENT,
+		IMMUTABLE_SNAPSHOT,
 		COPY_ON_WRITE,
-		CONCURRENT_MEMBERSHIP,
+		UNKNOWN
+	}
+
+	public enum AtomicityRequirement {
+		INDIVIDUAL_OPERATIONS,
+		CHECK_THEN_ACT,
+		COMPOUND_UPDATE,
+		DRAIN,
+		REPLACE_ALL,
+		TRANSACTION,
+		UNKNOWN
+	}
+
+	public enum WorkloadShape {
+		READ_MOSTLY,
+		WRITE_MOSTLY,
+		BALANCED,
+		REGISTRATION_HEAVY,
+		NOTIFICATION_HEAVY,
 		PRODUCER_CONSUMER,
-		ATOMIC_DRAIN,
 		UNKNOWN
 	}
 

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/api/TargetContainerContract.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/api/TargetContainerContract.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.container.api;
+
+import java.util.Objects;
+
+import org.sandbox.jdt.container.api.ContainerUsageProfile.NullContract;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.OrderRequirement;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.UniquenessRequirement;
+
+/**
+ * A semantic target contract proposed from a {@link ContainerUsageProfile}.
+ *
+ * <p>The contract intentionally names properties before implementation classes.
+ * A later migration planner may select a concrete implementation only after source
+ * level, compatibility and concurrency checks.</p>
+ *
+ * @param shape proposed structural representation
+ * @param orderRequirement required ordering
+ * @param uniquenessRequirement required uniqueness
+ * @param mutability required publication mutability
+ * @param nullContract required null behaviour
+ * @param rationale concise explanation of the proposal
+ */
+public record TargetContainerContract(
+		ContainerShape shape,
+		OrderRequirement orderRequirement,
+		UniquenessRequirement uniquenessRequirement,
+		Mutability mutability,
+		NullContract nullContract,
+		String rationale) {
+
+	public TargetContainerContract {
+		Objects.requireNonNull(shape, "shape"); //$NON-NLS-1$
+		Objects.requireNonNull(orderRequirement, "orderRequirement"); //$NON-NLS-1$
+		Objects.requireNonNull(uniquenessRequirement, "uniquenessRequirement"); //$NON-NLS-1$
+		Objects.requireNonNull(mutability, "mutability"); //$NON-NLS-1$
+		Objects.requireNonNull(nullContract, "nullContract"); //$NON-NLS-1$
+		rationale= Objects.requireNonNull(rationale, "rationale").strip(); //$NON-NLS-1$
+		if (rationale.isEmpty()) {
+			throw new IllegalArgumentException("rationale must not be empty"); //$NON-NLS-1$
+		}
+	}
+
+	public enum Mutability {
+		MUTABLE,
+		IMMUTABLE,
+		BUILD_THEN_FREEZE,
+		UNKNOWN
+	}
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/api/UsageEvidence.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/api/UsageEvidence.java
@@ -39,11 +39,19 @@ public record UsageEvidence(Kind kind, String summary, int sourceStart, int sour
 		}
 	}
 
-	/** Semantic categories understood by the initial container analysis. */
+	/** Semantic categories understood by container analysis and reporting. */
 	public enum Kind {
 		ARRAY_GROWTH,
 		APPEND_WRITE,
 		REFERENCE_COMPONENT,
+		ARRAY_LENGTH_READ,
+		INDEXED_READ,
+		INDEXED_WRITE,
+		ENCOUNTER_ITERATION,
+		LOCAL_USAGE_COMPLETE,
+		UNSAFE_ESCAPE,
+		ARRAY_IDENTITY,
+		UNCLASSIFIED_USAGE,
 		UNRESOLVED_BINDING,
 		REJECTION_BOUNDARY
 	}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/api/UsageEvidence.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/api/UsageEvidence.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.container.api;
+
+import java.util.Objects;
+
+/**
+ * One source-backed fact contributing to a container usage profile.
+ *
+ * <p>The record deliberately stores only stable scalar data. AST nodes belong to the
+ * parser pass that produced the evidence and must not be retained by a multi-file plan.</p>
+ *
+ * @param kind semantic category of the observation
+ * @param summary concise explanation suitable for reports
+ * @param sourceStart zero-based source offset
+ * @param sourceLength source length in characters
+ */
+public record UsageEvidence(Kind kind, String summary, int sourceStart, int sourceLength) {
+
+	public UsageEvidence {
+		Objects.requireNonNull(kind, "kind"); //$NON-NLS-1$
+		summary= Objects.requireNonNull(summary, "summary").strip(); //$NON-NLS-1$
+		if (summary.isEmpty()) {
+			throw new IllegalArgumentException("summary must not be empty"); //$NON-NLS-1$
+		}
+		if (sourceStart < 0) {
+			throw new IllegalArgumentException("sourceStart must not be negative"); //$NON-NLS-1$
+		}
+		if (sourceLength < 0) {
+			throw new IllegalArgumentException("sourceLength must not be negative"); //$NON-NLS-1$
+		}
+	}
+
+	/** Semantic categories understood by the initial container analysis. */
+	public enum Kind {
+		ARRAY_GROWTH,
+		APPEND_WRITE,
+		REFERENCE_COMPONENT,
+		UNRESOLVED_BINDING,
+		REJECTION_BOUNDARY
+	}
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/internal/common/AstProcessing.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/internal/common/AstProcessing.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.common;
+
+import java.util.Objects;
+
+import org.eclipse.jdt.core.dom.ASTNode;
+
+/**
+ * Entry point for AST processing whose execution model is explicit at the call site.
+ *
+ * <p>{@link #scoped(ReferenceHolder)} creates a semantic pipeline in which every
+ * stage searches only the scope selected by the preceding stage. In contrast,
+ * {@link #independent(ReferenceHolder)} registers visitors that each inspect the
+ * complete root passed to {@code build(...)}.</p>
+ */
+public final class AstProcessing {
+
+	private AstProcessing() {
+		// Static factory.
+	}
+
+	/** Creates an ordered, scoped semantic processing pipeline. */
+	public static <V, T> ScopedAstProcessorBuilder<V, T> scoped(ReferenceHolder<V, T> holder) {
+		return new ScopedAstProcessorBuilder<>(Objects.requireNonNull(holder, "holder")); //$NON-NLS-1$
+	}
+
+	/** Creates a group of visitors that each inspect the complete configured root. */
+	public static <V, T> IndependentAstProcessorBuilder<V, T> independent(ReferenceHolder<V, T> holder) {
+		return new IndependentAstProcessorBuilder<>(Objects.requireNonNull(holder, "holder")); //$NON-NLS-1$
+	}
+
+	static VisitorEnum visitorType(Class<? extends ASTNode> nodeType) {
+		Objects.requireNonNull(nodeType, "nodeType"); //$NON-NLS-1$
+		try {
+			return VisitorEnum.valueOf(nodeType.getSimpleName());
+		} catch (IllegalArgumentException exception) {
+			throw new IllegalArgumentException(
+					"No HelperVisitor dispatch is available for " + nodeType.getName(), exception); //$NON-NLS-1$
+		}
+	}
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/internal/common/IndependentAstProcessorBuilder.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/internal/common/IndependentAstProcessorBuilder.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.common;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.BiPredicate;
+
+import org.eclipse.jdt.core.dom.ASTNode;
+
+/**
+ * Collects independent AST visitors that each inspect the complete root supplied to
+ * {@link #build(ASTNode)}.
+ *
+ * <p>Registration order is deterministic, but one visitor never narrows the scope of
+ * another. Use {@link AstProcessing#scoped(ReferenceHolder)} when later stages are
+ * semantically dependent on an earlier match.</p>
+ *
+ * @param <V> reference-holder key type
+ * @param <T> reference-holder value type
+ */
+public final class IndependentAstProcessorBuilder<V, T> {
+
+	private final ReferenceHolder<V, T> holder;
+	private final List<Stage<V, T>> stages= new ArrayList<>();
+	private Set<ASTNode> excludedNodes= Set.of();
+
+	IndependentAstProcessorBuilder(ReferenceHolder<V, T> holder) {
+		this.holder= holder;
+	}
+
+	/**
+	 * Registers one typed visitor that will inspect the complete build root.
+	 *
+	 * @param <N> AST node type
+	 * @param nodeType node class to visit
+	 * @param handler processing callback; its result controls child traversal
+	 * @return this builder
+	 */
+	public <N extends ASTNode> IndependentAstProcessorBuilder<V, T> on(
+			Class<N> nodeType,
+			BiPredicate<? super N, ReferenceHolder<V, T>> handler) {
+		Objects.requireNonNull(nodeType, "nodeType"); //$NON-NLS-1$
+		Objects.requireNonNull(handler, "handler"); //$NON-NLS-1$
+		VisitorEnum visitorType= AstProcessing.visitorType(nodeType);
+		stages.add(new Stage<>(visitorType,
+				(node, data) -> handler.test(nodeType.cast(node), data)));
+		return this;
+	}
+
+	/**
+	 * Excludes the supplied nodes from every independent visitor traversal.
+	 *
+	 * @param nodes nodes already handled elsewhere
+	 * @return this builder
+	 */
+	public IndependentAstProcessorBuilder<V, T> excluding(Set<? extends ASTNode> nodes) {
+		excludedNodes= Set.copyOf(Objects.requireNonNull(nodes, "nodes")); //$NON-NLS-1$
+		return this;
+	}
+
+	/** Executes every registered visitor independently against {@code root}. */
+	public void build(ASTNode root) {
+		Objects.requireNonNull(root, "root"); //$NON-NLS-1$
+		for (Stage<V, T> stage : stages) {
+			HelperVisitor<ReferenceHolder<V, T>, V, T> visitor=
+					new HelperVisitor<>(new HashSet<>(excludedNodes), holder);
+			visitor.add(stage.visitorType(), stage.handler());
+			visitor.build(root);
+		}
+	}
+
+	private record Stage<V, T>(
+			VisitorEnum visitorType,
+			BiPredicate<ASTNode, ReferenceHolder<V, T>> handler) {
+	}
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/internal/common/ScopedAstProcessorBuilder.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/internal/common/ScopedAstProcessorBuilder.java
@@ -1,0 +1,213 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.common;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.eclipse.jdt.core.dom.ASTNode;
+
+/**
+ * Builds an ordered semantic AST pipeline.
+ *
+ * <p>Each successful stage selects the scope in which the next stage searches. A
+ * stage that finds no matching node ends that branch of the pipeline; later stages
+ * are never retried independently against an earlier scope.</p>
+ *
+ * <p>Matcher, handler, navigation and child traversal are separate concerns. The
+ * matcher decides whether the semantic chain advances. The handler records facts.
+ * Navigation chooses the next search scope. {@link TraversalDecision} controls only
+ * whether the current visitor descends below the matched node.</p>
+ *
+ * @param <V> reference-holder key type
+ * @param <T> reference-holder value type
+ */
+public final class ScopedAstProcessorBuilder<V, T> {
+
+	/** Child-traversal decision for the visitor executing one matched stage. */
+	public enum TraversalDecision {
+		DESCEND,
+		SKIP_CHILDREN
+	}
+
+	private final ReferenceHolder<V, T> holder;
+	private final List<Stage<V, T>> stages= new ArrayList<>();
+	private Set<ASTNode> excludedNodes= Set.of();
+
+	ScopedAstProcessorBuilder(ReferenceHolder<V, T> holder) {
+		this.holder= holder;
+	}
+
+	/**
+	 * Registers the first stage of the scoped pipeline.
+	 *
+	 * @param <N> AST node type
+	 * @param nodeType node class to search
+	 * @param matcher semantic match predicate
+	 * @param handler processing callback
+	 * @param nextScope navigation to the scope for the next stage
+	 * @return this builder
+	 */
+	public <N extends ASTNode> ScopedAstProcessorBuilder<V, T> find(
+			Class<N> nodeType,
+			Predicate<? super N> matcher,
+			BiConsumer<? super N, ReferenceHolder<V, T>> handler,
+			Function<? super N, ? extends ASTNode> nextScope) {
+		if (!stages.isEmpty()) {
+			throw new IllegalStateException("find(...) may only register the first stage"); //$NON-NLS-1$
+		}
+		return addStage(nodeType, matcher, consumerHandler(handler), nextScope);
+	}
+
+	/** Registers the first stage without navigation beyond the matched node. */
+	public <N extends ASTNode> ScopedAstProcessorBuilder<V, T> find(
+			Class<N> nodeType,
+			Predicate<? super N> matcher,
+			BiConsumer<? super N, ReferenceHolder<V, T>> handler) {
+		return find(nodeType, matcher, handler, Function.identity());
+	}
+
+	/**
+	 * Registers a dependent stage searched only in the scope selected by the preceding
+	 * successful stage.
+	 */
+	public <N extends ASTNode> ScopedAstProcessorBuilder<V, T> then(
+			Class<N> nodeType,
+			Predicate<? super N> matcher,
+			BiConsumer<? super N, ReferenceHolder<V, T>> handler,
+			Function<? super N, ? extends ASTNode> nextScope) {
+		requireFirstStage();
+		return addStage(nodeType, matcher, consumerHandler(handler), nextScope);
+	}
+
+	/** Registers a dependent terminal stage. */
+	public <N extends ASTNode> ScopedAstProcessorBuilder<V, T> then(
+			Class<N> nodeType,
+			Predicate<? super N> matcher,
+			BiConsumer<? super N, ReferenceHolder<V, T>> handler) {
+		return then(nodeType, matcher, handler, Function.identity());
+	}
+
+	/**
+	 * Registers the first stage with explicit child-traversal control.
+	 */
+	public <N extends ASTNode> ScopedAstProcessorBuilder<V, T> findWithTraversal(
+			Class<N> nodeType,
+			Predicate<? super N> matcher,
+			BiFunction<? super N, ReferenceHolder<V, T>, TraversalDecision> handler,
+			Function<? super N, ? extends ASTNode> nextScope) {
+		if (!stages.isEmpty()) {
+			throw new IllegalStateException("findWithTraversal(...) may only register the first stage"); //$NON-NLS-1$
+		}
+		return addStage(nodeType, matcher, handler, nextScope);
+	}
+
+	/** Registers a dependent stage with explicit child-traversal control. */
+	public <N extends ASTNode> ScopedAstProcessorBuilder<V, T> thenWithTraversal(
+			Class<N> nodeType,
+			Predicate<? super N> matcher,
+			BiFunction<? super N, ReferenceHolder<V, T>, TraversalDecision> handler,
+			Function<? super N, ? extends ASTNode> nextScope) {
+		requireFirstStage();
+		return addStage(nodeType, matcher, handler, nextScope);
+	}
+
+	/** Applies the same initial exclusion set to every stage traversal. */
+	public ScopedAstProcessorBuilder<V, T> excluding(Set<? extends ASTNode> nodes) {
+		excludedNodes= Set.copyOf(Objects.requireNonNull(nodes, "nodes")); //$NON-NLS-1$
+		return this;
+	}
+
+	/** Executes the scoped pipeline against {@code root}. */
+	public void build(ASTNode root) {
+		Objects.requireNonNull(root, "root"); //$NON-NLS-1$
+		if (stages.isEmpty()) {
+			throw new IllegalStateException("At least one scoped stage is required"); //$NON-NLS-1$
+		}
+		process(root, 0);
+	}
+
+	private void process(ASTNode scope, int stageIndex) {
+		if (scope == null || stageIndex >= stages.size()) {
+			return;
+		}
+
+		Stage<V, T> stage= stages.get(stageIndex);
+		HelperVisitor<ReferenceHolder<V, T>, V, T> visitor=
+				new HelperVisitor<>(new HashSet<>(excludedNodes), holder);
+		visitor.add(stage.visitorType(), (node, data) -> {
+			if (!stage.nodeType().isInstance(node) || !stage.matcher().test(node)) {
+				return true;
+			}
+
+			TraversalDecision traversal= stage.handler().apply(node, data);
+			if (stageIndex + 1 < stages.size()) {
+				ASTNode nextScope= stage.nextScope().apply(node);
+				if (nextScope != null) {
+					process(nextScope, stageIndex + 1);
+				}
+			}
+			return traversal == TraversalDecision.DESCEND;
+		});
+		visitor.build(scope);
+	}
+
+	private <N extends ASTNode> ScopedAstProcessorBuilder<V, T> addStage(
+			Class<N> nodeType,
+			Predicate<? super N> matcher,
+			BiFunction<? super N, ReferenceHolder<V, T>, TraversalDecision> handler,
+			Function<? super N, ? extends ASTNode> nextScope) {
+		Objects.requireNonNull(nodeType, "nodeType"); //$NON-NLS-1$
+		Objects.requireNonNull(matcher, "matcher"); //$NON-NLS-1$
+		Objects.requireNonNull(handler, "handler"); //$NON-NLS-1$
+		Objects.requireNonNull(nextScope, "nextScope"); //$NON-NLS-1$
+		VisitorEnum visitorType= AstProcessing.visitorType(nodeType);
+		stages.add(new Stage<>(
+				nodeType,
+				visitorType,
+				node -> matcher.test(nodeType.cast(node)),
+				(node, data) -> Objects.requireNonNull(
+						handler.apply(nodeType.cast(node), data), "traversalDecision"), //$NON-NLS-1$
+				node -> nextScope.apply(nodeType.cast(node))));
+		return this;
+	}
+
+	private static <N extends ASTNode, V, T>
+			BiFunction<N, ReferenceHolder<V, T>, TraversalDecision> consumerHandler(
+					BiConsumer<? super N, ReferenceHolder<V, T>> handler) {
+		Objects.requireNonNull(handler, "handler"); //$NON-NLS-1$
+		return (node, holder) -> {
+			handler.accept(node, holder);
+			return TraversalDecision.DESCEND;
+		};
+	}
+
+	private void requireFirstStage() {
+		if (stages.isEmpty()) {
+			throw new IllegalStateException("then(...) requires a preceding find(...) stage"); //$NON-NLS-1$
+		}
+	}
+
+	private record Stage<V, T>(
+			Class<? extends ASTNode> nodeType,
+			VisitorEnum visitorType,
+			Predicate<ASTNode> matcher,
+			BiFunction<ASTNode, ReferenceHolder<V, T>, TraversalDecision> handler,
+			Function<ASTNode, ? extends ASTNode> nextScope) {
+	}
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/internal/common/ScopedAstProcessorBuilder.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/internal/common/ScopedAstProcessorBuilder.java
@@ -17,6 +17,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -30,9 +31,10 @@ import org.eclipse.jdt.core.dom.ASTNode;
  * are never retried independently against an earlier scope.</p>
  *
  * <p>Matcher, handler, navigation and child traversal are separate concerns. The
- * matcher decides whether the semantic chain advances. The handler records facts.
- * Navigation chooses the next search scope. {@link TraversalDecision} controls only
- * whether the current visitor descends below the matched node.</p>
+ * matcher decides whether the semantic chain advances and may inspect facts stored by
+ * preceding stages. The handler records facts. Navigation chooses the next search
+ * scope. {@link TraversalDecision} controls only whether the current visitor descends
+ * below the matched node.</p>
  *
  * @param <V> reference-holder key type
  * @param <T> reference-holder value type
@@ -53,19 +55,20 @@ public final class ScopedAstProcessorBuilder<V, T> {
 		this.holder= holder;
 	}
 
-	/**
-	 * Registers the first stage of the scoped pipeline.
-	 *
-	 * @param <N> AST node type
-	 * @param nodeType node class to search
-	 * @param matcher semantic match predicate
-	 * @param handler processing callback
-	 * @param nextScope navigation to the scope for the next stage
-	 * @return this builder
-	 */
+	/** Registers the first state-independent stage of the scoped pipeline. */
 	public <N extends ASTNode> ScopedAstProcessorBuilder<V, T> find(
 			Class<N> nodeType,
 			Predicate<? super N> matcher,
+			BiConsumer<? super N, ReferenceHolder<V, T>> handler,
+			Function<? super N, ? extends ASTNode> nextScope) {
+		Objects.requireNonNull(matcher, "matcher"); //$NON-NLS-1$
+		return find(nodeType, (node, state) -> matcher.test(node), handler, nextScope);
+	}
+
+	/** Registers the first state-aware stage of the scoped pipeline. */
+	public <N extends ASTNode> ScopedAstProcessorBuilder<V, T> find(
+			Class<N> nodeType,
+			BiPredicate<? super N, ReferenceHolder<V, T>> matcher,
 			BiConsumer<? super N, ReferenceHolder<V, T>> handler,
 			Function<? super N, ? extends ASTNode> nextScope) {
 		if (!stages.isEmpty()) {
@@ -74,7 +77,7 @@ public final class ScopedAstProcessorBuilder<V, T> {
 		return addStage(nodeType, matcher, consumerHandler(handler), nextScope);
 	}
 
-	/** Registers the first stage without navigation beyond the matched node. */
+	/** Registers the first state-independent stage without additional navigation. */
 	public <N extends ASTNode> ScopedAstProcessorBuilder<V, T> find(
 			Class<N> nodeType,
 			Predicate<? super N> matcher,
@@ -82,20 +85,38 @@ public final class ScopedAstProcessorBuilder<V, T> {
 		return find(nodeType, matcher, handler, Function.identity());
 	}
 
-	/**
-	 * Registers a dependent stage searched only in the scope selected by the preceding
-	 * successful stage.
-	 */
+	/** Registers the first state-aware stage without additional navigation. */
+	public <N extends ASTNode> ScopedAstProcessorBuilder<V, T> find(
+			Class<N> nodeType,
+			BiPredicate<? super N, ReferenceHolder<V, T>> matcher,
+			BiConsumer<? super N, ReferenceHolder<V, T>> handler) {
+		return find(nodeType, matcher, handler, Function.identity());
+	}
+
+	/** Registers a state-independent dependent stage. */
 	public <N extends ASTNode> ScopedAstProcessorBuilder<V, T> then(
 			Class<N> nodeType,
 			Predicate<? super N> matcher,
+			BiConsumer<? super N, ReferenceHolder<V, T>> handler,
+			Function<? super N, ? extends ASTNode> nextScope) {
+		Objects.requireNonNull(matcher, "matcher"); //$NON-NLS-1$
+		return then(nodeType, (node, state) -> matcher.test(node), handler, nextScope);
+	}
+
+	/**
+	 * Registers a state-aware dependent stage searched only in the scope selected by
+	 * the preceding successful stage.
+	 */
+	public <N extends ASTNode> ScopedAstProcessorBuilder<V, T> then(
+			Class<N> nodeType,
+			BiPredicate<? super N, ReferenceHolder<V, T>> matcher,
 			BiConsumer<? super N, ReferenceHolder<V, T>> handler,
 			Function<? super N, ? extends ASTNode> nextScope) {
 		requireFirstStage();
 		return addStage(nodeType, matcher, consumerHandler(handler), nextScope);
 	}
 
-	/** Registers a dependent terminal stage. */
+	/** Registers a state-independent dependent terminal stage. */
 	public <N extends ASTNode> ScopedAstProcessorBuilder<V, T> then(
 			Class<N> nodeType,
 			Predicate<? super N> matcher,
@@ -103,12 +124,28 @@ public final class ScopedAstProcessorBuilder<V, T> {
 		return then(nodeType, matcher, handler, Function.identity());
 	}
 
-	/**
-	 * Registers the first stage with explicit child-traversal control.
-	 */
+	/** Registers a state-aware dependent terminal stage. */
+	public <N extends ASTNode> ScopedAstProcessorBuilder<V, T> then(
+			Class<N> nodeType,
+			BiPredicate<? super N, ReferenceHolder<V, T>> matcher,
+			BiConsumer<? super N, ReferenceHolder<V, T>> handler) {
+		return then(nodeType, matcher, handler, Function.identity());
+	}
+
+	/** Registers the first state-independent stage with child-traversal control. */
 	public <N extends ASTNode> ScopedAstProcessorBuilder<V, T> findWithTraversal(
 			Class<N> nodeType,
 			Predicate<? super N> matcher,
+			BiFunction<? super N, ReferenceHolder<V, T>, TraversalDecision> handler,
+			Function<? super N, ? extends ASTNode> nextScope) {
+		Objects.requireNonNull(matcher, "matcher"); //$NON-NLS-1$
+		return findWithTraversal(nodeType, (node, state) -> matcher.test(node), handler, nextScope);
+	}
+
+	/** Registers the first state-aware stage with child-traversal control. */
+	public <N extends ASTNode> ScopedAstProcessorBuilder<V, T> findWithTraversal(
+			Class<N> nodeType,
+			BiPredicate<? super N, ReferenceHolder<V, T>> matcher,
 			BiFunction<? super N, ReferenceHolder<V, T>, TraversalDecision> handler,
 			Function<? super N, ? extends ASTNode> nextScope) {
 		if (!stages.isEmpty()) {
@@ -117,10 +154,20 @@ public final class ScopedAstProcessorBuilder<V, T> {
 		return addStage(nodeType, matcher, handler, nextScope);
 	}
 
-	/** Registers a dependent stage with explicit child-traversal control. */
+	/** Registers a state-independent dependent stage with traversal control. */
 	public <N extends ASTNode> ScopedAstProcessorBuilder<V, T> thenWithTraversal(
 			Class<N> nodeType,
 			Predicate<? super N> matcher,
+			BiFunction<? super N, ReferenceHolder<V, T>, TraversalDecision> handler,
+			Function<? super N, ? extends ASTNode> nextScope) {
+		Objects.requireNonNull(matcher, "matcher"); //$NON-NLS-1$
+		return thenWithTraversal(nodeType, (node, state) -> matcher.test(node), handler, nextScope);
+	}
+
+	/** Registers a state-aware dependent stage with traversal control. */
+	public <N extends ASTNode> ScopedAstProcessorBuilder<V, T> thenWithTraversal(
+			Class<N> nodeType,
+			BiPredicate<? super N, ReferenceHolder<V, T>> matcher,
 			BiFunction<? super N, ReferenceHolder<V, T>, TraversalDecision> handler,
 			Function<? super N, ? extends ASTNode> nextScope) {
 		requireFirstStage();
@@ -151,7 +198,7 @@ public final class ScopedAstProcessorBuilder<V, T> {
 		HelperVisitor<ReferenceHolder<V, T>, V, T> visitor=
 				new HelperVisitor<>(new HashSet<>(excludedNodes), holder);
 		visitor.add(stage.visitorType(), (node, data) -> {
-			if (!stage.nodeType().isInstance(node) || !stage.matcher().test(node)) {
+			if (!stage.nodeType().isInstance(node) || !stage.matcher().test(node, data)) {
 				return true;
 			}
 
@@ -169,7 +216,7 @@ public final class ScopedAstProcessorBuilder<V, T> {
 
 	private <N extends ASTNode> ScopedAstProcessorBuilder<V, T> addStage(
 			Class<N> nodeType,
-			Predicate<? super N> matcher,
+			BiPredicate<? super N, ReferenceHolder<V, T>> matcher,
 			BiFunction<? super N, ReferenceHolder<V, T>, TraversalDecision> handler,
 			Function<? super N, ? extends ASTNode> nextScope) {
 		Objects.requireNonNull(nodeType, "nodeType"); //$NON-NLS-1$
@@ -180,7 +227,7 @@ public final class ScopedAstProcessorBuilder<V, T> {
 		stages.add(new Stage<>(
 				nodeType,
 				visitorType,
-				node -> matcher.test(nodeType.cast(node)),
+				(node, state) -> matcher.test(nodeType.cast(node), state),
 				(node, data) -> Objects.requireNonNull(
 						handler.apply(nodeType.cast(node), data), "traversalDecision"), //$NON-NLS-1$
 				node -> nextScope.apply(nodeType.cast(node))));
@@ -206,7 +253,7 @@ public final class ScopedAstProcessorBuilder<V, T> {
 	private record Stage<V, T>(
 			Class<? extends ASTNode> nodeType,
 			VisitorEnum visitorType,
-			Predicate<ASTNode> matcher,
+			BiPredicate<ASTNode, ReferenceHolder<V, T>> matcher,
 			BiFunction<ASTNode, ReferenceHolder<V, T>, TraversalDecision> handler,
 			Function<ASTNode, ? extends ASTNode> nextScope) {
 	}

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/container/analysis/AppendOnlyArraySeedDetectorTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/container/analysis/AppendOnlyArraySeedDetectorTest.java
@@ -1,0 +1,154 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.container.analysis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.junit.jupiter.api.Test;
+import org.sandbox.jdt.container.api.ContainerShape;
+import org.sandbox.jdt.container.api.ContainerUsageProfile;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.AnalysisCompleteness;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.ElementDomain;
+import org.sandbox.jdt.container.api.UsageEvidence.Kind;
+
+class AppendOnlyArraySeedDetectorTest {
+
+	private final AppendOnlyArraySeedDetector detector= new AppendOnlyArraySeedDetector();
+
+	@Test
+	void detectsReferenceArrayGrowthFollowedByTailWrite() {
+		CompilationUnit compilationUnit= parse("""
+			import java.util.Arrays;
+
+			class Sample {
+				void append(String value) {
+					String[] values = new String[0];
+					values = Arrays.copyOf(values, values.length + 1);
+					values[values.length - 1] = value;
+				}
+			}
+			""");
+
+		List<ContainerUsageProfile> profiles= detector.findSeeds(compilationUnit);
+
+		assertEquals(1, profiles.size());
+		ContainerUsageProfile profile= profiles.get(0);
+		assertEquals(ContainerShape.ARRAY, profile.currentShape());
+		assertEquals(ElementDomain.REFERENCE, profile.elementDomain());
+		assertEquals(AnalysisCompleteness.LOCAL_SEED, profile.completeness());
+		assertTrue(profile.access().append());
+		assertTrue(profile.access().indexedWrite());
+		assertFalse(profile.isFlowComplete());
+		assertEquals(List.of(Kind.ARRAY_GROWTH, Kind.APPEND_WRITE, Kind.REFERENCE_COMPONENT),
+				profile.evidence().stream().map(evidence -> evidence.kind()).toList());
+		assertThrows(UnsupportedOperationException.class,
+				() -> profile.evidence().add(profile.evidence().get(0)));
+	}
+
+	@Test
+	void ignoresPrimitiveArrays() {
+		CompilationUnit compilationUnit= parse("""
+			import java.util.Arrays;
+
+			class Sample {
+				void append(int value) {
+					int[] values = new int[0];
+					values = Arrays.copyOf(values, values.length + 1);
+					values[values.length - 1] = value;
+				}
+			}
+			""");
+
+		assertTrue(detector.findSeeds(compilationUnit).isEmpty());
+	}
+
+	@Test
+	void ignoresWriteToExistingPosition() {
+		CompilationUnit compilationUnit= parse("""
+			import java.util.Arrays;
+
+			class Sample {
+				void append(String value) {
+					String[] values = new String[0];
+					values = Arrays.copyOf(values, values.length + 1);
+					values[0] = value;
+				}
+			}
+			""");
+
+		assertTrue(detector.findSeeds(compilationUnit).isEmpty());
+	}
+
+	@Test
+	void ignoresTailWriteToDifferentArray() {
+		CompilationUnit compilationUnit= parse("""
+			import java.util.Arrays;
+
+			class Sample {
+				void append(String value) {
+					String[] values = new String[0];
+					String[] other = new String[1];
+					values = Arrays.copyOf(values, values.length + 1);
+					other[other.length - 1] = value;
+				}
+			}
+			""");
+
+		assertTrue(detector.findSeeds(compilationUnit).isEmpty());
+	}
+
+	@Test
+	void returnsCandidatesInSourceOrder() {
+		CompilationUnit compilationUnit= parse("""
+			import java.util.Arrays;
+
+			class Sample {
+				void appendFirst(String value) {
+					String[] first = new String[0];
+					first = Arrays.copyOf(first, first.length + 1);
+					first[first.length - 1] = value;
+				}
+
+				void appendSecond(Object value) {
+					Object[] second = new Object[0];
+					second = Arrays.copyOf(second, 1 + second.length);
+					second[second.length - 1] = value;
+				}
+			}
+			""");
+
+		List<ContainerUsageProfile> profiles= detector.findSeeds(compilationUnit);
+
+		assertEquals(List.of("first", "second"),
+				profiles.stream().map(profile -> profile.identity().displayName()).toList());
+		assertTrue(profiles.get(0).identity().sourceStart() < profiles.get(1).identity().sourceStart());
+	}
+
+	private static CompilationUnit parse(String source) {
+		ASTParser parser= ASTParser.newParser(AST.getJLSLatest());
+		parser.setSource(source.toCharArray());
+		parser.setKind(ASTParser.K_COMPILATION_UNIT);
+		parser.setResolveBindings(true);
+		parser.setBindingsRecovery(true);
+		parser.setStatementsRecovery(true);
+		parser.setUnitName("Sample.java"); //$NON-NLS-1$
+		parser.setEnvironment(new String[0], new String[0], new String[0], true);
+		return (CompilationUnit) parser.createAST(null);
+	}
+}

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/container/analysis/AppendOnlyArraySeedDetectorTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/container/analysis/AppendOnlyArraySeedDetectorTest.java
@@ -62,6 +62,28 @@ class AppendOnlyArraySeedDetectorTest {
 	}
 
 	@Test
+	void detectsExplicitFieldAccess() {
+		CompilationUnit compilationUnit= parse("""
+			import java.util.Arrays;
+
+			class Sample {
+				private String[] values = new String[0];
+
+				void append(String value) {
+					this.values = Arrays.copyOf(this.values, this.values.length + 1);
+					this.values[this.values.length - 1] = value;
+				}
+			}
+			""");
+
+		List<ContainerUsageProfile> profiles= detector.findSeeds(compilationUnit);
+
+		assertEquals(1, profiles.size());
+		assertEquals("this.values", profiles.get(0).identity().displayName());
+		assertTrue(profiles.get(0).identity().hasResolvedBinding());
+	}
+
+	@Test
 	void ignoresPrimitiveArrays() {
 		CompilationUnit compilationUnit= parse("""
 			import java.util.Arrays;
@@ -106,6 +128,27 @@ class AppendOnlyArraySeedDetectorTest {
 					String[] other = new String[1];
 					values = Arrays.copyOf(values, values.length + 1);
 					other[other.length - 1] = value;
+				}
+			}
+			""");
+
+		assertTrue(detector.findSeeds(compilationUnit).isEmpty());
+	}
+
+	@Test
+	void ignoresSameNamedCopyMethodFromAnotherType() {
+		CompilationUnit compilationUnit= parse("""
+			class Arrays {
+				static String[] copyOf(String[] source, int length) {
+					return source;
+				}
+			}
+
+			class Sample {
+				void append(String value) {
+					String[] values = new String[0];
+					values = Arrays.copyOf(values, values.length + 1);
+					values[values.length - 1] = value;
 				}
 			}
 			""");

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/container/analysis/LocalArrayUsageAnalyzerTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/container/analysis/LocalArrayUsageAnalyzerTest.java
@@ -1,0 +1,195 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.container.analysis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.junit.jupiter.api.Test;
+import org.sandbox.jdt.container.api.ContainerUsageProfile;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.AliasingContract;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.AnalysisCompleteness;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.EscapeLevel;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.OrderRequirement;
+import org.sandbox.jdt.container.api.UsageEvidence.Kind;
+
+class LocalArrayUsageAnalyzerTest {
+
+	private final AppendOnlyArraySeedDetector seedDetector= new AppendOnlyArraySeedDetector();
+	private final LocalArrayUsageAnalyzer analyzer= new LocalArrayUsageAnalyzer();
+
+	@Test
+	void completesLocalAppendAndEncounterIteration() {
+		ContainerUsageProfile profile= analyze("""
+			import java.util.Arrays;
+			class Sample {
+				void collect(String value) {
+					String[] values = new String[0];
+					values = Arrays.copyOf(values, values.length + 1);
+					values[values.length - 1] = value;
+					for (String current : values) {
+						System.out.println(current);
+					}
+				}
+			}
+			""");
+
+		assertEquals(AnalysisCompleteness.LOCAL_USAGE_COMPLETE, profile.completeness());
+		assertEquals(OrderRequirement.ENCOUNTER, profile.orderRequirement());
+		assertEquals(EscapeLevel.LOCAL, profile.escapeLevel());
+		assertEquals(AliasingContract.NO_OBSERVED_ALIAS, profile.aliasingContract());
+		assertTrue(hasEvidence(profile, Kind.ENCOUNTER_ITERATION));
+		assertTrue(hasEvidence(profile, Kind.LOCAL_USAGE_COMPLETE));
+		assertFalse(hasEvidence(profile, Kind.REJECTION_BOUNDARY));
+	}
+
+	@Test
+	void recordsPositionalContractForIndexedRead() {
+		ContainerUsageProfile profile= analyze("""
+			import java.util.Arrays;
+			class Sample {
+				String collect(String value) {
+					String[] values = new String[0];
+					values = Arrays.copyOf(values, values.length + 1);
+					values[values.length - 1] = value;
+					return values[0];
+				}
+			}
+			""");
+
+		assertEquals(AnalysisCompleteness.LOCAL_USAGE_COMPLETE, profile.completeness());
+		assertEquals(OrderRequirement.POSITIONAL, profile.orderRequirement());
+		assertTrue(profile.access().indexedRead());
+		assertTrue(hasEvidence(profile, Kind.INDEXED_READ));
+	}
+
+	@Test
+	void rejectsMethodArgumentEscape() {
+		ContainerUsageProfile profile= analyze("""
+			import java.util.Arrays;
+			class Sample {
+				void collect(String value) {
+					String[] values = new String[0];
+					values = Arrays.copyOf(values, values.length + 1);
+					values[values.length - 1] = value;
+					consume(values);
+				}
+				void consume(String[] values) { }
+			}
+			""");
+
+		assertEquals(AnalysisCompleteness.REJECTED, profile.completeness());
+		assertTrue(hasEvidence(profile, Kind.UNSAFE_ESCAPE));
+	}
+
+	@Test
+	void rejectsReturnEscape() {
+		ContainerUsageProfile profile= analyze("""
+			import java.util.Arrays;
+			class Sample {
+				String[] collect(String value) {
+					String[] values = new String[0];
+					values = Arrays.copyOf(values, values.length + 1);
+					values[values.length - 1] = value;
+					return values;
+				}
+			}
+			""");
+
+		assertEquals(AnalysisCompleteness.REJECTED, profile.completeness());
+		assertTrue(hasEvidence(profile, Kind.UNSAFE_ESCAPE));
+	}
+
+	@Test
+	void rejectsAliasCreation() {
+		ContainerUsageProfile profile= analyze("""
+			import java.util.Arrays;
+			class Sample {
+				void collect(String value) {
+					String[] values = new String[0];
+					values = Arrays.copyOf(values, values.length + 1);
+					values[values.length - 1] = value;
+					String[] alias = values;
+					System.out.println(alias.length);
+				}
+			}
+			""");
+
+		assertEquals(AnalysisCompleteness.REJECTED, profile.completeness());
+		assertTrue(hasEvidence(profile, Kind.UNSAFE_ESCAPE)
+				|| hasEvidence(profile, Kind.UNCLASSIFIED_USAGE));
+	}
+
+	@Test
+	void rejectsArrayIdentityComparison() {
+		ContainerUsageProfile profile= analyze("""
+			import java.util.Arrays;
+			class Sample {
+				boolean collect(String value, String[] other) {
+					String[] values = new String[0];
+					values = Arrays.copyOf(values, values.length + 1);
+					values[values.length - 1] = value;
+					return values == other;
+				}
+			}
+			""");
+
+		assertEquals(AnalysisCompleteness.REJECTED, profile.completeness());
+		assertTrue(hasEvidence(profile, Kind.ARRAY_IDENTITY));
+	}
+
+	@Test
+	void reportsFieldBoundaryWithoutRejectingClosedLocalUses() {
+		ContainerUsageProfile profile= analyze("""
+			import java.util.Arrays;
+			class Sample {
+				private String[] values = new String[0];
+				void collect(String value) {
+					this.values = Arrays.copyOf(this.values, this.values.length + 1);
+					this.values[this.values.length - 1] = value;
+					for (String current : this.values) {
+						System.out.println(current);
+					}
+				}
+			}
+			""");
+
+		assertEquals(AnalysisCompleteness.LOCAL_USAGE_COMPLETE, profile.completeness());
+		assertEquals(EscapeLevel.FIELD, profile.escapeLevel());
+		assertEquals(OrderRequirement.ENCOUNTER, profile.orderRequirement());
+	}
+
+	private ContainerUsageProfile analyze(String source) {
+		CompilationUnit unit= parse(source);
+		ContainerUsageProfile seed= seedDetector.findSeeds(unit).get(0);
+		return analyzer.analyze(unit, seed);
+	}
+
+	private static boolean hasEvidence(ContainerUsageProfile profile, Kind kind) {
+		return profile.evidence().stream().anyMatch(evidence -> evidence.kind() == kind);
+	}
+
+	private static CompilationUnit parse(String source) {
+		ASTParser parser= ASTParser.newParser(AST.getJLSLatest());
+		parser.setSource(source.toCharArray());
+		parser.setKind(ASTParser.K_COMPILATION_UNIT);
+		parser.setResolveBindings(true);
+		parser.setBindingsRecovery(true);
+		parser.setStatementsRecovery(true);
+		parser.setUnitName("Sample.java"); //$NON-NLS-1$
+		parser.setEnvironment(new String[0], new String[0], new String[0], true);
+		return (CompilationUnit) parser.createAST(null);
+	}
+}

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/internal/common/ExplicitAstProcessingTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/internal/common/ExplicitAstProcessingTest.java
@@ -1,0 +1,262 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.ArrayAccess;
+import org.eclipse.jdt.core.dom.Assignment;
+import org.eclipse.jdt.core.dom.Block;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.FieldDeclaration;
+import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.Statement;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.junit.jupiter.api.Test;
+
+class ExplicitAstProcessingTest {
+
+	@Test
+	void scopedPipelineNavigatesFromInvocationToFollowingArrayAccess() {
+		CompilationUnit unit= parse("""
+			import java.util.Arrays;
+			class Sample {
+				void append(String value) {
+					String[] values = new String[0];
+					values = Arrays.copyOf(values, values.length + 1);
+					values[values.length - 1] = value;
+				}
+			}
+			""");
+		AtomicInteger matches= new AtomicInteger();
+
+		AstProcessing.scoped(ReferenceHolder.<String, Object>create())
+				.find(MethodInvocation.class,
+						invocation -> "copyOf".equals(invocation.getName().getIdentifier()), //$NON-NLS-1$
+						(invocation, holder) -> holder.put("growth", invocation), //$NON-NLS-1$
+						ExplicitAstProcessingTest::followingStatement)
+				.then(ArrayAccess.class,
+						access -> true,
+						(access, holder) -> matches.incrementAndGet())
+				.build(unit);
+
+		assertEquals(1, matches.get());
+	}
+
+	@Test
+	void scopedPipelineAllowsRepeatedNodeTypes() {
+		CompilationUnit unit= parse("""
+			class Sample {
+				void update(int first, int second) {
+					int a;
+					int b;
+					a = first;
+					b = second;
+				}
+			}
+			""");
+		AtomicInteger matches= new AtomicInteger();
+
+		AstProcessing.scoped(ReferenceHolder.<String, Object>create())
+				.find(Assignment.class,
+						assignment -> hasLeftHandName(assignment, "a"), //$NON-NLS-1$
+						(assignment, holder) -> { },
+						ExplicitAstProcessingTest::followingStatement)
+				.then(Assignment.class,
+						assignment -> hasLeftHandName(assignment, "b"), //$NON-NLS-1$
+						(assignment, holder) -> matches.incrementAndGet())
+				.build(unit);
+
+		assertEquals(1, matches.get());
+	}
+
+	@Test
+	void failedScopedMatcherDoesNotAdvance() {
+		CompilationUnit unit= parse("""
+			class Sample {
+				void run() {
+					int a;
+					int b;
+					a = 1;
+					b = 2;
+				}
+			}
+			""");
+		AtomicInteger laterStageCalls= new AtomicInteger();
+
+		AstProcessing.scoped(ReferenceHolder.<String, Object>create())
+				.find(Assignment.class,
+						assignment -> false,
+						(assignment, holder) -> { },
+						ExplicitAstProcessingTest::followingStatement)
+				.then(Assignment.class,
+						assignment -> true,
+						(assignment, holder) -> laterStageCalls.incrementAndGet())
+				.build(unit);
+
+		assertEquals(0, laterStageCalls.get());
+	}
+
+	@Test
+	void nullNavigationEndsOnlyThatScopedBranch() {
+		CompilationUnit unit= parse("""
+			class Sample {
+				void run() {
+					int a;
+					a = 1;
+				}
+			}
+			""");
+		AtomicInteger laterStageCalls= new AtomicInteger();
+
+		AstProcessing.scoped(ReferenceHolder.<String, Object>create())
+				.find(Assignment.class,
+						assignment -> true,
+						(assignment, holder) -> { },
+						assignment -> null)
+				.then(Assignment.class,
+						assignment -> true,
+						(assignment, holder) -> laterStageCalls.incrementAndGet())
+				.build(unit);
+
+		assertEquals(0, laterStageCalls.get());
+	}
+
+	@Test
+	void everyFirstStageMatchGetsItsOwnScopedContinuation() {
+		CompilationUnit unit= parse("""
+			import java.util.Arrays;
+			class Sample {
+				void appendFirst(String value) {
+					String[] first = new String[0];
+					first = Arrays.copyOf(first, first.length + 1);
+					first[first.length - 1] = value;
+				}
+				void appendSecond(String value) {
+					String[] second = new String[0];
+					second = Arrays.copyOf(second, second.length + 1);
+					second[second.length - 1] = value;
+				}
+			}
+			""");
+		AtomicInteger continuations= new AtomicInteger();
+
+		AstProcessing.scoped(ReferenceHolder.<String, Object>create())
+				.find(MethodInvocation.class,
+						invocation -> "copyOf".equals(invocation.getName().getIdentifier()), //$NON-NLS-1$
+						(invocation, holder) -> { },
+						ExplicitAstProcessingTest::followingStatement)
+				.then(ArrayAccess.class,
+						access -> true,
+						(access, holder) -> continuations.incrementAndGet())
+				.build(unit);
+
+		assertEquals(2, continuations.get());
+	}
+
+	@Test
+	void independentVisitorsEachInspectTheCompleteRoot() {
+		CompilationUnit unit= parse("""
+			class Sample {
+				int first;
+				int second;
+			}
+			""");
+		AtomicInteger types= new AtomicInteger();
+		AtomicInteger fields= new AtomicInteger();
+
+		AstProcessing.independent(ReferenceHolder.<String, Object>create())
+				.on(TypeDeclaration.class, (type, holder) -> {
+					types.incrementAndGet();
+					return true;
+				})
+				.on(FieldDeclaration.class, (field, holder) -> {
+					fields.incrementAndGet();
+					return true;
+				})
+				.build(unit);
+
+		assertEquals(1, types.get());
+		assertEquals(2, fields.get());
+	}
+
+	@Test
+	void independentVisitorsAllowRepeatedNodeTypes() {
+		CompilationUnit unit= parse("""
+			class Sample {
+				void run() {
+					System.out.println("one");
+					System.out.println("two");
+				}
+			}
+			""");
+		AtomicInteger firstVisitor= new AtomicInteger();
+		AtomicInteger secondVisitor= new AtomicInteger();
+
+		AstProcessing.independent(ReferenceHolder.<String, Object>create())
+				.on(MethodInvocation.class, (invocation, holder) -> {
+					firstVisitor.incrementAndGet();
+					return true;
+				})
+				.on(MethodInvocation.class, (invocation, holder) -> {
+					secondVisitor.incrementAndGet();
+					return true;
+				})
+				.build(unit);
+
+		assertEquals(2, firstVisitor.get());
+		assertEquals(2, secondVisitor.get());
+	}
+
+	private static boolean hasLeftHandName(Assignment assignment, String expectedName) {
+		return assignment.getLeftHandSide() instanceof SimpleName name
+				&& expectedName.equals(name.getIdentifier());
+	}
+
+	private static ASTNode followingStatement(ASTNode node) {
+		Statement statement= containingStatement(node);
+		if (statement == null || !(statement.getParent() instanceof Block block)) {
+			return null;
+		}
+		List<?> statements= block.statements();
+		int index= statements.indexOf(statement);
+		return index >= 0 && index + 1 < statements.size()
+				? (ASTNode) statements.get(index + 1)
+				: null;
+	}
+
+	private static Statement containingStatement(ASTNode node) {
+		ASTNode current= node;
+		while (current != null && !(current instanceof Statement)) {
+			current= current.getParent();
+		}
+		return (Statement) current;
+	}
+
+	private static CompilationUnit parse(String source) {
+		ASTParser parser= ASTParser.newParser(AST.getJLSLatest());
+		parser.setSource(source.toCharArray());
+		parser.setKind(ASTParser.K_COMPILATION_UNIT);
+		parser.setResolveBindings(true);
+		parser.setBindingsRecovery(true);
+		parser.setStatementsRecovery(true);
+		parser.setUnitName("Sample.java"); //$NON-NLS-1$
+		parser.setEnvironment(new String[0], new String[0], new String[0], true);
+		return (CompilationUnit) parser.createAST(null);
+	}
+}

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/internal/common/ScopedAstProcessingSemanticsTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/internal/common/ScopedAstProcessingSemanticsTest.java
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.internal.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.sandbox.jdt.internal.common.ScopedAstProcessorBuilder.TraversalDecision.SKIP_CHILDREN;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.Assignment;
+import org.eclipse.jdt.core.dom.Block;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.Statement;
+import org.junit.jupiter.api.Test;
+
+class ScopedAstProcessingSemanticsTest {
+
+	@Test
+	void childTraversalDecisionDoesNotControlPipelineAdvancement() {
+		CompilationUnit unit= parseAssignments();
+		AtomicInteger laterStageCalls= new AtomicInteger();
+
+		AstProcessing.scoped(ReferenceHolder.<String, Object>create())
+				.findWithTraversal(Assignment.class,
+						assignment -> hasLeftHandName(assignment, "a"), //$NON-NLS-1$
+						(assignment, holder) -> SKIP_CHILDREN,
+						ScopedAstProcessingSemanticsTest::followingStatement)
+				.then(Assignment.class,
+						assignment -> hasLeftHandName(assignment, "b"), //$NON-NLS-1$
+						(assignment, holder) -> laterStageCalls.incrementAndGet())
+				.build(unit);
+
+		assertEquals(1, laterStageCalls.get());
+	}
+
+	@Test
+	void laterMatcherCanReadFactsFromEarlierStage() {
+		CompilationUnit unit= parseAssignments();
+		ReferenceHolder<String, Object> state= ReferenceHolder.create();
+		AtomicInteger matches= new AtomicInteger();
+
+		AstProcessing.scoped(state)
+				.find(Assignment.class,
+						assignment -> hasLeftHandName(assignment, "a"), //$NON-NLS-1$
+						(assignment, holder) -> holder.put("nextName", "b"), //$NON-NLS-1$ //$NON-NLS-2$
+						ScopedAstProcessingSemanticsTest::followingStatement)
+				.then(Assignment.class,
+						(assignment, holder) -> hasLeftHandName(
+								assignment, (String) holder.get("nextName")), //$NON-NLS-1$
+						(assignment, holder) -> matches.incrementAndGet())
+				.build(unit);
+
+		assertEquals(1, matches.get());
+	}
+
+	private static CompilationUnit parseAssignments() {
+		return parse("""
+			class Sample {
+				void update(int first, int second) {
+					int a;
+					int b;
+					a = first;
+					b = second;
+				}
+			}
+			""");
+	}
+
+	private static boolean hasLeftHandName(Assignment assignment, String expectedName) {
+		return assignment.getLeftHandSide() instanceof SimpleName name
+				&& expectedName.equals(name.getIdentifier());
+	}
+
+	private static ASTNode followingStatement(ASTNode node) {
+		Statement statement= containingStatement(node);
+		if (statement == null || !(statement.getParent() instanceof Block block)) {
+			return null;
+		}
+		List<?> statements= block.statements();
+		int index= statements.indexOf(statement);
+		return index >= 0 && index + 1 < statements.size()
+				? (ASTNode) statements.get(index + 1)
+				: null;
+	}
+
+	private static Statement containingStatement(ASTNode node) {
+		ASTNode current= node;
+		while (current != null && !(current instanceof Statement)) {
+			current= current.getParent();
+		}
+		return (Statement) current;
+	}
+
+	private static CompilationUnit parse(String source) {
+		ASTParser parser= ASTParser.newParser(AST.getJLSLatest());
+		parser.setSource(source.toCharArray());
+		parser.setKind(ASTParser.K_COMPILATION_UNIT);
+		parser.setResolveBindings(true);
+		parser.setBindingsRecovery(true);
+		parser.setStatementsRecovery(true);
+		parser.setUnitName("Sample.java"); //$NON-NLS-1$
+		parser.setEnvironment(new String[0], new String[0], new String[0], true);
+		return (CompilationUnit) parser.createAST(null);
+	}
+}


### PR DESCRIPTION
## Summary

Continues #1379 as a stacked slice on top of #1386.

- adds `LocalArrayUsageAnalyzer` for binding-resolved array candidates;
- upgrades a `LOCAL_SEED` to `LOCAL_USAGE_COMPLETE` only when every use in the compilation unit is classified;
- recognises declarations, the proven growth assignment, tail append, `length`, indexed reads/writes and enhanced-for iteration;
- distinguishes tail append from a genuinely positional write contract;
- records local, field and parameter escape levels;
- records `NO_OBSERVED_ALIAS` only after a complete local proof;
- rejects method arguments, returns, aliases, identity comparisons, synchronization monitors, type operations and unknown contexts with source-backed evidence;
- retains no AST nodes in the resulting profile.

## Reuse

The analyzer uses the explicit independent AST processing mode from #1386 and follows the binding-key/fail-closed approach already used by `TypeWideningAnalyzer`.

## Tests

Covers:

- local append plus encounter-order iteration;
- indexed reads producing a positional contract;
- method-argument escape;
- return escape;
- alias creation;
- array identity comparison;
- field boundary with otherwise closed local uses.

## Stacking

This PR targets `feature/explicit-ast-processing-modes`. After #1383 and #1386 merge, it can be retargeted to `main`.

Refs #1379
Refs #1378