### PR TITLE
Infer explainable container target contracts

### DIFF
--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/ContainerContractInferrer.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/ContainerContractInferrer.java
@@ -1,0 +1,137 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.container.analysis;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.sandbox.jdt.container.api.ContainerRecommendation;
+import org.sandbox.jdt.container.api.ContainerRecommendation.AutomationLevel;
+import org.sandbox.jdt.container.api.ContainerRecommendation.Confidence;
+import org.sandbox.jdt.container.api.ContainerRecommendation.ContractAssessment;
+import org.sandbox.jdt.container.api.ContainerRecommendation.ContractProperty;
+import org.sandbox.jdt.container.api.ContainerRecommendation.Preservation;
+import org.sandbox.jdt.container.api.ContainerShape;
+import org.sandbox.jdt.container.api.ContainerUsageProfile;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.AnalysisCompleteness;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.ElementDomain;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.NullContract;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.OrderRequirement;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.UniquenessRequirement;
+import org.sandbox.jdt.container.api.TargetContainerContract;
+import org.sandbox.jdt.container.api.TargetContainerContract.Mutability;
+
+/**
+ * Produces explainable semantic target contracts without creating source edits.
+ */
+public final class ContainerContractInferrer {
+
+	/**
+	 * Infers the first supported target contract.
+	 *
+	 * <p>Local completeness is sufficient for reporting, but deliberately insufficient
+	 * for interactive or automatic execution. Project-wide flow, aliases, signatures
+	 * and concurrency still require the planner described by the multi-file roadmap.</p>
+	 */
+	public Optional<ContainerRecommendation> infer(ContainerUsageProfile profile) {
+		Objects.requireNonNull(profile, "profile"); //$NON-NLS-1$
+		if (!isAppendArraySequence(profile)) {
+			return Optional.empty();
+		}
+
+		TargetContainerContract target= new TargetContainerContract(
+				ContainerShape.LIST,
+				profile.orderRequirement(),
+				profile.uniquenessRequirement(),
+				Mutability.MUTABLE,
+				profile.nullContract(),
+				rationale(profile));
+
+		return Optional.of(new ContainerRecommendation(
+				profile,
+				target,
+				ContainerRuleRegistry.arrayAppendSequence(),
+				Confidence.MEDIUM,
+				AutomationLevel.REPORT_ONLY,
+				assessments(profile)));
+	}
+
+	private static boolean isAppendArraySequence(ContainerUsageProfile profile) {
+		return profile.currentShape() == ContainerShape.ARRAY
+				&& profile.completeness() == AnalysisCompleteness.LOCAL_USAGE_COMPLETE
+				&& profile.access().append()
+				&& profile.elementDomain() != ElementDomain.PRIMITIVE;
+	}
+
+	private static String rationale(ContainerUsageProfile profile) {
+		return switch (profile.orderRequirement()) {
+			case POSITIONAL ->
+				"The growing reference array is used as a mutable positional sequence."; //$NON-NLS-1$
+			case ENCOUNTER ->
+				"The growing reference array is traversed as an ordered mutable sequence."; //$NON-NLS-1$
+			case SORTED ->
+				"The growing reference array carries a sorted sequence contract that a later planner must preserve."; //$NON-NLS-1$
+			case NONE ->
+				"The growing reference array is used as a mutable sequence without an observed order requirement."; //$NON-NLS-1$
+			case UNKNOWN ->
+				"The growing reference array behaves as a mutable sequence, while project-wide order remains unresolved."; //$NON-NLS-1$
+		};
+	}
+
+	private static List<ContractAssessment> assessments(ContainerUsageProfile profile) {
+		return List.of(
+				assessment(
+						ContractProperty.ORDER,
+						profile.orderRequirement() == OrderRequirement.UNKNOWN
+								? Preservation.REQUIRES_PROOF : Preservation.PRESERVED,
+						profile.orderRequirement() == OrderRequirement.UNKNOWN
+								? "A list preserves sequence order, but the required project-wide order is not known yet." //$NON-NLS-1$
+								: "A list can preserve the observed array order contract."), //$NON-NLS-1$
+				assessment(
+						ContractProperty.UNIQUENESS,
+						profile.uniquenessRequirement() == UniquenessRequirement.DUPLICATES_ALLOWED
+								? Preservation.PRESERVED : Preservation.REQUIRES_PROOF,
+						profile.uniquenessRequirement() == UniquenessRequirement.DUPLICATES_ALLOWED
+								? "Arrays and lists both allow duplicate elements." //$NON-NLS-1$
+								: "Any external or manually enforced uniqueness rule still needs a flow proof."), //$NON-NLS-1$
+				assessment(
+						ContractProperty.MUTABILITY,
+						Preservation.PRESERVED,
+						"A mutable list can preserve the observed build and update operations."), //$NON-NLS-1$
+				assessment(
+						ContractProperty.NULLS,
+						profile.nullContract() == NullContract.UNKNOWN
+								? Preservation.REQUIRES_PROOF : Preservation.PRESERVED,
+						profile.nullContract() == NullContract.UNKNOWN
+								? "Null insertion and observation have not yet been classified." //$NON-NLS-1$
+								: "The later implementation must select matching null behavior."), //$NON-NLS-1$
+				assessment(
+						ContractProperty.ALIASING,
+						Preservation.REQUIRES_PROOF,
+						"Local analysis found no alias, but fields, callers and returned values are not closed yet."), //$NON-NLS-1$
+				assessment(
+						ContractProperty.SIGNATURES,
+						Preservation.REQUIRES_PROOF,
+						"Parameters, returns, overrides and callers require a project-wide signature plan."), //$NON-NLS-1$
+				assessment(
+						ContractProperty.CONCURRENCY,
+						Preservation.REQUIRES_PROOF,
+						"Thread exposure and compound operations require the concurrency-specific analysis.")); //$NON-NLS-1$
+	}
+
+	private static ContractAssessment assessment(
+			ContractProperty property,
+			Preservation preservation,
+			String explanation) {
+		return new ContractAssessment(property, preservation, explanation);
+	}
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/ContainerRuleRegistry.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/ContainerRuleRegistry.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.container.analysis;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.sandbox.jdt.container.api.ContainerRuleDescriptor;
+import org.sandbox.jdt.container.api.ContainerRuleDescriptor.RuleOwnership;
+import org.sandbox.jdt.container.api.ContainerShape;
+
+/**
+ * Central inventory used to prevent semantic container analysis from duplicating
+ * existing local cleanups and refactorings.
+ */
+public final class ContainerRuleRegistry {
+
+	public static final String ARRAY_APPEND_SEQUENCE= "semantic.array.append.sequence"; //$NON-NLS-1$
+	public static final String COLLECTION_BULK_ADD= "existing.collection.bulk-add"; //$NON-NLS-1$
+	public static final String COLLECTION_COPY_CONSTRUCTOR= "existing.collection.copy-constructor"; //$NON-NLS-1$
+	public static final String ARRAY_FILL= "existing.array.fill"; //$NON-NLS-1$
+	public static final String TYPE_GENERALIZATION= "existing.type.generalization"; //$NON-NLS-1$
+
+	private static final Map<String, ContainerRuleDescriptor> RULES= createRules();
+
+	private ContainerRuleRegistry() {
+		// Static registry.
+	}
+
+	/** Returns one descriptor by stable identifier. */
+	public static Optional<ContainerRuleDescriptor> find(String ruleId) {
+		return Optional.ofNullable(RULES.get(ruleId));
+	}
+
+	/** Returns descriptors in deterministic registration order. */
+	public static List<ContainerRuleDescriptor> all() {
+		return List.copyOf(RULES.values());
+	}
+
+	/** Returns the descriptor for the first implemented semantic migration family. */
+	public static ContainerRuleDescriptor arrayAppendSequence() {
+		return RULES.get(ARRAY_APPEND_SEQUENCE);
+	}
+
+	private static Map<String, ContainerRuleDescriptor> createRules() {
+		Map<String, ContainerRuleDescriptor> rules= new LinkedHashMap<>();
+		register(rules, new ContainerRuleDescriptor(
+				COLLECTION_BULK_ADD,
+				ContainerShape.LIST,
+				ContainerShape.LIST,
+				RuleOwnership.DUPLICATE,
+				"Eclipse collection bulk-add cleanup", //$NON-NLS-1$
+				"Local loop-to-bulk-add syntax is already owned by an existing cleanup.")); //$NON-NLS-1$
+		register(rules, new ContainerRuleDescriptor(
+				COLLECTION_COPY_CONSTRUCTOR,
+				ContainerShape.LIST,
+				ContainerShape.LIST,
+				RuleOwnership.DUPLICATE,
+				"Eclipse collection copy-constructor cleanup", //$NON-NLS-1$
+				"Local construction followed by copying is already normalized elsewhere.")); //$NON-NLS-1$
+		register(rules, new ContainerRuleDescriptor(
+				ARRAY_FILL,
+				ContainerShape.ARRAY,
+				ContainerShape.ARRAY,
+				RuleOwnership.DUPLICATE,
+				"Eclipse array-fill cleanup", //$NON-NLS-1$
+				"Replacing a uniform assignment loop with array fill is a local syntax cleanup.")); //$NON-NLS-1$
+		register(rules, new ContainerRuleDescriptor(
+				TYPE_GENERALIZATION,
+				ContainerShape.LIST,
+				ContainerShape.LIST,
+				RuleOwnership.DUPLICATE,
+				"Eclipse Change Type and Sandbox Use General Type", //$NON-NLS-1$
+				"Changing only the declared supertype is already covered by type-generalization tools.")); //$NON-NLS-1$
+		register(rules, new ContainerRuleDescriptor(
+				ARRAY_APPEND_SEQUENCE,
+				ContainerShape.ARRAY,
+				ContainerShape.LIST,
+				RuleOwnership.NOVEL,
+				"", //$NON-NLS-1$
+				"The rule changes representation and may propagate through fields, signatures and callers.")); //$NON-NLS-1$
+		return Map.copyOf(rules);
+	}
+
+	private static void register(
+			Map<String, ContainerRuleDescriptor> rules,
+			ContainerRuleDescriptor descriptor) {
+		if (rules.putIfAbsent(descriptor.ruleId(), descriptor) != null) {
+			throw new IllegalStateException("Duplicate container rule id: " + descriptor.ruleId()); //$NON-NLS-1$
+		}
+	}
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/ContainerRuleRegistry.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/ContainerRuleRegistry.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.sandbox.jdt.container.analysis;
 
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -89,7 +90,7 @@ public final class ContainerRuleRegistry {
 				RuleOwnership.NOVEL,
 				"", //$NON-NLS-1$
 				"The rule changes representation and may propagate through fields, signatures and callers.")); //$NON-NLS-1$
-		return Map.copyOf(rules);
+		return Collections.unmodifiableMap(new LinkedHashMap<>(rules));
 	}
 
 	private static void register(

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/api/ContainerRecommendation.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/api/ContainerRecommendation.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.container.api;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Explainable, immutable recommendation produced before rewrite planning.
+ *
+ * @param sourceProfile analyzed current contract
+ * @param targetContract proposed semantic target
+ * @param rule rule ownership and overlap information
+ * @param confidence confidence supported by the current analysis scope
+ * @param automationLevel permitted execution level
+ * @param assessments preservation assessment by contract property
+ */
+public record ContainerRecommendation(
+		ContainerUsageProfile sourceProfile,
+		TargetContainerContract targetContract,
+		ContainerRuleDescriptor rule,
+		Confidence confidence,
+		AutomationLevel automationLevel,
+		List<ContractAssessment> assessments) {
+
+	public ContainerRecommendation {
+		Objects.requireNonNull(sourceProfile, "sourceProfile"); //$NON-NLS-1$
+		Objects.requireNonNull(targetContract, "targetContract"); //$NON-NLS-1$
+		Objects.requireNonNull(rule, "rule"); //$NON-NLS-1$
+		Objects.requireNonNull(confidence, "confidence"); //$NON-NLS-1$
+		Objects.requireNonNull(automationLevel, "automationLevel"); //$NON-NLS-1$
+		assessments= List.copyOf(Objects.requireNonNull(assessments, "assessments")); //$NON-NLS-1$
+		if (!rule.mayRecommend()) {
+			throw new IllegalArgumentException("Duplicate rules cannot own recommendations"); //$NON-NLS-1$
+		}
+	}
+
+	/** Returns whether source rewriting is currently permitted. */
+	public boolean isExecutable() {
+		return automationLevel != AutomationLevel.REPORT_ONLY;
+	}
+
+	/** One preservation statement for a semantic property. */
+	public record ContractAssessment(
+			ContractProperty property,
+			Preservation preservation,
+			String explanation) {
+
+		public ContractAssessment {
+			Objects.requireNonNull(property, "property"); //$NON-NLS-1$
+			Objects.requireNonNull(preservation, "preservation"); //$NON-NLS-1$
+			explanation= Objects.requireNonNull(explanation, "explanation").strip(); //$NON-NLS-1$
+			if (explanation.isEmpty()) {
+				throw new IllegalArgumentException("explanation must not be empty"); //$NON-NLS-1$
+			}
+		}
+	}
+
+	public enum Confidence {
+		LOW,
+		MEDIUM,
+		HIGH
+	}
+
+	public enum AutomationLevel {
+		REPORT_ONLY,
+		INTERACTIVE,
+		AUTOMATIC
+	}
+
+	public enum ContractProperty {
+		ORDER,
+		UNIQUENESS,
+		MUTABILITY,
+		NULLS,
+		ALIASING,
+		SIGNATURES,
+		CONCURRENCY
+	}
+
+	public enum Preservation {
+		PRESERVED,
+		REQUIRES_PROOF,
+		CHANGED,
+		UNKNOWN
+	}
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/api/ContainerRuleDescriptor.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/api/ContainerRuleDescriptor.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.container.api;
+
+import java.util.Objects;
+
+/**
+ * Machine-readable ownership and overlap information for one container rule.
+ *
+ * @param ruleId stable rule identifier
+ * @param source source representation
+ * @param target target representation
+ * @param ownership overlap classification
+ * @param existingTransformation existing owner when applicable
+ * @param rationale reason for the classification
+ */
+public record ContainerRuleDescriptor(
+		String ruleId,
+		ContainerShape source,
+		ContainerShape target,
+		RuleOwnership ownership,
+		String existingTransformation,
+		String rationale) {
+
+	public ContainerRuleDescriptor {
+		ruleId= requiredText(ruleId, "ruleId"); //$NON-NLS-1$
+		Objects.requireNonNull(source, "source"); //$NON-NLS-1$
+		Objects.requireNonNull(target, "target"); //$NON-NLS-1$
+		Objects.requireNonNull(ownership, "ownership"); //$NON-NLS-1$
+		existingTransformation= existingTransformation == null
+				? "" : existingTransformation.strip(); //$NON-NLS-1$
+		rationale= requiredText(rationale, "rationale"); //$NON-NLS-1$
+		if (ownership == RuleOwnership.DUPLICATE && existingTransformation.isEmpty()) {
+			throw new IllegalArgumentException(
+					"A duplicate rule must name the existing transformation"); //$NON-NLS-1$
+		}
+	}
+
+	/** Returns whether this rule may own a new semantic recommendation. */
+	public boolean mayRecommend() {
+		return ownership != RuleOwnership.DUPLICATE;
+	}
+
+	private static String requiredText(String value, String fieldName) {
+		String text= Objects.requireNonNull(value, fieldName).strip();
+		if (text.isEmpty()) {
+			throw new IllegalArgumentException(fieldName + " must not be empty"); //$NON-NLS-1$
+		}
+		return text;
+	}
+
+	public enum RuleOwnership {
+		DUPLICATE,
+		COMPLEMENT,
+		NOVEL
+	}
+}

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/container/analysis/ContainerContractInferrerTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/container/analysis/ContainerContractInferrerTest.java
@@ -1,0 +1,177 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.container.analysis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.junit.jupiter.api.Test;
+import org.sandbox.jdt.container.api.ContainerRecommendation;
+import org.sandbox.jdt.container.api.ContainerRecommendation.AutomationLevel;
+import org.sandbox.jdt.container.api.ContainerRecommendation.Confidence;
+import org.sandbox.jdt.container.api.ContainerRecommendation.ContractProperty;
+import org.sandbox.jdt.container.api.ContainerRecommendation.Preservation;
+import org.sandbox.jdt.container.api.ContainerRuleDescriptor.RuleOwnership;
+import org.sandbox.jdt.container.api.ContainerShape;
+import org.sandbox.jdt.container.api.ContainerUsageProfile;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.AnalysisCompleteness;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.OrderRequirement;
+
+class ContainerContractInferrerTest {
+
+	private final AppendOnlyArraySeedDetector seedDetector= new AppendOnlyArraySeedDetector();
+	private final LocalArrayUsageAnalyzer usageAnalyzer= new LocalArrayUsageAnalyzer();
+	private final ContainerContractInferrer inferrer= new ContainerContractInferrer();
+
+	@Test
+	void infersReportOnlyListContractForEncounterSequence() {
+		ContainerRecommendation recommendation= infer("""
+			import java.util.Arrays;
+			class Sample {
+				void collect(String value) {
+					String[] values = new String[0];
+					values = Arrays.copyOf(values, values.length + 1);
+					values[values.length - 1] = value;
+					for (String current : values) {
+						System.out.println(current);
+					}
+				}
+			}
+			""");
+
+		assertEquals(ContainerShape.LIST, recommendation.targetContract().shape());
+		assertEquals(OrderRequirement.ENCOUNTER,
+				recommendation.targetContract().orderRequirement());
+		assertEquals(Confidence.MEDIUM, recommendation.confidence());
+		assertEquals(AutomationLevel.REPORT_ONLY, recommendation.automationLevel());
+		assertEquals(RuleOwnership.NOVEL, recommendation.rule().ownership());
+		assertFalse(recommendation.isExecutable());
+		assertEquals(Preservation.PRESERVED,
+				preservation(recommendation, ContractProperty.ORDER));
+		assertEquals(Preservation.REQUIRES_PROOF,
+				preservation(recommendation, ContractProperty.SIGNATURES));
+	}
+
+	@Test
+	void preservesPositionalRequirementInTargetContract() {
+		ContainerRecommendation recommendation= infer("""
+			import java.util.Arrays;
+			class Sample {
+				String collect(String value) {
+					String[] values = new String[0];
+					values = Arrays.copyOf(values, values.length + 1);
+					values[values.length - 1] = value;
+					return values[0];
+				}
+			}
+			""");
+
+		assertEquals(OrderRequirement.POSITIONAL,
+				recommendation.targetContract().orderRequirement());
+		assertTrue(recommendation.targetContract().rationale().contains("positional")); //$NON-NLS-1$
+	}
+
+	@Test
+	void doesNotRecommendFromRejectedLocalProfile() {
+		CompilationUnit unit= parse("""
+			import java.util.Arrays;
+			class Sample {
+				String[] collect(String value) {
+					String[] values = new String[0];
+					values = Arrays.copyOf(values, values.length + 1);
+					values[values.length - 1] = value;
+					return values;
+				}
+			}
+			""");
+		ContainerUsageProfile seed= seedDetector.findSeeds(unit).get(0);
+		ContainerUsageProfile rejected= usageAnalyzer.analyze(unit, seed);
+
+		assertEquals(AnalysisCompleteness.REJECTED, rejected.completeness());
+		assertTrue(inferrer.infer(rejected).isEmpty());
+	}
+
+	@Test
+	void doesNotRecommendFromUnvalidatedLocalSeed() {
+		CompilationUnit unit= parse("""
+			import java.util.Arrays;
+			class Sample {
+				void collect(String value) {
+					String[] values = new String[0];
+					values = Arrays.copyOf(values, values.length + 1);
+					values[values.length - 1] = value;
+				}
+			}
+			""");
+		ContainerUsageProfile seed= seedDetector.findSeeds(unit).get(0);
+
+		assertEquals(AnalysisCompleteness.LOCAL_SEED, seed.completeness());
+		assertTrue(inferrer.infer(seed).isEmpty());
+	}
+
+	@Test
+	void registryPreventsKnownLocalCleanupOwnershipFromBecomingRecommendations() {
+		assertEquals(RuleOwnership.DUPLICATE,
+				ContainerRuleRegistry.find(ContainerRuleRegistry.COLLECTION_BULK_ADD)
+						.orElseThrow().ownership());
+		assertFalse(ContainerRuleRegistry.find(ContainerRuleRegistry.ARRAY_FILL)
+				.orElseThrow().mayRecommend());
+		assertTrue(ContainerRuleRegistry.arrayAppendSequence().mayRecommend());
+	}
+
+	@Test
+	void registryHasStableUniqueIdentifiers() {
+		List<String> ids= ContainerRuleRegistry.all().stream()
+				.map(rule -> rule.ruleId())
+				.toList();
+
+		assertEquals(ids.size(), ids.stream().distinct().count());
+		assertEquals(ContainerRuleRegistry.COLLECTION_BULK_ADD, ids.get(0));
+		assertEquals(ContainerRuleRegistry.ARRAY_APPEND_SEQUENCE, ids.get(ids.size() - 1));
+	}
+
+	private ContainerRecommendation infer(String source) {
+		CompilationUnit unit= parse(source);
+		ContainerUsageProfile seed= seedDetector.findSeeds(unit).get(0);
+		ContainerUsageProfile profile= usageAnalyzer.analyze(unit, seed);
+		Optional<ContainerRecommendation> recommendation= inferrer.infer(profile);
+		return recommendation.orElseThrow();
+	}
+
+	private static Preservation preservation(
+			ContainerRecommendation recommendation,
+			ContractProperty property) {
+		return recommendation.assessments().stream()
+				.filter(assessment -> assessment.property() == property)
+				.findFirst()
+				.orElseThrow()
+				.preservation();
+	}
+
+	private static CompilationUnit parse(String source) {
+		ASTParser parser= ASTParser.newParser(AST.getJLSLatest());
+		parser.setSource(source.toCharArray());
+		parser.setKind(ASTParser.K_COMPILATION_UNIT);
+		parser.setResolveBindings(true);
+		parser.setBindingsRecovery(true);
+		parser.setStatementsRecovery(true);
+		parser.setUnitName("Sample.java"); //$NON-NLS-1$
+		parser.setEnvironment(new String[0], new String[0], new String[0], true);
+		return (CompilationUnit) parser.createAST(null);
+	}
+}


### PR DESCRIPTION
## Summary

Continues #1379 as a report-only inference slice on top of #1387.

- adds machine-readable `ContainerRuleDescriptor` ownership metadata;
- registers known local bulk-add, collection-copy, array-fill and pure type-generalization transformations as `DUPLICATE`;
- registers semantic append-array → sequence migration as `NOVEL` because it changes representation and may propagate through signatures;
- adds immutable `ContainerRecommendation` with confidence, automation level and per-property preservation assessments;
- infers a mutable `List` contract only from `LOCAL_USAGE_COMPLETE` append-array profiles;
- preserves observed encounter or positional order in the proposed contract;
- keeps every current recommendation at `REPORT_ONLY` and medium confidence;
- explicitly marks aliasing, signatures and concurrency as requiring further proof;
- produces no recommendation from rejected profiles or unvalidated local seeds.

## Tests

Covers:

- encounter-order sequence inference;
- positional sequence inference;
- report-only and non-executable classification;
- rejected-profile suppression;
- raw-seed suppression;
- duplicate rule ownership;
- deterministic, unique registry identifiers.

## Stacking

This PR targets `feature/local-container-usage-analysis`. After #1383, #1386 and #1387 merge, it can be retargeted to `main`.

Refs #1379
Refs #1378