### PR TITLE
Discover container value flow across declarations

### DIFF
--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/ContainerFlowGraphAccumulator.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/ContainerFlowGraphAccumulator.java
@@ -34,12 +34,7 @@ import org.sandbox.jdt.container.api.ContainerFlowGraph.FlowNode;
 import org.sandbox.jdt.container.api.ContainerFlowGraph.NodeKind;
 import org.sandbox.jdt.container.api.ContainerUsageProfile;
 
-/**
- * Mutable graph assembly used only during one flow-analysis pass.
- *
- * <p>All public results are converted to immutable, AST-free records by
- * {@link #toGraph()}.</p>
- */
+/** Mutable graph assembly used only during one flow-analysis pass. */
 final class ContainerFlowGraphAccumulator {
 
 	private final ContainerUsageProfile profile;
@@ -71,6 +66,7 @@ final class ContainerFlowGraphAccumulator {
 				binding.getKey(),
 				ownerKey(binding),
 				info.compilationUnitHandle(),
+				info.signatureIndex(),
 				true,
 				start,
 				length));
@@ -88,6 +84,7 @@ final class ContainerFlowGraphAccumulator {
 				"", //$NON-NLS-1$
 				methodKey,
 				unitHandle,
+				-1,
 				true,
 				anchor.getStartPosition(),
 				anchor.getLength()));
@@ -108,6 +105,7 @@ final class ContainerFlowGraphAccumulator {
 				"", //$NON-NLS-1$
 				methodKey,
 				"", //$NON-NLS-1$
+				parameterIndex,
 				false,
 				anchor.getStartPosition(),
 				anchor.getLength()));
@@ -179,6 +177,7 @@ final class ContainerFlowGraphAccumulator {
 				profile.identity().bindingKey(),
 				"", //$NON-NLS-1$
 				compilationUnitHandle,
+				-1,
 				false,
 				profile.identity().sourceStart(),
 				profile.identity().sourceLength()));

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/ContainerFlowGraphAccumulator.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/ContainerFlowGraphAccumulator.java
@@ -1,0 +1,270 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.container.analysis;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.IVariableBinding;
+import org.eclipse.jdt.core.dom.Modifier;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.sandbox.jdt.container.analysis.ContainerFlowIndex.BindingInfo;
+import org.sandbox.jdt.container.api.ContainerFlowGraph;
+import org.sandbox.jdt.container.api.ContainerFlowGraph.ClosureStatus;
+import org.sandbox.jdt.container.api.ContainerFlowGraph.DiagnosticKind;
+import org.sandbox.jdt.container.api.ContainerFlowGraph.EdgeKind;
+import org.sandbox.jdt.container.api.ContainerFlowGraph.FlowDiagnostic;
+import org.sandbox.jdt.container.api.ContainerFlowGraph.FlowEdge;
+import org.sandbox.jdt.container.api.ContainerFlowGraph.FlowNode;
+import org.sandbox.jdt.container.api.ContainerFlowGraph.NodeKind;
+import org.sandbox.jdt.container.api.ContainerUsageProfile;
+
+/**
+ * Mutable graph assembly used only during one flow-analysis pass.
+ *
+ * <p>All public results are converted to immutable, AST-free records by
+ * {@link #toGraph()}.</p>
+ */
+final class ContainerFlowGraphAccumulator {
+
+	private final ContainerUsageProfile profile;
+	private final String compilationUnitHandle;
+	private final Map<String, FlowNode> nodes= new LinkedHashMap<>();
+	private final List<FlowEdge> edges= new ArrayList<>();
+	private final Set<String> edgeKeys= new LinkedHashSet<>();
+	private final List<FlowDiagnostic> diagnostics= new ArrayList<>();
+	private final Set<String> diagnosticKeys= new LinkedHashSet<>();
+	private ClosureStatus closureStatus= ClosureStatus.LOCAL_CLOSED;
+	private String rootNodeId;
+
+	ContainerFlowGraphAccumulator(
+			ContainerUsageProfile profile,
+			String compilationUnitHandle) {
+		this.profile= profile;
+		this.compilationUnitHandle= compilationUnitHandle;
+	}
+
+	FlowNode ensureVariableNode(BindingInfo info) {
+		IVariableBinding binding= info.binding();
+		String stableId= variableNodeId(binding.getKey());
+		SimpleName anchor= info.anchor();
+		int start= anchor == null ? profile.identity().sourceStart() : anchor.getStartPosition();
+		int length= anchor == null ? profile.identity().sourceLength() : anchor.getLength();
+		FlowNode node= nodes.computeIfAbsent(stableId, ignored -> new FlowNode(
+				stableId,
+				nodeKind(binding),
+				binding.getKey(),
+				ownerKey(binding),
+				info.compilationUnitHandle(),
+				true,
+				start,
+				length));
+		if (rootNodeId == null && binding.getKey().equals(profile.identity().bindingKey())) {
+			rootNodeId= stableId;
+		}
+		return node;
+	}
+
+	FlowNode ensureReturnNode(String methodKey, String unitHandle, ASTNode anchor) {
+		String stableId= "return:" + methodKey; //$NON-NLS-1$
+		return nodes.computeIfAbsent(stableId, ignored -> new FlowNode(
+				stableId,
+				NodeKind.RETURN_POSITION,
+				"", //$NON-NLS-1$
+				methodKey,
+				unitHandle,
+				true,
+				anchor.getStartPosition(),
+				anchor.getLength()));
+	}
+
+	void addParameterBoundary(
+			FlowNode sourceNode,
+			IMethodBinding method,
+			int parameterIndex,
+			ASTNode anchor) {
+		ITypeBinding declaringClass= method.getDeclaringClass();
+		boolean sourceType= declaringClass != null && declaringClass.isFromSource();
+		String methodKey= methodKey(method);
+		String stableId= "parameter:" + methodKey + ':' + parameterIndex; //$NON-NLS-1$
+		FlowNode target= nodes.computeIfAbsent(stableId, ignored -> new FlowNode(
+				stableId,
+				sourceType ? NodeKind.PARAMETER : NodeKind.EXTERNAL_PARAMETER,
+				"", //$NON-NLS-1$
+				methodKey,
+				"", //$NON-NLS-1$
+				false,
+				anchor.getStartPosition(),
+				anchor.getLength()));
+		addEdge(sourceNode, target, EdgeKind.ARGUMENT_TO_PARAMETER, anchor);
+		if (sourceType) {
+			requireScopeExpansion(
+					"Parameter declaration is in another source scope", anchor); //$NON-NLS-1$
+		} else {
+			raise(ClosureStatus.EXTERNAL_BOUNDARY);
+			addDiagnostic(
+					DiagnosticKind.EXTERNAL_OR_BINARY_TARGET,
+					"Container value reaches an external or binary method parameter", anchor); //$NON-NLS-1$
+		}
+	}
+
+	void addEdge(FlowNode source, FlowNode target, EdgeKind kind, ASTNode anchor) {
+		String edgeKey= source.stableId() + '|' + target.stableId() + '|'
+				+ kind + '|' + anchor.getStartPosition();
+		if (edgeKeys.add(edgeKey)) {
+			edges.add(new FlowEdge(
+					source.stableId(),
+					target.stableId(),
+					kind,
+					anchor.getStartPosition(),
+					anchor.getLength()));
+		}
+	}
+
+	void classifySignatureExposure(BindingInfo info) {
+		IVariableBinding binding= info.binding();
+		if (binding.isParameter()) {
+			requireScopeExpansion(
+					"Method parameter requires caller and override discovery", info.anchor()); //$NON-NLS-1$
+		} else if (binding.isField() && !Modifier.isPrivate(binding.getModifiers())) {
+			requireScopeExpansion(
+					"Non-private field requires project-wide reference discovery", info.anchor()); //$NON-NLS-1$
+		}
+	}
+
+	void requireScopeExpansion(String message, ASTNode anchor) {
+		raise(ClosureStatus.REQUIRES_SCOPE_EXPANSION);
+		addDiagnostic(DiagnosticKind.SCOPE_EXPANSION_REQUIRED, message, anchor);
+	}
+
+	void unresolvedBinding(String bindingKey, int start, int length) {
+		raise(ClosureStatus.REJECTED);
+		String suffix= bindingKey == null || bindingKey.isBlank()
+				? "" : ": " + bindingKey; //$NON-NLS-1$ //$NON-NLS-2$
+		addDiagnostic(
+				DiagnosticKind.UNRESOLVED_BINDING,
+				"A required flow binding could not be resolved" + suffix, //$NON-NLS-1$
+				start,
+				length);
+	}
+
+	void unclassifiedFlow(ASTNode anchor) {
+		raise(ClosureStatus.REJECTED);
+		addDiagnostic(
+				DiagnosticKind.UNCLASSIFIED_FLOW,
+				"Container flow reaches an unsupported expression shape", anchor); //$NON-NLS-1$
+	}
+
+	void addUnresolvedRoot() {
+		String stableId= "unknown:" + profile.identity().stableId(); //$NON-NLS-1$
+		rootNodeId= stableId;
+		nodes.put(stableId, new FlowNode(
+				stableId,
+				NodeKind.UNKNOWN_BOUNDARY,
+				profile.identity().bindingKey(),
+				"", //$NON-NLS-1$
+				compilationUnitHandle,
+				false,
+				profile.identity().sourceStart(),
+				profile.identity().sourceLength()));
+		unresolvedBinding(
+				profile.identity().bindingKey(),
+				profile.identity().sourceStart(),
+				profile.identity().sourceLength());
+	}
+
+	ContainerFlowGraph toGraph() {
+		return new ContainerFlowGraph(
+				rootNodeId,
+				List.copyOf(nodes.values()),
+				edges,
+				closureStatus,
+				diagnostics);
+	}
+
+	private void addDiagnostic(DiagnosticKind kind, String message, ASTNode anchor) {
+		if (anchor == null) {
+			addDiagnostic(
+					kind,
+					message,
+					profile.identity().sourceStart(),
+					profile.identity().sourceLength());
+		} else {
+			addDiagnostic(kind, message, anchor.getStartPosition(), anchor.getLength());
+		}
+	}
+
+	private void addDiagnostic(
+			DiagnosticKind kind,
+			String message,
+			int start,
+			int length) {
+		String key= kind + "|" + message + '|' + start; //$NON-NLS-1$
+		if (diagnosticKeys.add(key)) {
+			diagnostics.add(new FlowDiagnostic(kind, message, start, length));
+		}
+	}
+
+	private void raise(ClosureStatus candidate) {
+		if (rank(candidate) > rank(closureStatus)) {
+			closureStatus= candidate;
+		}
+	}
+
+	private static NodeKind nodeKind(IVariableBinding binding) {
+		if (binding.isField()) {
+			return NodeKind.FIELD;
+		}
+		if (binding.isParameter()) {
+			return NodeKind.PARAMETER;
+		}
+		return NodeKind.LOCAL_VARIABLE;
+	}
+
+	private static String ownerKey(IVariableBinding binding) {
+		IMethodBinding declaringMethod= binding.getDeclaringMethod();
+		if (declaringMethod != null) {
+			return methodKey(declaringMethod);
+		}
+		ITypeBinding declaringClass= binding.getDeclaringClass();
+		return declaringClass == null ? "" : declaringClass.getTypeDeclaration().getKey(); //$NON-NLS-1$
+	}
+
+	private static String methodKey(IMethodBinding method) {
+		String key= method.getMethodDeclaration().getKey();
+		if (key != null && !key.isBlank()) {
+			return key;
+		}
+		ITypeBinding owner= method.getDeclaringClass();
+		String ownerName= owner == null ? "" : owner.getErasure().getQualifiedName(); //$NON-NLS-1$
+		return ownerName + '#' + method.getName() + '/' + method.getParameterTypes().length;
+	}
+
+	private static String variableNodeId(String bindingKey) {
+		return "variable:" + bindingKey; //$NON-NLS-1$
+	}
+
+	private static int rank(ClosureStatus status) {
+		return switch (status) {
+			case LOCAL_CLOSED -> 0;
+			case REQUIRES_SCOPE_EXPANSION -> 1;
+			case EXTERNAL_BOUNDARY -> 2;
+			case REJECTED -> 3;
+		};
+	}
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/ContainerFlowIndex.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/ContainerFlowIndex.java
@@ -1,0 +1,189 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.container.analysis;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.IVariableBinding;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
+import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+import org.sandbox.jdt.internal.common.AstProcessing;
+import org.sandbox.jdt.internal.common.ReferenceHolder;
+
+/**
+ * Deterministic binding and reference index for one compilation unit.
+ *
+ * <p>The index is intentionally scoped to one parser result. AST nodes never leave
+ * the current analysis pass; only the resulting flow graph is retained.</p>
+ */
+final class ContainerFlowIndex {
+
+	private final Map<String, BindingInfo> bindings;
+	private final Map<String, List<SimpleName>> references;
+	private final Map<String, MethodInfo> methods;
+	private final String compilationUnitHandle;
+
+	private ContainerFlowIndex(
+			Map<String, BindingInfo> bindings,
+			Map<String, List<SimpleName>> references,
+			Map<String, MethodInfo> methods,
+			String compilationUnitHandle) {
+		this.bindings= immutableLinkedMap(bindings);
+		this.references= immutableReferenceMap(references);
+		this.methods= immutableLinkedMap(methods);
+		this.compilationUnitHandle= compilationUnitHandle;
+	}
+
+	static ContainerFlowIndex create(CompilationUnit compilationUnit) {
+		Map<String, BindingInfo> bindings= new LinkedHashMap<>();
+		Map<String, List<SimpleName>> references= new LinkedHashMap<>();
+		Map<String, MethodInfo> methods= new LinkedHashMap<>();
+		IJavaElement javaElement= compilationUnit.getJavaElement();
+		String unitHandle= javaElement == null ? "" : javaElement.getHandleIdentifier(); //$NON-NLS-1$
+
+		AstProcessing.independent(ReferenceHolder.<String, Object>create())
+				.on(MethodDeclaration.class, (method, holder) -> {
+					indexMethod(method, methods);
+					return true;
+				})
+				.on(SimpleName.class, (name, holder) -> {
+					indexVariable(name, bindings, references, unitHandle);
+					return true;
+				})
+				.build(compilationUnit);
+
+		return new ContainerFlowIndex(bindings, references, methods, unitHandle);
+	}
+
+	Map<String, BindingInfo> bindings() {
+		return bindings;
+	}
+
+	Map<String, List<SimpleName>> references() {
+		return references;
+	}
+
+	Map<String, MethodInfo> methods() {
+		return methods;
+	}
+
+	String compilationUnitHandle() {
+		return compilationUnitHandle;
+	}
+
+	private static void indexMethod(
+			MethodDeclaration method,
+			Map<String, MethodInfo> methods) {
+		IMethodBinding binding= method.resolveBinding();
+		if (binding == null) {
+			return;
+		}
+		List<String> parameterBindingKeys= new ArrayList<>();
+		for (Object parameterObject : method.parameters()) {
+			SingleVariableDeclaration parameter= (SingleVariableDeclaration) parameterObject;
+			IVariableBinding parameterBinding= parameter.resolveBinding();
+			parameterBindingKeys.add(parameterBinding == null
+					? "" : parameterBinding.getVariableDeclaration().getKey()); //$NON-NLS-1$
+		}
+		methods.put(
+				binding.getMethodDeclaration().getKey(),
+				new MethodInfo(parameterBindingKeys));
+	}
+
+	private static void indexVariable(
+			SimpleName name,
+			Map<String, BindingInfo> bindings,
+			Map<String, List<SimpleName>> references,
+			String unitHandle) {
+		IBinding resolved= name.resolveBinding();
+		if (!(resolved instanceof IVariableBinding variable)) {
+			return;
+		}
+		IVariableBinding declaration= variable.getVariableDeclaration();
+		String bindingKey= declaration.getKey();
+		if (bindingKey == null || bindingKey.isBlank()) {
+			return;
+		}
+
+		BindingInfo info= bindings.computeIfAbsent(
+				bindingKey,
+				ignored -> new BindingInfo(declaration, unitHandle));
+		if (isDeclarationName(name)) {
+			info.recordDeclaration(name);
+		}
+		references.computeIfAbsent(bindingKey, ignored -> new ArrayList<>()).add(name);
+	}
+
+	private static boolean isDeclarationName(SimpleName name) {
+		return name.getParent() instanceof VariableDeclarationFragment fragment
+				&& fragment.getName() == name
+				|| name.getParent() instanceof SingleVariableDeclaration declaration
+						&& declaration.getName() == name;
+	}
+
+	private static <K, V> Map<K, V> immutableLinkedMap(Map<K, V> source) {
+		return Collections.unmodifiableMap(new LinkedHashMap<>(source));
+	}
+
+	private static Map<String, List<SimpleName>> immutableReferenceMap(
+			Map<String, List<SimpleName>> source) {
+		Map<String, List<SimpleName>> copy= new LinkedHashMap<>();
+		source.forEach((key, value) -> copy.put(key, List.copyOf(value)));
+		return Collections.unmodifiableMap(copy);
+	}
+
+	/** Binding metadata used while the parser result is alive. */
+	static final class BindingInfo {
+
+		private final IVariableBinding binding;
+		private final String compilationUnitHandle;
+		private SimpleName declarationName;
+
+		BindingInfo(IVariableBinding binding, String compilationUnitHandle) {
+			this.binding= binding.getVariableDeclaration();
+			this.compilationUnitHandle= compilationUnitHandle;
+		}
+
+		void recordDeclaration(SimpleName name) {
+			declarationName= name;
+		}
+
+		IVariableBinding binding() {
+			return binding;
+		}
+
+		SimpleName anchor() {
+			return declarationName;
+		}
+
+		String compilationUnitHandle() {
+			return compilationUnitHandle;
+		}
+	}
+
+	/** Parameter binding keys for one local method declaration. */
+	static record MethodInfo(List<String> parameterBindingKeys) {
+
+		MethodInfo {
+			parameterBindingKeys= List.copyOf(parameterBindingKeys);
+		}
+	}
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/ContainerFlowIndex.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/ContainerFlowIndex.java
@@ -28,12 +28,7 @@ import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.sandbox.jdt.internal.common.AstProcessing;
 import org.sandbox.jdt.internal.common.ReferenceHolder;
 
-/**
- * Deterministic binding and reference index for one compilation unit.
- *
- * <p>The index is intentionally scoped to one parser result. AST nodes never leave
- * the current analysis pass; only the resulting flow graph is retained.</p>
- */
+/** Deterministic binding and reference index for one compilation unit. */
 final class ContainerFlowIndex {
 
 	private final Map<String, BindingInfo> bindings;
@@ -56,16 +51,17 @@ final class ContainerFlowIndex {
 		Map<String, BindingInfo> bindings= new LinkedHashMap<>();
 		Map<String, List<SimpleName>> references= new LinkedHashMap<>();
 		Map<String, MethodInfo> methods= new LinkedHashMap<>();
+		Map<String, Integer> parameterIndices= new LinkedHashMap<>();
 		IJavaElement javaElement= compilationUnit.getJavaElement();
 		String unitHandle= javaElement == null ? "" : javaElement.getHandleIdentifier(); //$NON-NLS-1$
 
 		AstProcessing.independent(ReferenceHolder.<String, Object>create())
 				.on(MethodDeclaration.class, (method, holder) -> {
-					indexMethod(method, methods);
+					indexMethod(method, methods, parameterIndices);
 					return true;
 				})
 				.on(SimpleName.class, (name, holder) -> {
-					indexVariable(name, bindings, references, unitHandle);
+					indexVariable(name, bindings, references, parameterIndices, unitHandle);
 					return true;
 				})
 				.build(compilationUnit);
@@ -91,17 +87,23 @@ final class ContainerFlowIndex {
 
 	private static void indexMethod(
 			MethodDeclaration method,
-			Map<String, MethodInfo> methods) {
+			Map<String, MethodInfo> methods,
+			Map<String, Integer> parameterIndices) {
 		IMethodBinding binding= method.resolveBinding();
 		if (binding == null) {
 			return;
 		}
 		List<String> parameterBindingKeys= new ArrayList<>();
-		for (Object parameterObject : method.parameters()) {
-			SingleVariableDeclaration parameter= (SingleVariableDeclaration) parameterObject;
+		for (int index= 0; index < method.parameters().size(); index++) {
+			SingleVariableDeclaration parameter=
+					(SingleVariableDeclaration) method.parameters().get(index);
 			IVariableBinding parameterBinding= parameter.resolveBinding();
-			parameterBindingKeys.add(parameterBinding == null
-					? "" : parameterBinding.getVariableDeclaration().getKey()); //$NON-NLS-1$
+			String parameterKey= parameterBinding == null
+					? "" : parameterBinding.getVariableDeclaration().getKey(); //$NON-NLS-1$
+			parameterBindingKeys.add(parameterKey);
+			if (parameterKey != null && !parameterKey.isBlank()) {
+				parameterIndices.put(parameterKey, Integer.valueOf(index));
+			}
 		}
 		methods.put(
 				binding.getMethodDeclaration().getKey(),
@@ -112,6 +114,7 @@ final class ContainerFlowIndex {
 			SimpleName name,
 			Map<String, BindingInfo> bindings,
 			Map<String, List<SimpleName>> references,
+			Map<String, Integer> parameterIndices,
 			String unitHandle) {
 		IBinding resolved= name.resolveBinding();
 		if (!(resolved instanceof IVariableBinding variable)) {
@@ -123,9 +126,10 @@ final class ContainerFlowIndex {
 			return;
 		}
 
+		int signatureIndex= parameterIndices.getOrDefault(bindingKey, Integer.valueOf(-1)).intValue();
 		BindingInfo info= bindings.computeIfAbsent(
 				bindingKey,
-				ignored -> new BindingInfo(declaration, unitHandle));
+				ignored -> new BindingInfo(declaration, unitHandle, signatureIndex));
 		if (isDeclarationName(name)) {
 			info.recordDeclaration(name);
 		}
@@ -155,11 +159,16 @@ final class ContainerFlowIndex {
 
 		private final IVariableBinding binding;
 		private final String compilationUnitHandle;
+		private final int signatureIndex;
 		private SimpleName declarationName;
 
-		BindingInfo(IVariableBinding binding, String compilationUnitHandle) {
+		BindingInfo(
+				IVariableBinding binding,
+				String compilationUnitHandle,
+				int signatureIndex) {
 			this.binding= binding.getVariableDeclaration();
 			this.compilationUnitHandle= compilationUnitHandle;
+			this.signatureIndex= signatureIndex;
 		}
 
 		void recordDeclaration(SimpleName name) {
@@ -176,6 +185,10 @@ final class ContainerFlowIndex {
 
 		String compilationUnitHandle() {
 			return compilationUnitHandle;
+		}
+
+		int signatureIndex() {
+			return signatureIndex;
 		}
 	}
 

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/ContainerFlowSearchSeedExtractor.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/ContainerFlowSearchSeedExtractor.java
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.container.analysis;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.sandbox.jdt.container.api.ContainerFlowGraph;
+import org.sandbox.jdt.container.api.ContainerFlowGraph.FlowNode;
+import org.sandbox.jdt.container.api.ContainerFlowGraph.NodeKind;
+import org.sandbox.jdt.container.api.ContainerFlowSearchPlan;
+import org.sandbox.jdt.container.api.ContainerFlowSearchPlan.SearchKind;
+import org.sandbox.jdt.container.api.ContainerFlowSearchPlan.SearchSeed;
+
+/** Converts graph boundaries into duplicate-free, stable source-search intentions. */
+public final class ContainerFlowSearchSeedExtractor {
+
+	/** Derives searches needed to expand the current source closure. */
+	public ContainerFlowSearchPlan extract(ContainerFlowGraph graph) {
+		Objects.requireNonNull(graph, "graph"); //$NON-NLS-1$
+		Map<String, SearchSeed> seeds= new LinkedHashMap<>();
+
+		for (FlowNode node : graph.nodes()) {
+			switch (node.kind()) {
+				case FIELD -> addFieldReferences(node, seeds);
+				case PARAMETER -> addMethodSignatureSearches(node, seeds, true);
+				case RETURN_POSITION -> addMethodSignatureSearches(node, seeds, false);
+				case LOCAL_VARIABLE, EXTERNAL_PARAMETER, UNKNOWN_BOUNDARY -> {
+					// No source-scope expansion can be derived from this node alone.
+				}
+			}
+		}
+
+		return new ContainerFlowSearchPlan(new ArrayList<>(seeds.values()));
+	}
+
+	private static void addFieldReferences(
+			FlowNode node,
+			Map<String, SearchSeed> seeds) {
+		if (node.bindingKey().isBlank()) {
+			return;
+		}
+		add(seeds, new SearchSeed(
+				node.stableId(),
+				SearchKind.FIELD_REFERENCES,
+				node.bindingKey(),
+				node.ownerKey(),
+				-1,
+				"Find all source reads and writes of the field participating in container flow.")); //$NON-NLS-1$
+	}
+
+	private static void addMethodSignatureSearches(
+			FlowNode node,
+			Map<String, SearchSeed> seeds,
+			boolean includeDeclaration) {
+		if (node.ownerKey().isBlank()) {
+			return;
+		}
+		if (includeDeclaration && !node.sourceResolved()) {
+			add(seeds, new SearchSeed(
+					node.stableId(),
+					SearchKind.METHOD_DECLARATION,
+					node.bindingKey(),
+					node.ownerKey(),
+					node.signatureIndex(),
+					"Resolve the source declaration that owns the parameter position.")); //$NON-NLS-1$
+		}
+		add(seeds, new SearchSeed(
+				node.stableId(),
+				SearchKind.METHOD_CALLERS,
+				node.bindingKey(),
+				node.ownerKey(),
+				node.signatureIndex(),
+				includeDeclaration
+						? "Find callers that pass values into the parameter position." //$NON-NLS-1$
+						: "Find callers that consume the method return value.")); //$NON-NLS-1$
+		add(seeds, new SearchSeed(
+				node.stableId(),
+				SearchKind.METHOD_OVERRIDE_FAMILY,
+				node.bindingKey(),
+				node.ownerKey(),
+				node.signatureIndex(),
+				"Find all source declarations in the method override and implementation family.")); //$NON-NLS-1$
+	}
+
+	private static void add(Map<String, SearchSeed> seeds, SearchSeed seed) {
+		seeds.putIfAbsent(seed.stableKey(), seed);
+	}
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/LocalContainerFlowGraphBuilder.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/LocalContainerFlowGraphBuilder.java
@@ -1,0 +1,696 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.container.analysis;
+
+import static org.sandbox.jdt.container.analysis.ContainerAstFacts.variableBinding;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ArrayAccess;
+import org.eclipse.jdt.core.dom.Assignment;
+import org.eclipse.jdt.core.dom.ClassInstanceCreation;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.EnhancedForStatement;
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.FieldAccess;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.IVariableBinding;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.Modifier;
+import org.eclipse.jdt.core.dom.ParenthesizedExpression;
+import org.eclipse.jdt.core.dom.QualifiedName;
+import org.eclipse.jdt.core.dom.ReturnStatement;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
+import org.eclipse.jdt.core.dom.SuperFieldAccess;
+import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+import org.sandbox.jdt.container.api.ContainerFlowGraph;
+import org.sandbox.jdt.container.api.ContainerFlowGraph.ClosureStatus;
+import org.sandbox.jdt.container.api.ContainerFlowGraph.DiagnosticKind;
+import org.sandbox.jdt.container.api.ContainerFlowGraph.EdgeKind;
+import org.sandbox.jdt.container.api.ContainerFlowGraph.FlowDiagnostic;
+import org.sandbox.jdt.container.api.ContainerFlowGraph.FlowEdge;
+import org.sandbox.jdt.container.api.ContainerFlowGraph.FlowNode;
+import org.sandbox.jdt.container.api.ContainerFlowGraph.NodeKind;
+import org.sandbox.jdt.container.api.ContainerUsageProfile;
+import org.sandbox.jdt.internal.common.AstProcessing;
+import org.sandbox.jdt.internal.common.ReferenceHolder;
+
+/**
+ * Discovers value-flow edges reachable from one container binding inside a compilation
+ * unit.
+ *
+ * <p>The builder follows local variable aliases to a fixed point. Signature edges are
+ * represented even when their declarations are outside the current compilation unit;
+ * the closure status and diagnostics then instruct the multi-file planner to expand
+ * scope or stop at an external boundary.</p>
+ */
+public final class LocalContainerFlowGraphBuilder {
+
+	/** Builds a local flow graph for the supplied candidate profile. */
+	public ContainerFlowGraph build(
+			CompilationUnit compilationUnit,
+			ContainerUsageProfile profile) {
+		Objects.requireNonNull(compilationUnit, "compilationUnit"); //$NON-NLS-1$
+		Objects.requireNonNull(profile, "profile"); //$NON-NLS-1$
+
+		FlowIndex index= FlowIndex.create(compilationUnit);
+		GraphAccumulator graph= new GraphAccumulator(profile, index.compilationUnitHandle());
+		String rootBindingKey= profile.identity().bindingKey();
+		if (rootBindingKey.isBlank()) {
+			graph.addUnresolvedRoot();
+			return graph.toGraph();
+		}
+
+		BindingInfo root= index.bindings().get(rootBindingKey);
+		if (root == null) {
+			graph.addUnresolvedRoot();
+			return graph.toGraph();
+		}
+
+		Deque<String> pendingBindings= new ArrayDeque<>();
+		Set<String> visitedBindings= new LinkedHashSet<>();
+		pendingBindings.add(rootBindingKey);
+		graph.ensureVariableNode(root);
+
+		while (!pendingBindings.isEmpty()) {
+			String bindingKey= pendingBindings.removeFirst();
+			if (!visitedBindings.add(bindingKey)) {
+				continue;
+			}
+			BindingInfo source= index.bindings().get(bindingKey);
+			if (source == null) {
+				graph.unresolvedBinding(bindingKey, profile.identity().sourceStart(),
+						profile.identity().sourceLength());
+				continue;
+			}
+
+			FlowNode sourceNode= graph.ensureVariableNode(source);
+			graph.classifySignatureExposure(source);
+			for (SimpleName referenceName : index.references().getOrDefault(bindingKey, List.of())) {
+				if (isDeclarationName(referenceName)) {
+					continue;
+				}
+				Expression reference= completeReferenceExpression(referenceName, bindingKey);
+				classifyReference(
+						reference,
+						sourceNode,
+						index,
+						graph,
+						pendingBindings);
+			}
+		}
+
+		return graph.toGraph();
+	}
+
+	private static void classifyReference(
+			Expression reference,
+			FlowNode sourceNode,
+			FlowIndex index,
+			GraphAccumulator graph,
+			Deque<String> pendingBindings) {
+		ASTNode parent= reference.getParent();
+		if (parent instanceof VariableDeclarationFragment fragment
+				&& fragment.getInitializer() == reference) {
+			connectVariable(
+					sourceNode,
+					fragment.resolveBinding(),
+					EdgeKind.INITIALIZER,
+					reference,
+					index,
+					graph,
+					pendingBindings);
+		} else if (parent instanceof Assignment assignment
+				&& assignment.getRightHandSide() == reference) {
+			connectExpression(
+					sourceNode,
+					assignment.getLeftHandSide(),
+					EdgeKind.ASSIGNMENT,
+					reference,
+					index,
+					graph,
+					pendingBindings);
+		} else if (parent instanceof MethodInvocation invocation
+				&& invocation.arguments().contains(reference)) {
+			if (!isRepresentationInternalCopy(invocation, reference)) {
+				connectArguments(
+						sourceNode,
+						invocation.resolveMethodBinding(),
+						invocation.arguments(),
+						reference,
+						index,
+						graph,
+						pendingBindings);
+			}
+		} else if (parent instanceof ClassInstanceCreation creation
+				&& creation.arguments().contains(reference)) {
+			connectArguments(
+					sourceNode,
+					creation.resolveConstructorBinding(),
+					creation.arguments(),
+					reference,
+					index,
+					graph,
+					pendingBindings);
+		} else if (parent instanceof ReturnStatement) {
+			connectReturn(sourceNode, reference, index, graph);
+		} else if (!isInternalNonFlowUse(reference, parent)) {
+			graph.unclassifiedFlow(reference);
+		}
+	}
+
+	private static void connectExpression(
+			FlowNode sourceNode,
+			Expression targetExpression,
+			EdgeKind edgeKind,
+			ASTNode evidence,
+			FlowIndex index,
+			GraphAccumulator graph,
+			Deque<String> pendingBindings) {
+		Optional<IVariableBinding> target= variableBinding(targetExpression);
+		if (target.isPresent()) {
+			connectVariable(sourceNode, target.get(), edgeKind, evidence,
+					index, graph, pendingBindings);
+		} else {
+			graph.unclassifiedFlow(evidence);
+		}
+	}
+
+	private static void connectVariable(
+			FlowNode sourceNode,
+			IVariableBinding targetBinding,
+			EdgeKind edgeKind,
+			ASTNode evidence,
+			FlowIndex index,
+			GraphAccumulator graph,
+			Deque<String> pendingBindings) {
+		if (targetBinding == null || targetBinding.getVariableDeclaration().getKey() == null) {
+			graph.unresolvedBinding("", evidence.getStartPosition(), evidence.getLength()); //$NON-NLS-1$
+			return;
+		}
+		String targetKey= targetBinding.getVariableDeclaration().getKey();
+		BindingInfo target= index.bindings().get(targetKey);
+		if (target == null) {
+			graph.unresolvedBinding(targetKey, evidence.getStartPosition(), evidence.getLength());
+			return;
+		}
+		FlowNode targetNode= graph.ensureVariableNode(target);
+		graph.addEdge(sourceNode, targetNode, edgeKind, evidence);
+		pendingBindings.addLast(targetKey);
+	}
+
+	private static void connectArguments(
+			FlowNode sourceNode,
+			IMethodBinding invokedMethod,
+			List<?> arguments,
+			Expression reference,
+			FlowIndex index,
+			GraphAccumulator graph,
+			Deque<String> pendingBindings) {
+		if (invokedMethod == null) {
+			graph.unresolvedBinding("", reference.getStartPosition(), reference.getLength()); //$NON-NLS-1$
+			return;
+		}
+		IMethodBinding declaration= invokedMethod.getMethodDeclaration();
+		String methodKey= declaration.getKey();
+		for (int argumentIndex= 0; argumentIndex < arguments.size(); argumentIndex++) {
+			if (arguments.get(argumentIndex) != reference) {
+				continue;
+			}
+			int parameterIndex= parameterIndex(declaration, argumentIndex);
+			MethodInfo localMethod= index.methods().get(methodKey);
+			if (localMethod != null && parameterIndex < localMethod.parameterBindingKeys().size()) {
+				String parameterKey= localMethod.parameterBindingKeys().get(parameterIndex);
+				BindingInfo parameter= index.bindings().get(parameterKey);
+				if (parameter != null) {
+					FlowNode parameterNode= graph.ensureVariableNode(parameter);
+					graph.addEdge(sourceNode, parameterNode,
+							EdgeKind.ARGUMENT_TO_PARAMETER, reference);
+					graph.requireScopeExpansion(
+							"Method parameter signature participates in the container flow", reference); //$NON-NLS-1$
+					pendingBindings.addLast(parameterKey);
+					continue;
+				}
+			}
+			graph.addParameterBoundary(
+					sourceNode,
+					declaration,
+					parameterIndex,
+					reference);
+		}
+	}
+
+	private static int parameterIndex(IMethodBinding method, int argumentIndex) {
+		int parameterCount= method.getParameterTypes().length;
+		if (method.isVarargs() && parameterCount > 0 && argumentIndex >= parameterCount - 1) {
+			return parameterCount - 1;
+		}
+		return argumentIndex;
+	}
+
+	private static void connectReturn(
+			FlowNode sourceNode,
+			Expression reference,
+			FlowIndex index,
+			GraphAccumulator graph) {
+		MethodDeclaration method= ancestor(reference, MethodDeclaration.class);
+		IMethodBinding methodBinding= method == null ? null : method.resolveBinding();
+		if (methodBinding == null) {
+			graph.unresolvedBinding("", reference.getStartPosition(), reference.getLength()); //$NON-NLS-1$
+			return;
+		}
+		String methodKey= methodBinding.getMethodDeclaration().getKey();
+		FlowNode returnNode= graph.ensureReturnNode(
+				methodKey,
+				index.compilationUnitHandle(),
+				reference);
+		graph.addEdge(sourceNode, returnNode, EdgeKind.RETURN_TO_METHOD, reference);
+		graph.requireScopeExpansion(
+				"Method return type and all call sites participate in the container flow", reference); //$NON-NLS-1$
+	}
+
+	private static boolean isRepresentationInternalCopy(
+			MethodInvocation invocation,
+			Expression reference) {
+		if (!"copyOf".equals(invocation.getName().getIdentifier()) //$NON-NLS-1$
+				|| invocation.arguments().isEmpty()
+				|| invocation.arguments().get(0) != reference) {
+			return false;
+		}
+		IMethodBinding binding= invocation.resolveMethodBinding();
+		return binding != null
+				&& binding.getDeclaringClass() != null
+				&& "java.util.Arrays".equals( //$NON-NLS-1$
+						binding.getDeclaringClass().getErasure().getQualifiedName());
+	}
+
+	private static boolean isInternalNonFlowUse(Expression reference, ASTNode parent) {
+		return parent instanceof ArrayAccess access && access.getArray() == reference
+				|| parent instanceof QualifiedName qualified
+						&& qualified.getQualifier() == reference
+						&& "length".equals(qualified.getName().getIdentifier()) //$NON-NLS-1$
+				|| parent instanceof FieldAccess fieldAccess
+						&& fieldAccess.getExpression() == reference
+						&& "length".equals(fieldAccess.getName().getIdentifier()) //$NON-NLS-1$
+				|| parent instanceof EnhancedForStatement enhancedFor
+						&& enhancedFor.getExpression() == reference
+				|| parent instanceof Assignment assignment
+						&& assignment.getLeftHandSide() == reference;
+	}
+
+	private static boolean isDeclarationName(SimpleName name) {
+		ASTNode parent= name.getParent();
+		return parent instanceof VariableDeclarationFragment fragment && fragment.getName() == name
+				|| parent instanceof SingleVariableDeclaration declaration
+						&& declaration.getName() == name;
+	}
+
+	private static Expression completeReferenceExpression(SimpleName name, String bindingKey) {
+		Expression reference= name;
+		ASTNode parent= reference.getParent();
+		if (parent instanceof QualifiedName qualified
+				&& qualified.getName() == reference
+				&& hasBindingKey(qualified.resolveBinding(), bindingKey)) {
+			reference= qualified;
+		} else if (parent instanceof FieldAccess fieldAccess
+				&& fieldAccess.getName() == reference
+				&& hasBindingKey(fieldAccess.resolveFieldBinding(), bindingKey)) {
+			reference= fieldAccess;
+		} else if (parent instanceof SuperFieldAccess superFieldAccess
+				&& superFieldAccess.getName() == reference
+				&& hasBindingKey(superFieldAccess.resolveFieldBinding(), bindingKey)) {
+			reference= superFieldAccess;
+		}
+		while (reference.getParent() instanceof ParenthesizedExpression parenthesized) {
+			reference= parenthesized;
+		}
+		return reference;
+	}
+
+	private static boolean hasBindingKey(IBinding binding, String bindingKey) {
+		return binding instanceof IVariableBinding variable
+				&& bindingKey.equals(variable.getVariableDeclaration().getKey());
+	}
+
+	private static <N extends ASTNode> N ancestor(ASTNode node, Class<N> type) {
+		ASTNode current= node.getParent();
+		while (current != null && !type.isInstance(current)) {
+			current= current.getParent();
+		}
+		return type.isInstance(current) ? type.cast(current) : null;
+	}
+
+	private record MethodInfo(String methodKey, List<String> parameterBindingKeys) {
+		private MethodInfo {
+			parameterBindingKeys= List.copyOf(parameterBindingKeys);
+		}
+	}
+
+	private static final class BindingInfo {
+
+		private final IVariableBinding binding;
+		private SimpleName declarationName;
+		private final String compilationUnitHandle;
+
+		BindingInfo(
+				IVariableBinding binding,
+				SimpleName declarationName,
+				String compilationUnitHandle) {
+			this.binding= binding.getVariableDeclaration();
+			this.declarationName= declarationName;
+			this.compilationUnitHandle= compilationUnitHandle;
+		}
+
+		void recordDeclaration(SimpleName name) {
+			declarationName= name;
+		}
+
+		IVariableBinding binding() {
+			return binding;
+		}
+
+		SimpleName anchor() {
+			return declarationName;
+		}
+
+		String compilationUnitHandle() {
+			return compilationUnitHandle;
+		}
+	}
+
+	private record FlowIndex(
+			Map<String, BindingInfo> bindings,
+			Map<String, List<SimpleName>> references,
+			Map<String, MethodInfo> methods,
+			String compilationUnitHandle) {
+
+		static FlowIndex create(CompilationUnit compilationUnit) {
+			Map<String, BindingInfo> bindings= new LinkedHashMap<>();
+			Map<String, List<SimpleName>> references= new LinkedHashMap<>();
+			Map<String, MethodInfo> methods= new LinkedHashMap<>();
+			IJavaElement javaElement= compilationUnit.getJavaElement();
+			String unitHandle= javaElement == null ? "" : javaElement.getHandleIdentifier(); //$NON-NLS-1$
+
+			AstProcessing.independent(ReferenceHolder.<String, Object>create())
+					.on(MethodDeclaration.class, (method, holder) -> {
+						indexMethod(method, methods);
+						return true;
+					})
+					.on(SimpleName.class, (name, holder) -> {
+						indexVariable(name, bindings, references, unitHandle);
+						return true;
+					})
+					.build(compilationUnit);
+
+			return new FlowIndex(
+					Map.copyOf(bindings),
+					copyReferenceMap(references),
+					Map.copyOf(methods),
+					unitHandle);
+		}
+
+		private static void indexMethod(
+				MethodDeclaration method,
+				Map<String, MethodInfo> methods) {
+			IMethodBinding binding= method.resolveBinding();
+			if (binding == null) {
+				return;
+			}
+			List<String> parameters= new ArrayList<>();
+			for (Object parameterObject : method.parameters()) {
+				SingleVariableDeclaration parameter= (SingleVariableDeclaration) parameterObject;
+				IVariableBinding parameterBinding= parameter.resolveBinding();
+				parameters.add(parameterBinding == null
+						? "" : parameterBinding.getVariableDeclaration().getKey()); //$NON-NLS-1$
+			}
+			String methodKey= binding.getMethodDeclaration().getKey();
+			methods.put(methodKey, new MethodInfo(methodKey, parameters));
+		}
+
+		private static void indexVariable(
+				SimpleName name,
+				Map<String, BindingInfo> bindings,
+				Map<String, List<SimpleName>> references,
+				String unitHandle) {
+			IBinding resolved= name.resolveBinding();
+			if (!(resolved instanceof IVariableBinding variable)) {
+				return;
+			}
+			IVariableBinding declaration= variable.getVariableDeclaration();
+			String key= declaration.getKey();
+			if (key == null || key.isBlank()) {
+				return;
+			}
+			BindingInfo info= bindings.computeIfAbsent(
+					key, ignored -> new BindingInfo(declaration, null, unitHandle));
+			if (isDeclarationName(name)) {
+				info.recordDeclaration(name);
+			}
+			references.computeIfAbsent(key, ignored -> new ArrayList<>()).add(name);
+		}
+
+		private static Map<String, List<SimpleName>> copyReferenceMap(
+				Map<String, List<SimpleName>> references) {
+			Map<String, List<SimpleName>> copy= new LinkedHashMap<>();
+			references.forEach((key, value) -> copy.put(key, List.copyOf(value)));
+			return Map.copyOf(copy);
+		}
+	}
+
+	private static final class GraphAccumulator {
+
+		private final ContainerUsageProfile profile;
+		private final String compilationUnitHandle;
+		private final Map<String, FlowNode> nodes= new LinkedHashMap<>();
+		private final List<FlowEdge> edges= new ArrayList<>();
+		private final Set<String> edgeKeys= new LinkedHashSet<>();
+		private final List<FlowDiagnostic> diagnostics= new ArrayList<>();
+		private final Set<String> diagnosticKeys= new LinkedHashSet<>();
+		private ClosureStatus closureStatus= ClosureStatus.LOCAL_CLOSED;
+		private String rootNodeId;
+
+		GraphAccumulator(ContainerUsageProfile profile, String compilationUnitHandle) {
+			this.profile= profile;
+			this.compilationUnitHandle= compilationUnitHandle;
+		}
+
+		FlowNode ensureVariableNode(BindingInfo info) {
+			IVariableBinding binding= info.binding();
+			String stableId= variableNodeId(binding.getKey());
+			SimpleName anchor= info.anchor();
+			int start= anchor == null ? profile.identity().sourceStart() : anchor.getStartPosition();
+			int length= anchor == null ? profile.identity().sourceLength() : anchor.getLength();
+			FlowNode node= nodes.computeIfAbsent(stableId, ignored -> new FlowNode(
+					stableId,
+					nodeKind(binding),
+					binding.getKey(),
+					ownerKey(binding),
+					info.compilationUnitHandle(),
+					true,
+					start,
+					length));
+			if (rootNodeId == null && binding.getKey().equals(profile.identity().bindingKey())) {
+				rootNodeId= stableId;
+			}
+			return node;
+		}
+
+		FlowNode ensureReturnNode(String methodKey, String unitHandle, ASTNode anchor) {
+			String stableId= "return:" + methodKey; //$NON-NLS-1$
+			return nodes.computeIfAbsent(stableId, ignored -> new FlowNode(
+					stableId,
+					NodeKind.RETURN_POSITION,
+					"", //$NON-NLS-1$
+					methodKey,
+					unitHandle,
+					true,
+					anchor.getStartPosition(),
+					anchor.getLength()));
+		}
+
+		void addParameterBoundary(
+				FlowNode sourceNode,
+				IMethodBinding method,
+				int parameterIndex,
+				ASTNode anchor) {
+			ITypeBinding declaringClass= method.getDeclaringClass();
+			boolean sourceType= declaringClass != null && declaringClass.isFromSource();
+			String methodKey= method.getMethodDeclaration().getKey();
+			String stableId= "parameter:" + methodKey + ':' + parameterIndex; //$NON-NLS-1$
+			FlowNode target= nodes.computeIfAbsent(stableId, ignored -> new FlowNode(
+					stableId,
+					sourceType ? NodeKind.PARAMETER : NodeKind.EXTERNAL_PARAMETER,
+					"", //$NON-NLS-1$
+					methodKey,
+					"", //$NON-NLS-1$
+					false,
+					anchor.getStartPosition(),
+					anchor.getLength()));
+			addEdge(sourceNode, target, EdgeKind.ARGUMENT_TO_PARAMETER, anchor);
+			if (sourceType) {
+				requireScopeExpansion(
+						"Parameter declaration is in another source scope", anchor); //$NON-NLS-1$
+			} else {
+				raise(ClosureStatus.EXTERNAL_BOUNDARY);
+				addDiagnostic(
+						DiagnosticKind.EXTERNAL_OR_BINARY_TARGET,
+						"Container value reaches an external or binary method parameter", anchor); //$NON-NLS-1$
+			}
+		}
+
+		void addEdge(FlowNode source, FlowNode target, EdgeKind kind, ASTNode anchor) {
+			String edgeKey= source.stableId() + '|' + target.stableId() + '|'
+					+ kind + '|' + anchor.getStartPosition();
+			if (edgeKeys.add(edgeKey)) {
+				edges.add(new FlowEdge(
+						source.stableId(),
+						target.stableId(),
+						kind,
+						anchor.getStartPosition(),
+						anchor.getLength()));
+			}
+		}
+
+		void classifySignatureExposure(BindingInfo info) {
+			IVariableBinding binding= info.binding();
+			if (binding.isParameter()) {
+				requireScopeExpansion(
+						"Method parameter requires caller and override discovery", info.anchor()); //$NON-NLS-1$
+			} else if (binding.isField() && !Modifier.isPrivate(binding.getModifiers())) {
+				requireScopeExpansion(
+						"Non-private field requires project-wide reference discovery", info.anchor()); //$NON-NLS-1$
+			}
+		}
+
+		void requireScopeExpansion(String message, ASTNode anchor) {
+			raise(ClosureStatus.REQUIRES_SCOPE_EXPANSION);
+			addDiagnostic(DiagnosticKind.SCOPE_EXPANSION_REQUIRED, message, anchor);
+		}
+
+		void unresolvedBinding(String bindingKey, int start, int length) {
+			raise(ClosureStatus.REJECTED);
+			String suffix= bindingKey == null || bindingKey.isBlank()
+					? "" : ": " + bindingKey; //$NON-NLS-1$ //$NON-NLS-2$
+			addDiagnostic(
+					DiagnosticKind.UNRESOLVED_BINDING,
+					"A required flow binding could not be resolved" + suffix, //$NON-NLS-1$
+					start,
+					length);
+		}
+
+		void unclassifiedFlow(ASTNode anchor) {
+			raise(ClosureStatus.REJECTED);
+			addDiagnostic(
+					DiagnosticKind.UNCLASSIFIED_FLOW,
+					"Container flow reaches an unsupported expression shape", anchor); //$NON-NLS-1$
+		}
+
+		void addUnresolvedRoot() {
+			String stableId= "unknown:" + profile.identity().stableId(); //$NON-NLS-1$
+			rootNodeId= stableId;
+			nodes.put(stableId, new FlowNode(
+					stableId,
+					NodeKind.UNKNOWN_BOUNDARY,
+					profile.identity().bindingKey(),
+					"", //$NON-NLS-1$
+					compilationUnitHandle,
+					false,
+					profile.identity().sourceStart(),
+					profile.identity().sourceLength()));
+			unresolvedBinding(
+					profile.identity().bindingKey(),
+					profile.identity().sourceStart(),
+					profile.identity().sourceLength());
+		}
+
+		ContainerFlowGraph toGraph() {
+			return new ContainerFlowGraph(
+					rootNodeId,
+					List.copyOf(nodes.values()),
+					edges,
+					closureStatus,
+					diagnostics);
+		}
+
+		private void addDiagnostic(DiagnosticKind kind, String message, ASTNode anchor) {
+			if (anchor == null) {
+				addDiagnostic(kind, message,
+						profile.identity().sourceStart(), profile.identity().sourceLength());
+			} else {
+				addDiagnostic(kind, message, anchor.getStartPosition(), anchor.getLength());
+			}
+		}
+
+		private void addDiagnostic(
+				DiagnosticKind kind,
+				String message,
+				int start,
+				int length) {
+			String key= kind + "|" + message + '|' + start; //$NON-NLS-1$
+			if (diagnosticKeys.add(key)) {
+				diagnostics.add(new FlowDiagnostic(kind, message, start, length));
+			}
+		}
+
+		private void raise(ClosureStatus candidate) {
+			if (rank(candidate) > rank(closureStatus)) {
+				closureStatus= candidate;
+			}
+		}
+	}
+
+	private static NodeKind nodeKind(IVariableBinding binding) {
+		if (binding.isField()) {
+			return NodeKind.FIELD;
+		}
+		if (binding.isParameter()) {
+			return NodeKind.PARAMETER;
+		}
+		return NodeKind.LOCAL_VARIABLE;
+	}
+
+	private static String ownerKey(IVariableBinding binding) {
+		IMethodBinding declaringMethod= binding.getDeclaringMethod();
+		if (declaringMethod != null) {
+			return declaringMethod.getMethodDeclaration().getKey();
+		}
+		ITypeBinding declaringClass= binding.getDeclaringClass();
+		return declaringClass == null ? "" : declaringClass.getTypeDeclaration().getKey(); //$NON-NLS-1$
+	}
+
+	private static String variableNodeId(String bindingKey) {
+		return "variable:" + bindingKey; //$NON-NLS-1$
+	}
+
+	private static int rank(ClosureStatus status) {
+		return switch (status) {
+			case LOCAL_CLOSED -> 0;
+			case REQUIRES_SCOPE_EXPANSION -> 1;
+			case EXTERNAL_BOUNDARY -> 2;
+			case REJECTED -> 3;
+		};
+	}
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/LocalContainerFlowGraphBuilder.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/analysis/LocalContainerFlowGraphBuilder.java
@@ -13,17 +13,13 @@ package org.sandbox.jdt.container.analysis;
 import static org.sandbox.jdt.container.analysis.ContainerAstFacts.variableBinding;
 
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Deque;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
-import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ArrayAccess;
 import org.eclipse.jdt.core.dom.Assignment;
@@ -34,11 +30,9 @@ import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.FieldAccess;
 import org.eclipse.jdt.core.dom.IBinding;
 import org.eclipse.jdt.core.dom.IMethodBinding;
-import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.IVariableBinding;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
-import org.eclipse.jdt.core.dom.Modifier;
 import org.eclipse.jdt.core.dom.ParenthesizedExpression;
 import org.eclipse.jdt.core.dom.QualifiedName;
 import org.eclipse.jdt.core.dom.ReturnStatement;
@@ -46,17 +40,12 @@ import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
 import org.eclipse.jdt.core.dom.SuperFieldAccess;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+import org.sandbox.jdt.container.analysis.ContainerFlowIndex.BindingInfo;
+import org.sandbox.jdt.container.analysis.ContainerFlowIndex.MethodInfo;
 import org.sandbox.jdt.container.api.ContainerFlowGraph;
-import org.sandbox.jdt.container.api.ContainerFlowGraph.ClosureStatus;
-import org.sandbox.jdt.container.api.ContainerFlowGraph.DiagnosticKind;
 import org.sandbox.jdt.container.api.ContainerFlowGraph.EdgeKind;
-import org.sandbox.jdt.container.api.ContainerFlowGraph.FlowDiagnostic;
-import org.sandbox.jdt.container.api.ContainerFlowGraph.FlowEdge;
 import org.sandbox.jdt.container.api.ContainerFlowGraph.FlowNode;
-import org.sandbox.jdt.container.api.ContainerFlowGraph.NodeKind;
 import org.sandbox.jdt.container.api.ContainerUsageProfile;
-import org.sandbox.jdt.internal.common.AstProcessing;
-import org.sandbox.jdt.internal.common.ReferenceHolder;
 
 /**
  * Discovers value-flow edges reachable from one container binding inside a compilation
@@ -66,6 +55,9 @@ import org.sandbox.jdt.internal.common.ReferenceHolder;
  * represented even when their declarations are outside the current compilation unit;
  * the closure status and diagnostics then instruct the multi-file planner to expand
  * scope or stop at an external boundary.</p>
+ *
+ * <p>Index construction and graph accumulation are separate package-private
+ * components so this class remains focused on flow rules.</p>
  */
 public final class LocalContainerFlowGraphBuilder {
 
@@ -76,8 +68,9 @@ public final class LocalContainerFlowGraphBuilder {
 		Objects.requireNonNull(compilationUnit, "compilationUnit"); //$NON-NLS-1$
 		Objects.requireNonNull(profile, "profile"); //$NON-NLS-1$
 
-		FlowIndex index= FlowIndex.create(compilationUnit);
-		GraphAccumulator graph= new GraphAccumulator(profile, index.compilationUnitHandle());
+		ContainerFlowIndex index= ContainerFlowIndex.create(compilationUnit);
+		ContainerFlowGraphAccumulator graph=
+				new ContainerFlowGraphAccumulator(profile, index.compilationUnitHandle());
 		String rootBindingKey= profile.identity().bindingKey();
 		if (rootBindingKey.isBlank()) {
 			graph.addUnresolvedRoot();
@@ -102,24 +95,22 @@ public final class LocalContainerFlowGraphBuilder {
 			}
 			BindingInfo source= index.bindings().get(bindingKey);
 			if (source == null) {
-				graph.unresolvedBinding(bindingKey, profile.identity().sourceStart(),
+				graph.unresolvedBinding(
+						bindingKey,
+						profile.identity().sourceStart(),
 						profile.identity().sourceLength());
 				continue;
 			}
 
 			FlowNode sourceNode= graph.ensureVariableNode(source);
 			graph.classifySignatureExposure(source);
-			for (SimpleName referenceName : index.references().getOrDefault(bindingKey, List.of())) {
+			for (SimpleName referenceName :
+					index.references().getOrDefault(bindingKey, List.of())) {
 				if (isDeclarationName(referenceName)) {
 					continue;
 				}
 				Expression reference= completeReferenceExpression(referenceName, bindingKey);
-				classifyReference(
-						reference,
-						sourceNode,
-						index,
-						graph,
-						pendingBindings);
+				classifyReference(reference, sourceNode, index, graph, pendingBindings);
 			}
 		}
 
@@ -129,8 +120,8 @@ public final class LocalContainerFlowGraphBuilder {
 	private static void classifyReference(
 			Expression reference,
 			FlowNode sourceNode,
-			FlowIndex index,
-			GraphAccumulator graph,
+			ContainerFlowIndex index,
+			ContainerFlowGraphAccumulator graph,
 			Deque<String> pendingBindings) {
 		ASTNode parent= reference.getParent();
 		if (parent instanceof VariableDeclarationFragment fragment
@@ -187,13 +178,19 @@ public final class LocalContainerFlowGraphBuilder {
 			Expression targetExpression,
 			EdgeKind edgeKind,
 			ASTNode evidence,
-			FlowIndex index,
-			GraphAccumulator graph,
+			ContainerFlowIndex index,
+			ContainerFlowGraphAccumulator graph,
 			Deque<String> pendingBindings) {
 		Optional<IVariableBinding> target= variableBinding(targetExpression);
 		if (target.isPresent()) {
-			connectVariable(sourceNode, target.get(), edgeKind, evidence,
-					index, graph, pendingBindings);
+			connectVariable(
+					sourceNode,
+					target.get(),
+					edgeKind,
+					evidence,
+					index,
+					graph,
+					pendingBindings);
 		} else {
 			graph.unclassifiedFlow(evidence);
 		}
@@ -204,17 +201,19 @@ public final class LocalContainerFlowGraphBuilder {
 			IVariableBinding targetBinding,
 			EdgeKind edgeKind,
 			ASTNode evidence,
-			FlowIndex index,
-			GraphAccumulator graph,
+			ContainerFlowIndex index,
+			ContainerFlowGraphAccumulator graph,
 			Deque<String> pendingBindings) {
 		if (targetBinding == null || targetBinding.getVariableDeclaration().getKey() == null) {
-			graph.unresolvedBinding("", evidence.getStartPosition(), evidence.getLength()); //$NON-NLS-1$
+			graph.unresolvedBinding(
+					"", evidence.getStartPosition(), evidence.getLength()); //$NON-NLS-1$
 			return;
 		}
 		String targetKey= targetBinding.getVariableDeclaration().getKey();
 		BindingInfo target= index.bindings().get(targetKey);
 		if (target == null) {
-			graph.unresolvedBinding(targetKey, evidence.getStartPosition(), evidence.getLength());
+			graph.unresolvedBinding(
+					targetKey, evidence.getStartPosition(), evidence.getLength());
 			return;
 		}
 		FlowNode targetNode= graph.ensureVariableNode(target);
@@ -227,11 +226,12 @@ public final class LocalContainerFlowGraphBuilder {
 			IMethodBinding invokedMethod,
 			List<?> arguments,
 			Expression reference,
-			FlowIndex index,
-			GraphAccumulator graph,
+			ContainerFlowIndex index,
+			ContainerFlowGraphAccumulator graph,
 			Deque<String> pendingBindings) {
 		if (invokedMethod == null) {
-			graph.unresolvedBinding("", reference.getStartPosition(), reference.getLength()); //$NON-NLS-1$
+			graph.unresolvedBinding(
+					"", reference.getStartPosition(), reference.getLength()); //$NON-NLS-1$
 			return;
 		}
 		IMethodBinding declaration= invokedMethod.getMethodDeclaration();
@@ -241,16 +241,20 @@ public final class LocalContainerFlowGraphBuilder {
 				continue;
 			}
 			int parameterIndex= parameterIndex(declaration, argumentIndex);
-			MethodInfo localMethod= index.methods().get(methodKey);
+			MethodInfo localMethod= methodKey == null ? null : index.methods().get(methodKey);
 			if (localMethod != null && parameterIndex < localMethod.parameterBindingKeys().size()) {
 				String parameterKey= localMethod.parameterBindingKeys().get(parameterIndex);
 				BindingInfo parameter= index.bindings().get(parameterKey);
 				if (parameter != null) {
 					FlowNode parameterNode= graph.ensureVariableNode(parameter);
-					graph.addEdge(sourceNode, parameterNode,
-							EdgeKind.ARGUMENT_TO_PARAMETER, reference);
+					graph.addEdge(
+							sourceNode,
+							parameterNode,
+							EdgeKind.ARGUMENT_TO_PARAMETER,
+							reference);
 					graph.requireScopeExpansion(
-							"Method parameter signature participates in the container flow", reference); //$NON-NLS-1$
+							"Method parameter signature participates in the container flow", //$NON-NLS-1$
+							reference);
 					pendingBindings.addLast(parameterKey);
 					continue;
 				}
@@ -274,22 +278,29 @@ public final class LocalContainerFlowGraphBuilder {
 	private static void connectReturn(
 			FlowNode sourceNode,
 			Expression reference,
-			FlowIndex index,
-			GraphAccumulator graph) {
+			ContainerFlowIndex index,
+			ContainerFlowGraphAccumulator graph) {
 		MethodDeclaration method= ancestor(reference, MethodDeclaration.class);
 		IMethodBinding methodBinding= method == null ? null : method.resolveBinding();
 		if (methodBinding == null) {
-			graph.unresolvedBinding("", reference.getStartPosition(), reference.getLength()); //$NON-NLS-1$
+			graph.unresolvedBinding(
+					"", reference.getStartPosition(), reference.getLength()); //$NON-NLS-1$
 			return;
 		}
 		String methodKey= methodBinding.getMethodDeclaration().getKey();
+		if (methodKey == null || methodKey.isBlank()) {
+			graph.unresolvedBinding(
+					"", reference.getStartPosition(), reference.getLength()); //$NON-NLS-1$
+			return;
+		}
 		FlowNode returnNode= graph.ensureReturnNode(
 				methodKey,
 				index.compilationUnitHandle(),
 				reference);
 		graph.addEdge(sourceNode, returnNode, EdgeKind.RETURN_TO_METHOD, reference);
 		graph.requireScopeExpansion(
-				"Method return type and all call sites participate in the container flow", reference); //$NON-NLS-1$
+				"Method return type and all call sites participate in the container flow", //$NON-NLS-1$
+				reference);
 	}
 
 	private static boolean isRepresentationInternalCopy(
@@ -361,336 +372,5 @@ public final class LocalContainerFlowGraphBuilder {
 			current= current.getParent();
 		}
 		return type.isInstance(current) ? type.cast(current) : null;
-	}
-
-	private record MethodInfo(String methodKey, List<String> parameterBindingKeys) {
-		private MethodInfo {
-			parameterBindingKeys= List.copyOf(parameterBindingKeys);
-		}
-	}
-
-	private static final class BindingInfo {
-
-		private final IVariableBinding binding;
-		private SimpleName declarationName;
-		private final String compilationUnitHandle;
-
-		BindingInfo(
-				IVariableBinding binding,
-				SimpleName declarationName,
-				String compilationUnitHandle) {
-			this.binding= binding.getVariableDeclaration();
-			this.declarationName= declarationName;
-			this.compilationUnitHandle= compilationUnitHandle;
-		}
-
-		void recordDeclaration(SimpleName name) {
-			declarationName= name;
-		}
-
-		IVariableBinding binding() {
-			return binding;
-		}
-
-		SimpleName anchor() {
-			return declarationName;
-		}
-
-		String compilationUnitHandle() {
-			return compilationUnitHandle;
-		}
-	}
-
-	private record FlowIndex(
-			Map<String, BindingInfo> bindings,
-			Map<String, List<SimpleName>> references,
-			Map<String, MethodInfo> methods,
-			String compilationUnitHandle) {
-
-		static FlowIndex create(CompilationUnit compilationUnit) {
-			Map<String, BindingInfo> bindings= new LinkedHashMap<>();
-			Map<String, List<SimpleName>> references= new LinkedHashMap<>();
-			Map<String, MethodInfo> methods= new LinkedHashMap<>();
-			IJavaElement javaElement= compilationUnit.getJavaElement();
-			String unitHandle= javaElement == null ? "" : javaElement.getHandleIdentifier(); //$NON-NLS-1$
-
-			AstProcessing.independent(ReferenceHolder.<String, Object>create())
-					.on(MethodDeclaration.class, (method, holder) -> {
-						indexMethod(method, methods);
-						return true;
-					})
-					.on(SimpleName.class, (name, holder) -> {
-						indexVariable(name, bindings, references, unitHandle);
-						return true;
-					})
-					.build(compilationUnit);
-
-			return new FlowIndex(
-					Map.copyOf(bindings),
-					copyReferenceMap(references),
-					Map.copyOf(methods),
-					unitHandle);
-		}
-
-		private static void indexMethod(
-				MethodDeclaration method,
-				Map<String, MethodInfo> methods) {
-			IMethodBinding binding= method.resolveBinding();
-			if (binding == null) {
-				return;
-			}
-			List<String> parameters= new ArrayList<>();
-			for (Object parameterObject : method.parameters()) {
-				SingleVariableDeclaration parameter= (SingleVariableDeclaration) parameterObject;
-				IVariableBinding parameterBinding= parameter.resolveBinding();
-				parameters.add(parameterBinding == null
-						? "" : parameterBinding.getVariableDeclaration().getKey()); //$NON-NLS-1$
-			}
-			String methodKey= binding.getMethodDeclaration().getKey();
-			methods.put(methodKey, new MethodInfo(methodKey, parameters));
-		}
-
-		private static void indexVariable(
-				SimpleName name,
-				Map<String, BindingInfo> bindings,
-				Map<String, List<SimpleName>> references,
-				String unitHandle) {
-			IBinding resolved= name.resolveBinding();
-			if (!(resolved instanceof IVariableBinding variable)) {
-				return;
-			}
-			IVariableBinding declaration= variable.getVariableDeclaration();
-			String key= declaration.getKey();
-			if (key == null || key.isBlank()) {
-				return;
-			}
-			BindingInfo info= bindings.computeIfAbsent(
-					key, ignored -> new BindingInfo(declaration, null, unitHandle));
-			if (isDeclarationName(name)) {
-				info.recordDeclaration(name);
-			}
-			references.computeIfAbsent(key, ignored -> new ArrayList<>()).add(name);
-		}
-
-		private static Map<String, List<SimpleName>> copyReferenceMap(
-				Map<String, List<SimpleName>> references) {
-			Map<String, List<SimpleName>> copy= new LinkedHashMap<>();
-			references.forEach((key, value) -> copy.put(key, List.copyOf(value)));
-			return Map.copyOf(copy);
-		}
-	}
-
-	private static final class GraphAccumulator {
-
-		private final ContainerUsageProfile profile;
-		private final String compilationUnitHandle;
-		private final Map<String, FlowNode> nodes= new LinkedHashMap<>();
-		private final List<FlowEdge> edges= new ArrayList<>();
-		private final Set<String> edgeKeys= new LinkedHashSet<>();
-		private final List<FlowDiagnostic> diagnostics= new ArrayList<>();
-		private final Set<String> diagnosticKeys= new LinkedHashSet<>();
-		private ClosureStatus closureStatus= ClosureStatus.LOCAL_CLOSED;
-		private String rootNodeId;
-
-		GraphAccumulator(ContainerUsageProfile profile, String compilationUnitHandle) {
-			this.profile= profile;
-			this.compilationUnitHandle= compilationUnitHandle;
-		}
-
-		FlowNode ensureVariableNode(BindingInfo info) {
-			IVariableBinding binding= info.binding();
-			String stableId= variableNodeId(binding.getKey());
-			SimpleName anchor= info.anchor();
-			int start= anchor == null ? profile.identity().sourceStart() : anchor.getStartPosition();
-			int length= anchor == null ? profile.identity().sourceLength() : anchor.getLength();
-			FlowNode node= nodes.computeIfAbsent(stableId, ignored -> new FlowNode(
-					stableId,
-					nodeKind(binding),
-					binding.getKey(),
-					ownerKey(binding),
-					info.compilationUnitHandle(),
-					true,
-					start,
-					length));
-			if (rootNodeId == null && binding.getKey().equals(profile.identity().bindingKey())) {
-				rootNodeId= stableId;
-			}
-			return node;
-		}
-
-		FlowNode ensureReturnNode(String methodKey, String unitHandle, ASTNode anchor) {
-			String stableId= "return:" + methodKey; //$NON-NLS-1$
-			return nodes.computeIfAbsent(stableId, ignored -> new FlowNode(
-					stableId,
-					NodeKind.RETURN_POSITION,
-					"", //$NON-NLS-1$
-					methodKey,
-					unitHandle,
-					true,
-					anchor.getStartPosition(),
-					anchor.getLength()));
-		}
-
-		void addParameterBoundary(
-				FlowNode sourceNode,
-				IMethodBinding method,
-				int parameterIndex,
-				ASTNode anchor) {
-			ITypeBinding declaringClass= method.getDeclaringClass();
-			boolean sourceType= declaringClass != null && declaringClass.isFromSource();
-			String methodKey= method.getMethodDeclaration().getKey();
-			String stableId= "parameter:" + methodKey + ':' + parameterIndex; //$NON-NLS-1$
-			FlowNode target= nodes.computeIfAbsent(stableId, ignored -> new FlowNode(
-					stableId,
-					sourceType ? NodeKind.PARAMETER : NodeKind.EXTERNAL_PARAMETER,
-					"", //$NON-NLS-1$
-					methodKey,
-					"", //$NON-NLS-1$
-					false,
-					anchor.getStartPosition(),
-					anchor.getLength()));
-			addEdge(sourceNode, target, EdgeKind.ARGUMENT_TO_PARAMETER, anchor);
-			if (sourceType) {
-				requireScopeExpansion(
-						"Parameter declaration is in another source scope", anchor); //$NON-NLS-1$
-			} else {
-				raise(ClosureStatus.EXTERNAL_BOUNDARY);
-				addDiagnostic(
-						DiagnosticKind.EXTERNAL_OR_BINARY_TARGET,
-						"Container value reaches an external or binary method parameter", anchor); //$NON-NLS-1$
-			}
-		}
-
-		void addEdge(FlowNode source, FlowNode target, EdgeKind kind, ASTNode anchor) {
-			String edgeKey= source.stableId() + '|' + target.stableId() + '|'
-					+ kind + '|' + anchor.getStartPosition();
-			if (edgeKeys.add(edgeKey)) {
-				edges.add(new FlowEdge(
-						source.stableId(),
-						target.stableId(),
-						kind,
-						anchor.getStartPosition(),
-						anchor.getLength()));
-			}
-		}
-
-		void classifySignatureExposure(BindingInfo info) {
-			IVariableBinding binding= info.binding();
-			if (binding.isParameter()) {
-				requireScopeExpansion(
-						"Method parameter requires caller and override discovery", info.anchor()); //$NON-NLS-1$
-			} else if (binding.isField() && !Modifier.isPrivate(binding.getModifiers())) {
-				requireScopeExpansion(
-						"Non-private field requires project-wide reference discovery", info.anchor()); //$NON-NLS-1$
-			}
-		}
-
-		void requireScopeExpansion(String message, ASTNode anchor) {
-			raise(ClosureStatus.REQUIRES_SCOPE_EXPANSION);
-			addDiagnostic(DiagnosticKind.SCOPE_EXPANSION_REQUIRED, message, anchor);
-		}
-
-		void unresolvedBinding(String bindingKey, int start, int length) {
-			raise(ClosureStatus.REJECTED);
-			String suffix= bindingKey == null || bindingKey.isBlank()
-					? "" : ": " + bindingKey; //$NON-NLS-1$ //$NON-NLS-2$
-			addDiagnostic(
-					DiagnosticKind.UNRESOLVED_BINDING,
-					"A required flow binding could not be resolved" + suffix, //$NON-NLS-1$
-					start,
-					length);
-		}
-
-		void unclassifiedFlow(ASTNode anchor) {
-			raise(ClosureStatus.REJECTED);
-			addDiagnostic(
-					DiagnosticKind.UNCLASSIFIED_FLOW,
-					"Container flow reaches an unsupported expression shape", anchor); //$NON-NLS-1$
-		}
-
-		void addUnresolvedRoot() {
-			String stableId= "unknown:" + profile.identity().stableId(); //$NON-NLS-1$
-			rootNodeId= stableId;
-			nodes.put(stableId, new FlowNode(
-					stableId,
-					NodeKind.UNKNOWN_BOUNDARY,
-					profile.identity().bindingKey(),
-					"", //$NON-NLS-1$
-					compilationUnitHandle,
-					false,
-					profile.identity().sourceStart(),
-					profile.identity().sourceLength()));
-			unresolvedBinding(
-					profile.identity().bindingKey(),
-					profile.identity().sourceStart(),
-					profile.identity().sourceLength());
-		}
-
-		ContainerFlowGraph toGraph() {
-			return new ContainerFlowGraph(
-					rootNodeId,
-					List.copyOf(nodes.values()),
-					edges,
-					closureStatus,
-					diagnostics);
-		}
-
-		private void addDiagnostic(DiagnosticKind kind, String message, ASTNode anchor) {
-			if (anchor == null) {
-				addDiagnostic(kind, message,
-						profile.identity().sourceStart(), profile.identity().sourceLength());
-			} else {
-				addDiagnostic(kind, message, anchor.getStartPosition(), anchor.getLength());
-			}
-		}
-
-		private void addDiagnostic(
-				DiagnosticKind kind,
-				String message,
-				int start,
-				int length) {
-			String key= kind + "|" + message + '|' + start; //$NON-NLS-1$
-			if (diagnosticKeys.add(key)) {
-				diagnostics.add(new FlowDiagnostic(kind, message, start, length));
-			}
-		}
-
-		private void raise(ClosureStatus candidate) {
-			if (rank(candidate) > rank(closureStatus)) {
-				closureStatus= candidate;
-			}
-		}
-	}
-
-	private static NodeKind nodeKind(IVariableBinding binding) {
-		if (binding.isField()) {
-			return NodeKind.FIELD;
-		}
-		if (binding.isParameter()) {
-			return NodeKind.PARAMETER;
-		}
-		return NodeKind.LOCAL_VARIABLE;
-	}
-
-	private static String ownerKey(IVariableBinding binding) {
-		IMethodBinding declaringMethod= binding.getDeclaringMethod();
-		if (declaringMethod != null) {
-			return declaringMethod.getMethodDeclaration().getKey();
-		}
-		ITypeBinding declaringClass= binding.getDeclaringClass();
-		return declaringClass == null ? "" : declaringClass.getTypeDeclaration().getKey(); //$NON-NLS-1$
-	}
-
-	private static String variableNodeId(String bindingKey) {
-		return "variable:" + bindingKey; //$NON-NLS-1$
-	}
-
-	private static int rank(ClosureStatus status) {
-		return switch (status) {
-			case LOCAL_CLOSED -> 0;
-			case REQUIRES_SCOPE_EXPANSION -> 1;
-			case EXTERNAL_BOUNDARY -> 2;
-			case REJECTED -> 3;
-		};
 	}
 }

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/api/ContainerFlowGraph.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/api/ContainerFlowGraph.java
@@ -73,13 +73,19 @@ public record ContainerFlowGraph(
 		}
 	}
 
-	/** One declaration, signature position or external boundary in the value flow. */
+	/**
+	 * One declaration, signature position or external boundary in the value flow.
+	 *
+	 * @param signatureIndex zero-based parameter index, or {@code -1} when the node
+	 *                       is not a parameter position
+	 */
 	public record FlowNode(
 			String stableId,
 			NodeKind kind,
 			String bindingKey,
 			String ownerKey,
 			String compilationUnitHandle,
+			int signatureIndex,
 			boolean sourceResolved,
 			int sourceStart,
 			int sourceLength) {
@@ -90,7 +96,15 @@ public record ContainerFlowGraph(
 			bindingKey= optionalText(bindingKey);
 			ownerKey= optionalText(ownerKey);
 			compilationUnitHandle= optionalText(compilationUnitHandle);
+			if (signatureIndex < -1) {
+				throw new IllegalArgumentException("signatureIndex must be -1 or a parameter index"); //$NON-NLS-1$
+			}
 			validateRange(sourceStart, sourceLength);
+		}
+
+		/** Returns whether this node represents one concrete parameter position. */
+		public boolean isParameterPosition() {
+			return signatureIndex >= 0;
 		}
 	}
 

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/api/ContainerFlowGraph.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/api/ContainerFlowGraph.java
@@ -1,0 +1,174 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.container.api;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Stable, AST-free value-flow graph used to plan project-wide container migrations.
+ *
+ * @param rootNodeId stable identifier of the candidate root
+ * @param nodes graph nodes in deterministic discovery order
+ * @param edges graph edges in deterministic discovery order
+ * @param closureStatus current closure classification
+ * @param diagnostics source-backed boundary and rejection explanations
+ */
+public record ContainerFlowGraph(
+		String rootNodeId,
+		List<FlowNode> nodes,
+		List<FlowEdge> edges,
+		ClosureStatus closureStatus,
+		List<FlowDiagnostic> diagnostics) {
+
+	public ContainerFlowGraph {
+		rootNodeId= requiredText(rootNodeId, "rootNodeId"); //$NON-NLS-1$
+		nodes= List.copyOf(Objects.requireNonNull(nodes, "nodes")); //$NON-NLS-1$
+		edges= List.copyOf(Objects.requireNonNull(edges, "edges")); //$NON-NLS-1$
+		Objects.requireNonNull(closureStatus, "closureStatus"); //$NON-NLS-1$
+		diagnostics= List.copyOf(Objects.requireNonNull(diagnostics, "diagnostics")); //$NON-NLS-1$
+		validateGraph(rootNodeId, nodes, edges);
+	}
+
+	/** Returns one node by stable identifier. */
+	public Optional<FlowNode> node(String stableId) {
+		return nodes.stream().filter(candidate -> candidate.stableId().equals(stableId)).findFirst();
+	}
+
+	/** Returns outgoing edges in deterministic discovery order. */
+	public List<FlowEdge> outgoing(String stableId) {
+		return edges.stream().filter(edge -> edge.sourceNodeId().equals(stableId)).toList();
+	}
+
+	private static void validateGraph(
+			String rootNodeId,
+			List<FlowNode> nodes,
+			List<FlowEdge> edges) {
+		Set<String> identifiers= new HashSet<>();
+		for (FlowNode node : nodes) {
+			if (!identifiers.add(node.stableId())) {
+				throw new IllegalArgumentException("Duplicate flow node id: " + node.stableId()); //$NON-NLS-1$
+			}
+		}
+		if (!identifiers.contains(rootNodeId)) {
+			throw new IllegalArgumentException("Flow root is not present in node list"); //$NON-NLS-1$
+		}
+		for (FlowEdge edge : edges) {
+			if (!identifiers.contains(edge.sourceNodeId())
+					|| !identifiers.contains(edge.targetNodeId())) {
+				throw new IllegalArgumentException(
+						"Flow edge references an unknown node: " + edge); //$NON-NLS-1$
+			}
+		}
+	}
+
+	/** One declaration, signature position or external boundary in the value flow. */
+	public record FlowNode(
+			String stableId,
+			NodeKind kind,
+			String bindingKey,
+			String ownerKey,
+			String compilationUnitHandle,
+			boolean sourceResolved,
+			int sourceStart,
+			int sourceLength) {
+
+		public FlowNode {
+			stableId= requiredText(stableId, "stableId"); //$NON-NLS-1$
+			Objects.requireNonNull(kind, "kind"); //$NON-NLS-1$
+			bindingKey= optionalText(bindingKey);
+			ownerKey= optionalText(ownerKey);
+			compilationUnitHandle= optionalText(compilationUnitHandle);
+			validateRange(sourceStart, sourceLength);
+		}
+	}
+
+	/** One directed transfer of the represented container value. */
+	public record FlowEdge(
+			String sourceNodeId,
+			String targetNodeId,
+			EdgeKind kind,
+			int sourceStart,
+			int sourceLength) {
+
+		public FlowEdge {
+			sourceNodeId= requiredText(sourceNodeId, "sourceNodeId"); //$NON-NLS-1$
+			targetNodeId= requiredText(targetNodeId, "targetNodeId"); //$NON-NLS-1$
+			Objects.requireNonNull(kind, "kind"); //$NON-NLS-1$
+			validateRange(sourceStart, sourceLength);
+		}
+	}
+
+	/** One explanation why the currently analyzed scope is or is not closed. */
+	public record FlowDiagnostic(
+			DiagnosticKind kind,
+			String message,
+			int sourceStart,
+			int sourceLength) {
+
+		public FlowDiagnostic {
+			Objects.requireNonNull(kind, "kind"); //$NON-NLS-1$
+			message= requiredText(message, "message"); //$NON-NLS-1$
+			validateRange(sourceStart, sourceLength);
+		}
+	}
+
+	public enum NodeKind {
+		LOCAL_VARIABLE,
+		FIELD,
+		PARAMETER,
+		RETURN_POSITION,
+		EXTERNAL_PARAMETER,
+		UNKNOWN_BOUNDARY
+	}
+
+	public enum EdgeKind {
+		ASSIGNMENT,
+		INITIALIZER,
+		ARGUMENT_TO_PARAMETER,
+		RETURN_TO_METHOD
+	}
+
+	public enum ClosureStatus {
+		LOCAL_CLOSED,
+		REQUIRES_SCOPE_EXPANSION,
+		EXTERNAL_BOUNDARY,
+		REJECTED
+	}
+
+	public enum DiagnosticKind {
+		SCOPE_EXPANSION_REQUIRED,
+		EXTERNAL_OR_BINARY_TARGET,
+		UNRESOLVED_BINDING,
+		UNCLASSIFIED_FLOW
+	}
+
+	private static String requiredText(String value, String fieldName) {
+		String text= Objects.requireNonNull(value, fieldName).strip();
+		if (text.isEmpty()) {
+			throw new IllegalArgumentException(fieldName + " must not be empty"); //$NON-NLS-1$
+		}
+		return text;
+	}
+
+	private static String optionalText(String value) {
+		return value == null ? "" : value.strip(); //$NON-NLS-1$
+	}
+
+	private static void validateRange(int sourceStart, int sourceLength) {
+		if (sourceStart < 0 || sourceLength < 0) {
+			throw new IllegalArgumentException("Source range must not be negative"); //$NON-NLS-1$
+		}
+	}
+}

--- a/sandbox_common_core/src/main/java/org/sandbox/jdt/container/api/ContainerFlowSearchPlan.java
+++ b/sandbox_common_core/src/main/java/org/sandbox/jdt/container/api/ContainerFlowSearchPlan.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.container.api;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Stable search requests derived from a container flow graph.
+ *
+ * <p>This model does not execute JDT searches. The Eclipse-dependent multi-file layer
+ * resolves these seeds to source compilation units and repeats planning to a fixed
+ * point.</p>
+ *
+ * @param seeds deterministic, duplicate-free search requests
+ */
+public record ContainerFlowSearchPlan(List<SearchSeed> seeds) {
+
+	public ContainerFlowSearchPlan {
+		seeds= List.copyOf(Objects.requireNonNull(seeds, "seeds")); //$NON-NLS-1$
+	}
+
+	/** Returns whether no further source-scope search is requested. */
+	public boolean isEmpty() {
+		return seeds.isEmpty();
+	}
+
+	/** One JDT-search intention independent of Eclipse UI classes. */
+	public record SearchSeed(
+			String sourceNodeId,
+			SearchKind kind,
+			String bindingKey,
+			String ownerKey,
+			int signatureIndex,
+			String reason) {
+
+		public SearchSeed {
+			sourceNodeId= requiredText(sourceNodeId, "sourceNodeId"); //$NON-NLS-1$
+			Objects.requireNonNull(kind, "kind"); //$NON-NLS-1$
+			bindingKey= optionalText(bindingKey);
+			ownerKey= optionalText(ownerKey);
+			if (signatureIndex < -1) {
+				throw new IllegalArgumentException("signatureIndex must be -1 or a parameter index"); //$NON-NLS-1$
+			}
+			reason= requiredText(reason, "reason"); //$NON-NLS-1$
+			if (kind == SearchKind.FIELD_REFERENCES && bindingKey.isEmpty()) {
+				throw new IllegalArgumentException("Field reference search requires a binding key"); //$NON-NLS-1$
+			}
+			if (kind != SearchKind.FIELD_REFERENCES && ownerKey.isEmpty()) {
+				throw new IllegalArgumentException("Method search requires an owner key"); //$NON-NLS-1$
+			}
+		}
+
+		/** Stable key for deterministic de-duplication. */
+		public String stableKey() {
+			return kind + "|" + bindingKey + '|' + ownerKey + '|' + signatureIndex; //$NON-NLS-1$
+		}
+	}
+
+	public enum SearchKind {
+		FIELD_REFERENCES,
+		METHOD_DECLARATION,
+		METHOD_CALLERS,
+		METHOD_OVERRIDE_FAMILY
+	}
+
+	private static String requiredText(String value, String fieldName) {
+		String text= Objects.requireNonNull(value, fieldName).strip();
+		if (text.isEmpty()) {
+			throw new IllegalArgumentException(fieldName + " must not be empty"); //$NON-NLS-1$
+		}
+		return text;
+	}
+
+	private static String optionalText(String value) {
+		return value == null ? "" : value.strip(); //$NON-NLS-1$
+	}
+}

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/container/analysis/LocalContainerFlowGraphBuilderTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/container/analysis/LocalContainerFlowGraphBuilderTest.java
@@ -1,0 +1,236 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.sandbox.jdt.container.analysis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.junit.jupiter.api.Test;
+import org.sandbox.jdt.container.api.ContainerFlowGraph;
+import org.sandbox.jdt.container.api.ContainerFlowGraph.ClosureStatus;
+import org.sandbox.jdt.container.api.ContainerFlowGraph.DiagnosticKind;
+import org.sandbox.jdt.container.api.ContainerFlowGraph.EdgeKind;
+import org.sandbox.jdt.container.api.ContainerFlowGraph.NodeKind;
+import org.sandbox.jdt.container.api.ContainerUsageProfile;
+import org.sandbox.jdt.container.api.ContainerUsageProfile.ContainerIdentity;
+
+class LocalContainerFlowGraphBuilderTest {
+
+	private final AppendOnlyArraySeedDetector seedDetector= new AppendOnlyArraySeedDetector();
+	private final LocalContainerFlowGraphBuilder graphBuilder= new LocalContainerFlowGraphBuilder();
+
+	@Test
+	void followsLocalAliasesToAFixedPoint() {
+		ContainerFlowGraph graph= build("""
+			import java.util.Arrays;
+			class Sample {
+				void collect(String value) {
+					String[] values = new String[0];
+					values = Arrays.copyOf(values, values.length + 1);
+					values[values.length - 1] = value;
+					String[] alias = values;
+					String[] second = alias;
+					System.out.println(second.length);
+				}
+			}
+			""");
+
+		assertEquals(ClosureStatus.LOCAL_CLOSED, graph.closureStatus());
+		assertEquals(3, graph.nodes().stream()
+				.filter(node -> node.kind() == NodeKind.LOCAL_VARIABLE)
+				.count());
+		assertEquals(2, graph.edges().stream()
+				.filter(edge -> edge.kind() == EdgeKind.INITIALIZER)
+				.count());
+		assertTrue(graph.diagnostics().isEmpty());
+		assertEquals(1, graph.outgoing(graph.rootNodeId()).size());
+	}
+
+	@Test
+	void connectsArgumentToLocalParameterAndRequestsScopeExpansion() {
+		ContainerFlowGraph graph= build("""
+			import java.util.Arrays;
+			class Sample {
+				void collect(String value) {
+					String[] values = new String[0];
+					values = Arrays.copyOf(values, values.length + 1);
+					values[values.length - 1] = value;
+					consume(values);
+				}
+				void consume(String[] input) {
+					System.out.println(input.length);
+				}
+			}
+			""");
+
+		assertEquals(ClosureStatus.REQUIRES_SCOPE_EXPANSION, graph.closureStatus());
+		assertTrue(graph.nodes().stream().anyMatch(node -> node.kind() == NodeKind.PARAMETER));
+		assertTrue(graph.edges().stream()
+				.anyMatch(edge -> edge.kind() == EdgeKind.ARGUMENT_TO_PARAMETER));
+		assertTrue(hasDiagnostic(graph, DiagnosticKind.SCOPE_EXPANSION_REQUIRED));
+	}
+
+	@Test
+	void connectsReturnValueToMethodReturnPosition() {
+		ContainerFlowGraph graph= build("""
+			import java.util.Arrays;
+			class Sample {
+				String[] collect(String value) {
+					String[] values = new String[0];
+					values = Arrays.copyOf(values, values.length + 1);
+					values[values.length - 1] = value;
+					return values;
+				}
+			}
+			""");
+
+		assertEquals(ClosureStatus.REQUIRES_SCOPE_EXPANSION, graph.closureStatus());
+		assertTrue(graph.nodes().stream()
+				.anyMatch(node -> node.kind() == NodeKind.RETURN_POSITION));
+		assertTrue(graph.edges().stream()
+				.anyMatch(edge -> edge.kind() == EdgeKind.RETURN_TO_METHOD));
+		assertTrue(hasDiagnostic(graph, DiagnosticKind.SCOPE_EXPANSION_REQUIRED));
+	}
+
+	@Test
+	void stopsAtExternalBinaryParameterBoundary() {
+		ContainerFlowGraph graph= build("""
+			import java.util.Arrays;
+			class Sample {
+				int collect(String value) {
+					String[] values = new String[0];
+					values = Arrays.copyOf(values, values.length + 1);
+					values[values.length - 1] = value;
+					return System.identityHashCode(values);
+				}
+			}
+			""");
+
+		assertEquals(ClosureStatus.EXTERNAL_BOUNDARY, graph.closureStatus());
+		assertTrue(graph.nodes().stream()
+				.anyMatch(node -> node.kind() == NodeKind.EXTERNAL_PARAMETER));
+		assertTrue(hasDiagnostic(graph, DiagnosticKind.EXTERNAL_OR_BINARY_TARGET));
+	}
+
+	@Test
+	void doesNotTreatArraysCopyOfAsAnExternalFlowBoundary() {
+		ContainerFlowGraph graph= build("""
+			import java.util.Arrays;
+			class Sample {
+				void collect(String value) {
+					String[] values = new String[0];
+					values = Arrays.copyOf(values, values.length + 1);
+					values[values.length - 1] = value;
+					System.out.println(values.length);
+				}
+			}
+			""");
+
+		assertEquals(ClosureStatus.LOCAL_CLOSED, graph.closureStatus());
+		assertFalse(graph.nodes().stream()
+				.anyMatch(node -> node.kind() == NodeKind.EXTERNAL_PARAMETER));
+		assertFalse(hasDiagnostic(graph, DiagnosticKind.EXTERNAL_OR_BINARY_TARGET));
+	}
+
+	@Test
+	void rejectsAProfileWithoutResolvedRootBinding() {
+		CompilationUnit unit= parse("""
+			class Sample {
+				void collect() { }
+			}
+			""");
+		ContainerUsageProfile template= seedDetector.findSeeds(parse("""
+			import java.util.Arrays;
+			class Other {
+				void collect(String value) {
+					String[] values = new String[0];
+					values = Arrays.copyOf(values, values.length + 1);
+					values[values.length - 1] = value;
+				}
+			}
+			""")).get(0);
+		ContainerUsageProfile unresolved= new ContainerUsageProfile(
+				new ContainerIdentity(
+						"", //$NON-NLS-1$
+						template.identity().displayName(),
+						template.identity().sourceStart(),
+						template.identity().sourceLength()),
+				template.currentShape(),
+				template.elementDomain(),
+				template.access(),
+				template.orderRequirement(),
+				template.uniquenessRequirement(),
+				template.mutationLifecycle(),
+				template.nullContract(),
+				template.aliasingContract(),
+				template.escapeLevel(),
+				template.concurrency(),
+				template.completeness(),
+				template.evidence());
+
+		ContainerFlowGraph graph= graphBuilder.build(unit, unresolved);
+
+		assertEquals(ClosureStatus.REJECTED, graph.closureStatus());
+		assertEquals(NodeKind.UNKNOWN_BOUNDARY,
+				graph.node(graph.rootNodeId()).orElseThrow().kind());
+		assertTrue(hasDiagnostic(graph, DiagnosticKind.UNRESOLVED_BINDING));
+	}
+
+	@Test
+	void graphCollectionsAreImmutableAndValidateReferences() {
+		ContainerFlowGraph graph= build("""
+			import java.util.Arrays;
+			class Sample {
+				void collect(String value) {
+					String[] values = new String[0];
+					values = Arrays.copyOf(values, values.length + 1);
+					values[values.length - 1] = value;
+				}
+			}
+			""");
+
+		assertThrows(UnsupportedOperationException.class,
+				() -> graph.nodes().add(graph.nodes().get(0)));
+		assertThrows(UnsupportedOperationException.class,
+				() -> graph.edges().addAll(new ArrayList<>()));
+		assertTrue(graph.node(graph.rootNodeId()).isPresent());
+	}
+
+	private ContainerFlowGraph build(String source) {
+		CompilationUnit unit= parse(source);
+		ContainerUsageProfile seed= seedDetector.findSeeds(unit).get(0);
+		return graphBuilder.build(unit, seed);
+	}
+
+	private static boolean hasDiagnostic(ContainerFlowGraph graph, DiagnosticKind kind) {
+		return graph.diagnostics().stream().anyMatch(diagnostic -> diagnostic.kind() == kind);
+	}
+
+	private static CompilationUnit parse(String source) {
+		ASTParser parser= ASTParser.newParser(AST.getJLSLatest());
+		parser.setSource(source.toCharArray());
+		parser.setKind(ASTParser.K_COMPILATION_UNIT);
+		parser.setResolveBindings(true);
+		parser.setBindingsRecovery(true);
+		parser.setStatementsRecovery(true);
+		parser.setUnitName("Sample.java"); //$NON-NLS-1$
+		parser.setEnvironment(new String[0], new String[0], new String[0], true);
+		return (CompilationUnit) parser.createAST(null);
+	}
+}

--- a/sandbox_common_core/src/test/java/org/sandbox/jdt/container/analysis/LocalContainerFlowGraphBuilderTest.java
+++ b/sandbox_common_core/src/test/java/org/sandbox/jdt/container/analysis/LocalContainerFlowGraphBuilderTest.java
@@ -15,9 +15,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTParser;
 import org.eclipse.jdt.core.dom.CompilationUnit;
@@ -201,14 +198,17 @@ class LocalContainerFlowGraphBuilderTest {
 					String[] values = new String[0];
 					values = Arrays.copyOf(values, values.length + 1);
 					values[values.length - 1] = value;
+					String[] alias = values;
+					System.out.println(alias.length);
 				}
 			}
 			""");
 
+		assertFalse(graph.edges().isEmpty());
 		assertThrows(UnsupportedOperationException.class,
 				() -> graph.nodes().add(graph.nodes().get(0)));
 		assertThrows(UnsupportedOperationException.class,
-				() -> graph.edges().addAll(new ArrayList<>()));
+				() -> graph.edges().remove(0));
 		assertTrue(graph.node(graph.rootNodeId()).isPresent());
 	}
 


### PR DESCRIPTION
## Summary

Begins the project-wide planning work from #1380 as a stacked slice on top of #1388.

- adds an immutable, AST-free `ContainerFlowGraph` model;
- represents local variables, fields, parameters, return positions and external parameter boundaries as stable nodes;
- represents assignment, initializer, argument-to-parameter and return-to-method transfers as directed edges;
- follows local aliases to a fixed point using binding keys;
- distinguishes `LOCAL_CLOSED`, `REQUIRES_SCOPE_EXPANSION`, `EXTERNAL_BOUNDARY` and `REJECTED` closure states;
- records source-backed diagnostics for unresolved bindings, unsupported flow shapes and scope boundaries;
- treats `Arrays.copyOf` as representation-internal rather than an external method escape;
- requests transitive discovery for method parameters, return types and non-private fields;
- retains no AST nodes in the resulting graph.

## Readability

The implementation is separated into:

- `ContainerFlowIndex`: deterministic one-CU binding/reference index;
- `LocalContainerFlowGraphBuilder`: readable flow rules and fixed-point traversal;
- `ContainerFlowGraphAccumulator`: node/edge creation and closure classification.

## Tests

Covers:

- multi-hop local alias flow;
- same-source method argument to parameter;
- return-position flow;
- external binary parameter boundary;
- exclusion of the internal `Arrays.copyOf` operation;
- unresolved root binding;
- immutable graph collections and node lookup.

## Stacking

This PR targets `feature/container-contract-inference`. After #1386, #1387 and #1388 merge, the branch will be rebuilt on `main` before review.

Refs #1380
Refs #1378